### PR TITLE
fix: исправлена привязка выполненных работ

### DIFF
--- a/routes/api/v1/admin/project-based.php
+++ b/routes/api/v1/admin/project-based.php
@@ -102,11 +102,11 @@ Route::prefix('projects/{project}')->middleware(['project.context'])->group(func
     Route::prefix('works')->group(function () {
         Route::get('/', [CompletedWorkController::class, 'index']);
         Route::post('/', [CompletedWorkController::class, 'store']);
-        Route::get('/{completedWork}', [CompletedWorkController::class, 'show']);
-        Route::put('/{completedWork}', [CompletedWorkController::class, 'update']);
-        Route::delete('/{completedWork}', [CompletedWorkController::class, 'destroy']);
-        Route::post('/{completedWork}/attach-schedule-task', [CompletedWorkController::class, 'attachScheduleTask']);
-        Route::post('/{completedWork}/create-schedule-task', [CompletedWorkController::class, 'createScheduleTaskFromWork']);
+        Route::get('/{completed_work}', [CompletedWorkController::class, 'show']);
+        Route::put('/{completed_work}', [CompletedWorkController::class, 'update']);
+        Route::delete('/{completed_work}', [CompletedWorkController::class, 'destroy']);
+        Route::post('/{completed_work}/attach-schedule-task', [CompletedWorkController::class, 'attachScheduleTask']);
+        Route::post('/{completed_work}/create-schedule-task', [CompletedWorkController::class, 'createScheduleTaskFromWork']);
         Route::post('/bulk', [CompletedWorkController::class, 'bulkCreate']);
         Route::get('/export/excel', [CompletedWorkController::class, 'exportExcel']);
     });

--- a/tests/Unit/Admin/CompletedWorkProjectRoutesTest.php
+++ b/tests/Unit/Admin/CompletedWorkProjectRoutesTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Admin;
+
+use PHPUnit\Framework\TestCase;
+
+class CompletedWorkProjectRoutesTest extends TestCase
+{
+    public function test_project_work_routes_use_completed_work_binding_parameter(): void
+    {
+        $routes = file_get_contents(dirname(__DIR__, 3) . '/routes/api/v1/admin/project-based.php');
+
+        $this->assertIsString($routes);
+        $this->assertSame(5, substr_count($routes, '{completed_work}'));
+        $this->assertSame(0, substr_count($routes, '{completedWork}'));
+    }
+}


### PR DESCRIPTION
﻿## Что исправлено

Исправляет GlitchTip issue `PROHELPER-BACKEND-3Q` / issue `122`:
- TypeError в `App\Http\Controllers\Api\V1\Admin\CompletedWorkController::update()`.
- Route: `PUT /api/v1/admin/projects/{project}/works/{completedWork}`.
- GlitchTip: http://5.129.220.32:8000/prohelper-backend/issues/122

## Root cause

Project-based routes для выполненных работ использовали параметр `{completedWork}`, а явный route model binding в `RouteServiceProvider` зарегистрирован для `completed_work`. Laravel не резолвил модель и передавал строковый ID в контроллер, где метод ожидает `App\Models\CompletedWork`.

## Что изменено

- В `routes/api/v1/admin/project-based.php` параметры маршрутов выполненных работ заменены на `{completed_work}`.
- Добавлен регрессионный тест, который фиксирует соответствие project-based routes существующему binding.

## Проверки

- `vendor\bin\phpunit tests\Unit\Admin\CompletedWorkProjectRoutesTest.php`
- `php -l routes\api\v1\admin\project-based.php`
- `php -l tests\Unit\Admin\CompletedWorkProjectRoutesTest.php`
- `vendor\bin\phpstan.bat analyse routes\api\v1\admin\project-based.php tests\Unit\Admin\CompletedWorkProjectRoutesTest.php --no-progress --memory-limit=512M`
