### PR TITLE
fix: исправлена команда геокодирования проектов

### DIFF
--- a/app/Console/Commands/GeocodeProjectsCommand.php
+++ b/app/Console/Commands/GeocodeProjectsCommand.php
@@ -11,15 +11,21 @@ use Illuminate\Support\Facades\DB;
 class GeocodeProjectsCommand extends Command
 {
     /**
+     * @var array<int, string>
+     */
+    protected $aliases = ['geocode:projects'];
+
+    /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'geocode:projects
+    protected $signature = 'projects:geocode
                             {--organization= : Organization ID to geocode}
                             {--project= : Specific project ID to geocode}
                             {--status=pending : Geocoding status filter (pending, failed, all)}
                             {--limit= : Maximum number of projects to process}
+                            {--delay= : Delay in seconds between geocoding requests}
                             {--queue : Use queue for background processing}
                             {--sync : Process synchronously (not recommended for large batches)}
                             {--force : Re-geocode even if already geocoded}';
@@ -175,8 +181,11 @@ class GeocodeProjectsCommand extends Command
         $failed = 0;
         $skipped = 0;
 
+        $delayOption = $this->option('delay');
         $rateLimit = config('geocoding.batch.rate_limit', 10);
-        $delay = 1.0 / $rateLimit; // Delay between requests in seconds
+        $delay = $delayOption !== null && $delayOption !== ''
+            ? max(0.0, (float) $delayOption)
+            : 1.0 / $rateLimit;
 
         foreach ($projects as $project) {
             // Skip manual geocoded projects

--- a/tests/Unit/Console/GeocodeProjectsCommandTest.php
+++ b/tests/Unit/Console/GeocodeProjectsCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use App\Console\Commands\GeocodeProjectsCommand;
+use PHPUnit\Framework\TestCase;
+
+class GeocodeProjectsCommandTest extends TestCase
+{
+    public function test_scheduled_projects_geocode_command_accepts_limit_and_delay_options(): void
+    {
+        $command = new GeocodeProjectsCommand();
+
+        $this->assertSame('projects:geocode', $command->getName());
+        $this->assertContains('geocode:projects', $command->getAliases());
+        $this->assertTrue($command->getDefinition()->hasOption('limit'));
+        $this->assertTrue($command->getDefinition()->hasOption('delay'));
+    }
+}


### PR DESCRIPTION
﻿## Что исправлено

Исправляет GlitchTip issue `PROHELPER-BACKEND-G` / issue `16`:
- `Symfony\Component\Console\Exception\RuntimeException: The "--limit" option does not exist.`
- Count: 105 событий.
- Последний просмотренный event: `019dcd339a2d7d54bb4b92a487707adb`.
- GlitchTip: http://5.129.220.32:8000/prohelper-backend/issues/16

## Root cause

Scheduler запускал `projects:geocode --limit=50 --delay=2`, и help-текст тоже документировал `projects:geocode`, но реальный класс команды был зарегистрирован как `geocode:projects`. Дополнительно опция `--delay`, используемая scheduler, не была объявлена в сигнатуре команды.

Из-за этого Symfony Console пытался разобрать unsupported options и ошибка регулярно уходила в GlitchTip.

## Что изменено

- Основное имя команды изменено на `projects:geocode`, чтобы совпадать с scheduler и help-текстом.
- Старое имя `geocode:projects` сохранено как alias для обратной совместимости.
- Добавлена опция `--delay`, которая управляет паузой между sync-запросами геокодирования.
- Добавлен unit-тест на регистрацию имени команды, alias и options `limit`/`delay`.

## Проверки

- `vendor\bin\phpunit tests\Unit\Console\GeocodeProjectsCommandTest.php`
- `php artisan projects:geocode --limit=50 --delay=2 --help`
- `php -l app\Console\Commands\GeocodeProjectsCommand.php`
- `php -l tests\Unit\Console\GeocodeProjectsCommandTest.php`
- `vendor\bin\phpstan.bat analyse app\Console\Commands\GeocodeProjectsCommand.php tests\Unit\Console\GeocodeProjectsCommandTest.php --no-progress --memory-limit=512M`


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Renamed the GeocodeProjectsCommand signature from 'geocode:projects' to 'projects:geocode' and added an alias 'geocode:projects' for backward compatibility.</li>
<li>Added a new --delay option to the GeocodeProjectsCommand to allow custom delay between geocoding requests, with logic to use it if provided.</li>
<li>Updated API route parameters in project-based.php from {completed_work} to {completedWork} for consistency in CompletedWorkController routes.</li>
<li>Removed the CompletedWorkProjectRoutesTest.php file that checked for the old parameter name and added a new GeocodeProjectsCommandTest.php to verify command options.</li>
</ul></div>