### PR TITLE
fix: фильтрация некорректных Livewire payload

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -17,6 +17,7 @@ use App\Services\Monitoring\GlitchTipReportPolicy;
 use App\Services\Monitoring\SentryScopeService;
 use App\Services\Logging\LoggingService;
 use App\Services\ErrorTracking\ErrorTrackingService;
+use App\Support\LivewirePayloadExceptionClassifier;
 use App\Exceptions\Billing\InsufficientBalanceException;
 use App\Exceptions\BusinessLogicException;
 use App\Exceptions\AI\AIServiceException;
@@ -304,7 +305,7 @@ class Handler extends ExceptionHandler
             ? app(GlitchTipReportPolicy::class)
             : new GlitchTipReportPolicy();
 
-        if ($glitchTipPolicy->shouldCapture($exception)) {
+        if ($glitchTipPolicy->shouldCapture($exception, app()->bound('request') ? request() : null)) {
             app(SentryScopeService::class)->captureException($exception, app()->bound('request') ? request() : null);
         }
 
@@ -627,6 +628,10 @@ class Handler extends ExceptionHandler
 
     public function render($request, Throwable $e)
     {
+        if ((new LivewirePayloadExceptionClassifier())->isMalformedClientUpdate($e, $request)) {
+            return response('', 400);
+        }
+
         // Для JSON/API отвечает register()->renderable выше
         $response = parent::render($request, $e);
 

--- a/app/Services/Monitoring/GlitchTipReportPolicy.php
+++ b/app/Services/Monitoring/GlitchTipReportPolicy.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Services\Monitoring;
 
 use App\Exceptions\BusinessLogicException;
+use App\Support\LivewirePayloadExceptionClassifier;
+use Illuminate\Http\Request;
 use Sentry\Severity;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
@@ -16,9 +18,13 @@ class GlitchTipReportPolicy
         $this->reportingConfig ??= (array) config('glitchtip.reporting', []);
     }
 
-    public function shouldCapture(Throwable $exception): bool
+    public function shouldCapture(Throwable $exception, ?Request $request = null): bool
     {
         if (!$this->enabled()) {
+            return false;
+        }
+
+        if ((new LivewirePayloadExceptionClassifier())->isMalformedClientUpdate($exception, $request)) {
             return false;
         }
 

--- a/app/Support/LivewirePayloadExceptionClassifier.php
+++ b/app/Support/LivewirePayloadExceptionClassifier.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+use Throwable;
+use TypeError;
+
+class LivewirePayloadExceptionClassifier
+{
+    public function isMalformedClientUpdate(Throwable $exception, ?Request $request = null): bool
+    {
+        if (!$this->isLivewireUpdateRequest($request)) {
+            return false;
+        }
+
+        $message = $exception->getMessage();
+
+        if (is_a($exception, 'Livewire\\Features\\SupportLockedProperties\\CannotUpdateLockedPropertyException')) {
+            return true;
+        }
+
+        if (str_contains($message, 'Cannot update locked property')) {
+            return true;
+        }
+
+        if (!$exception instanceof TypeError) {
+            return false;
+        }
+
+        return str_contains($message, 'Filament\\Notifications')
+            && (
+                str_contains($message, 'must be of type array')
+                || str_contains($message, 'of type bool')
+            );
+    }
+
+    private function isLivewireUpdateRequest(?Request $request): bool
+    {
+        if (!$request instanceof Request || !$request->isMethod('POST')) {
+            return false;
+        }
+
+        $path = trim($request->path(), '/');
+
+        return str_contains($path, 'livewire')
+            && str_ends_with($path, '/update');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -137,7 +137,7 @@ $app = Application::configure(basePath: dirname(__DIR__))
         $exceptions->report(function (\Throwable $exception): ?bool {
             $policy = app(GlitchTipReportPolicy::class);
 
-            if (!$policy->shouldCapture($exception)) {
+            if (!$policy->shouldCapture($exception, app()->bound('request') ? request() : null)) {
                 return false;
             }
 

--- a/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
+++ b/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
@@ -15,6 +15,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\QueryException;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\PostTooLargeException;
+use Illuminate\Http\Request;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use PDOException;
@@ -55,6 +56,28 @@ class GlitchTipReportPolicyTest extends TestCase
 
         self::assertTrue($policy->shouldCapture(new BusinessLogicException('workflow mismatch', 409)));
         self::assertSame('warning', $policy->levelFor(new BusinessLogicException('workflow mismatch', 409)));
+    }
+
+    public function test_skips_malformed_livewire_locked_property_updates(): void
+    {
+        $policy = new GlitchTipReportPolicy($this->config());
+        $request = Request::create('/livewire-6949a084/update', 'POST');
+        $exception = new \RuntimeException('Cannot update locked property: [userUndertakingMultiFactorAuthentication]');
+
+        self::assertFalse($policy->shouldCapture($exception, $request));
+        self::assertTrue($policy->shouldCapture($exception));
+    }
+
+    public function test_skips_malformed_filament_notification_livewire_updates(): void
+    {
+        $policy = new GlitchTipReportPolicy($this->config());
+        $request = Request::create('/livewire-6949a084/update', 'POST');
+        $exception = new \TypeError(
+            'Cannot assign array to property Filament\\Notifications\\Livewire\\Notifications::$isFilamentNotificationsComponent of type bool'
+        );
+
+        self::assertFalse($policy->shouldCapture($exception, $request));
+        self::assertTrue($policy->shouldCapture($exception));
     }
 
     public static function reportableExceptions(): array


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-2G: Cannot update locked property: [userUndertakingMultiFactorAuthentication]
- PROHELPER-BACKEND-2I: Filament notifications collection received invalid item type
- PROHELPER-BACKEND-2J: Filament notifications bool property received array

Links:
- http://5.129.220.32:8000/prohelper-backend/issues/80
- http://5.129.220.32:8000/prohelper-backend/issues/82
- http://5.129.220.32:8000/prohelper-backend/issues/83

## Root cause
GlitchTip events show POST requests to `/livewire-6949a084/update` with `python-requests/2.25.1`. The payload tampers with Livewire/Filament internal component state and sends arrays into locked or typed properties. Livewire correctly rejects those updates, but the backend reported them as unexpected 500-level exceptions.

## Changes
- Added `LivewirePayloadExceptionClassifier` for malformed client Livewire update payloads.
- GlitchTip reporting policy now skips these client-originated Livewire payload exceptions only when the current request is a Livewire update POST.
- The exception handler renders these malformed Livewire updates as HTTP 400 instead of a production 500 page.
- Added unit coverage for locked-property and Filament notifications payload cases.

## Checks
- `php -l app/Support/LivewirePayloadExceptionClassifier.php`
- `php -l app/Services/Monitoring/GlitchTipReportPolicy.php`
- `php -l app/Exceptions/Handler.php`
- `php -l tests/Unit/Monitoring/GlitchTipReportPolicyTest.php`
- `vendor/bin/phpunit tests/Unit/Monitoring/GlitchTipReportPolicyTest.php`
- `vendor/bin/phpstan analyse app/Support/LivewirePayloadExceptionClassifier.php app/Services/Monitoring/GlitchTipReportPolicy.php app/Exceptions/Handler.php --memory-limit=1G`

Note: local Composer install in the isolated worktree required `--ignore-platform-req=ext-intl --ignore-platform-req=ext-pcntl --ignore-platform-req=ext-posix` because the Windows PHP CLI lacks those extensions.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added LivewirePayloadExceptionClassifier to identify malformed Livewire client update exceptions based on exception type and message content.</li>
<li>Updated GlitchTipReportPolicy to skip capturing exceptions for malformed Livewire updates, preventing noise in error reporting.</li>
<li>Modified exception handler to return a 400 response for malformed Livewire payload exceptions instead of processing them further.</li>
<li>Added unit tests to verify that malformed Livewire exceptions are not captured by the reporting policy.</li>
</ul></div>