### PR TITLE
[codex] исправлена категория блога холдинга

### DIFF
--- a/app/BusinessModules/Enterprise/MultiOrganization/Website/Services/HoldingSiteBlogService.php
+++ b/app/BusinessModules/Enterprise/MultiOrganization/Website/Services/HoldingSiteBlogService.php
@@ -177,19 +177,39 @@ class HoldingSiteBlogService
             }
         }
 
-        return BlogCategory::firstOrCreate(
-            [
-                'organization_group_id' => $group->id,
-                'blog_context' => BlogContextEnum::HOLDING->value,
-                'slug' => 'holding-news',
-            ],
-            [
-                'name' => 'Новости холдинга',
-                'description' => 'Публикации холдинга',
-                'sort_order' => 1,
-                'is_active' => true,
-            ]
-        );
+        $category = BlogCategory::query()
+            ->where('blog_context', BlogContextEnum::HOLDING->value)
+            ->where('organization_group_id', $group->id)
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->first();
+
+        if ($category instanceof BlogCategory) {
+            return $category;
+        }
+
+        return BlogCategory::create([
+            'organization_group_id' => $group->id,
+            'blog_context' => BlogContextEnum::HOLDING->value,
+            'slug' => $this->generateUniqueCategorySlug('holding-news'),
+            'name' => 'Новости холдинга',
+            'description' => 'Публикации холдинга',
+            'sort_order' => 1,
+            'is_active' => true,
+        ]);
+    }
+
+    private function generateUniqueCategorySlug(string $baseSlug): string
+    {
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while (BlogCategory::query()->where('slug', $slug)->exists()) {
+            $counter++;
+            $slug = sprintf('%s-%d', $baseSlug, $counter);
+        }
+
+        return $slug;
     }
 
     private function generateUniqueSlug(string $source, ?int $ignoreId = null): string

--- a/tests/Unit/Enterprise/MultiOrganization/Website/HoldingSiteBlogServiceTest.php
+++ b/tests/Unit/Enterprise/MultiOrganization/Website/HoldingSiteBlogServiceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enterprise\MultiOrganization\Website;
+
+use App\BusinessModules\Enterprise\MultiOrganization\Website\Services\HoldingSiteBlogService;
+use App\Enums\Blog\BlogContextEnum;
+use App\Models\Blog\BlogCategory;
+use App\Models\Organization;
+use App\Models\OrganizationGroup;
+use App\Models\User;
+use Tests\TestCase;
+
+class HoldingSiteBlogServiceTest extends TestCase
+{
+    public function test_default_category_uses_unique_slug_for_each_holding_group(): void
+    {
+        $service = new HoldingSiteBlogService();
+        $firstGroup = $this->createOrganizationGroup('Первый холдинг', 'first-holding');
+        $secondGroup = $this->createOrganizationGroup('Второй холдинг', 'second-holding');
+
+        $firstCategory = $service->defaultCategory($firstGroup);
+        $secondCategory = $service->defaultCategory($secondGroup);
+
+        $this->assertSame('holding-news', $firstCategory->slug);
+        $this->assertNotSame($firstCategory->id, $secondCategory->id);
+        $this->assertSame($secondGroup->id, $secondCategory->organization_group_id);
+        $this->assertSame(BlogContextEnum::HOLDING, $secondCategory->blog_context);
+        $this->assertStringStartsWith('holding-news-', $secondCategory->slug);
+        $this->assertCount(2, BlogCategory::query()->holding()->get());
+    }
+
+    private function createOrganizationGroup(string $name, string $slug): OrganizationGroup
+    {
+        $organization = Organization::factory()->create();
+        $user = User::factory()->create();
+
+        return OrganizationGroup::create([
+            'name' => $name,
+            'slug' => $slug,
+            'parent_organization_id' => $organization->id,
+            'created_by_user_id' => $user->id,
+            'status' => 'active',
+        ]);
+    }
+}


### PR DESCRIPTION
﻿## GlitchTip

- Issue: PROHELPER-BACKEND-4F / 143
- Link: http://5.129.220.32:8000/prohelper-backend/issues/143
- Route: GET /api/v1/landing/holding/site

## Root cause

`HoldingSiteBlogService::resolveCategory()` created the default holding blog category through `firstOrCreate()` with lookup fields `organization_group_id`, `blog_context` and slug `holding-news`. The `blog_categories.slug` column still has a global unique constraint, so a second holding group could not create its own default category with the same slug.

## Что изменено

- Для группы сначала переиспользуется существующая holding-категория.
- Новая дефолтная категория создается с глобально уникальным slug: `holding-news`, `holding-news-2`, `holding-news-3` и так далее.
- Добавлен регрессионный тест на две разные группы холдинга.

## Проверки

- `php -l app/BusinessModules/Enterprise/MultiOrganization/Website/Services/HoldingSiteBlogService.php`
- `php -l tests/Unit/Enterprise/MultiOrganization/Website/HoldingSiteBlogServiceTest.php`
- `php artisan test tests/Unit/Enterprise/MultiOrganization/Website/HoldingSiteBlogServiceTest.php`
- `vendor\bin\phpstan analyse app\BusinessModules\Enterprise\MultiOrganization\Website\Services\HoldingSiteBlogService.php tests\Unit\Enterprise\MultiOrganization\Website\HoldingSiteBlogServiceTest.php --memory-limit=1G --no-progress`
- `git diff --check -- app/BusinessModules/Enterprise/MultiOrganization/Website/Services/HoldingSiteBlogService.php tests/Unit/Enterprise/MultiOrganization/Website/HoldingSiteBlogServiceTest.php`
