### PR TITLE
[codex] Импорт региональных цен материалов Минстроя

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/EstimateGenerationServiceProvider.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/EstimateGenerationServiceProvider.php
@@ -10,8 +10,10 @@ use App\BusinessModules\Addons\EstimateGeneration\Normatives\Console\Commands\Im
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Console\Commands\InspectEstimateNormativesCommand;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Console\Commands\QualityEstimateNormativesCommand;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Console\Commands\RollbackRegionalPricePeriodCommand;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Console\Commands\SyncFgiscsBuildingResourcePricesCommand;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Console\Commands\SyncFgiscsRegionalPricesCommand;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Fgiscs\FgiscsClient;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Fgiscs\FgiscsBuildingResourcePriceUpdateService;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Fgiscs\FgiscsRegionalCatalogService;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Fgiscs\FgiscsRegionalPriceUpdateService;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Fgiscs\RegionalPriceActivationService;
@@ -21,6 +23,7 @@ use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import\Est
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import\EstimateResourceClassificationService;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import\EstimateResourceClassifier;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import\EstimateSourceImportService;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import\FgiscsBuildingResourcePriceSpreadsheetParser;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\EstimateNormativeMatcher;
 use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Storage\EstimateSourceStorageService;
 use App\BusinessModules\Addons\EstimateGeneration\Services\ConstructionSemanticParser;
@@ -64,6 +67,8 @@ class EstimateGenerationServiceProvider extends ServiceProvider
         $this->app->singleton(FgiscsClient::class);
         $this->app->singleton(FgiscsRegionalCatalogService::class);
         $this->app->singleton(FgiscsRegionalPriceUpdateService::class);
+        $this->app->singleton(FgiscsBuildingResourcePriceSpreadsheetParser::class);
+        $this->app->singleton(FgiscsBuildingResourcePriceUpdateService::class);
         $this->app->singleton(RegionalPriceQualityService::class);
         $this->app->singleton(RegionalPriceActivationService::class);
     }
@@ -84,6 +89,7 @@ class EstimateGenerationServiceProvider extends ServiceProvider
                 InspectEstimateNormativesCommand::class,
                 QualityEstimateNormativesCommand::class,
                 SyncFgiscsRegionalPricesCommand::class,
+                SyncFgiscsBuildingResourcePricesCommand::class,
                 RollbackRegionalPricePeriodCommand::class,
             ]);
         }

--- a/app/BusinessModules/Addons/EstimateGeneration/Normatives/Console/Commands/SyncFgiscsBuildingResourcePricesCommand.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Normatives/Console/Commands/SyncFgiscsBuildingResourcePricesCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Normatives\Console\Commands;
+
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Fgiscs\FgiscsBuildingResourcePriceUpdateService;
+use Illuminate\Console\Command;
+use Throwable;
+
+class SyncFgiscsBuildingResourcePricesCommand extends Command
+{
+    protected $signature = 'estimates:regional-prices:sync-fgiscs-building-resources
+        {--bucket=prohelper-storage}
+        {--period-id=}
+        {--without-split-form}
+        {--force}';
+
+    protected $description = 'Синхронизировать региональные сметные цены строительных ресурсов ФГИС ЦС для смет.';
+
+    public function handle(FgiscsBuildingResourcePriceUpdateService $service): int
+    {
+        try {
+            $startedAt = microtime(true);
+            $progress = function (string $event, array $payload) use ($startedAt): void {
+                $elapsed = (int) floor(microtime(true) - $startedAt);
+                $this->line(sprintf('[%s +%ds] %s: %s', now()->format('Y-m-d H:i:s'), $elapsed, $event, json_encode($payload, JSON_UNESCAPED_UNICODE)));
+            };
+
+            $result = $service->syncTatarstan(
+                bucket: (string) $this->option('bucket'),
+                periodId: $this->option('period-id') !== null ? (int) $this->option('period-id') : null,
+                force: (bool) $this->option('force'),
+                withSplitForm: !(bool) $this->option('without-split-form'),
+                progress: $progress,
+            );
+
+            $this->newLine();
+            $this->info('Синхронизация сметных цен строительных ресурсов завершена.');
+            $this->table(['Показатель', 'Значение'], $this->summaryRows($result));
+
+            return self::SUCCESS;
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     * @return array<int, array{0:string,1:string}>
+     */
+    private function summaryRows(array $result): array
+    {
+        return [
+            ['region', (string) ($result['region'] ?? '')],
+            ['price_zone', (string) ($result['price_zone'] ?? '')],
+            ['period', (string) ($result['period'] ?? '')],
+            ['version_id', (string) ($result['version_id'] ?? '')],
+            ['version_key', (string) ($result['version_key'] ?? '')],
+            ['status', (string) ($result['status'] ?? '')],
+            ['files_count', (string) ($result['files_count'] ?? 0)],
+            ['rows_read', (string) ($result['rows_read'] ?? 0)],
+            ['rows_imported', (string) ($result['rows_imported'] ?? 0)],
+            ['errors_count', (string) ($result['errors_count'] ?? 0)],
+            ['skipped', (string) ((bool) ($result['skipped'] ?? false) ? 'yes' : 'no')],
+        ];
+    }
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Normatives/DTOs/FgiscsBuildingResourcePriceDTO.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Normatives/DTOs/FgiscsBuildingResourcePriceDTO.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Normatives\DTOs;
+
+final readonly class FgiscsBuildingResourcePriceDTO
+{
+    public function __construct(
+        public string $code,
+        public string $name,
+        public ?string $unit,
+        public float $currentPrice,
+        public string $sourcePriceKind,
+        public array $rawData = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'code' => $this->code,
+            'name' => $this->name,
+            'unit' => $this->unit,
+            'current_price' => $this->currentPrice,
+            'source_price_kind' => $this->sourcePriceKind,
+            'raw_data' => $this->rawData,
+        ];
+    }
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Fgiscs/FgiscsBuildingResourcePriceUpdateService.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Fgiscs/FgiscsBuildingResourcePriceUpdateService.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Fgiscs;
+
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\DTOs\FgiscsBuildingResourcePriceDTO;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Enums\EstimateImportStatus;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Enums\EstimateResourceType;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Enums\EstimateSourceType;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Enums\RegionalPriceStatus;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Models\ConstructionResource;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Models\EstimateDatasetVersion;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Models\EstimatePricePeriod;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Models\EstimatePriceZone;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Models\EstimateRegionalPriceVersion;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Models\EstimateResourcePrice;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import\FgiscsBuildingResourcePriceSpreadsheetParser;
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Storage\EstimateSourceStorageService;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class FgiscsBuildingResourcePriceUpdateService
+{
+    private const SOURCE_KINDS = [
+        'regional_building_resource_export',
+        'regional_building_resource_direct',
+        'regional_building_resource_index',
+    ];
+
+    public function __construct(
+        private readonly FgiscsClient $client,
+        private readonly FgiscsRegionalCatalogService $catalogService,
+        private readonly FgiscsBuildingResourcePriceSpreadsheetParser $parser,
+        private readonly EstimateSourceStorageService $storageService,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function syncTatarstan(string $bucket, ?int $periodId = null, bool $force = false, bool $withSplitForm = true, ?callable $progress = null): array
+    {
+        $catalog = $this->catalogService->syncTatarstan();
+        $period = $this->resolvePeriod((int) $catalog['price_zone']->fgiscs_price_zone_id, $periodId);
+
+        return $this->syncPeriod($bucket, $catalog['price_zone'], $period, $force, $withSplitForm, $progress);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function syncPeriod(
+        string $bucket,
+        EstimatePriceZone $priceZone,
+        EstimatePricePeriod $period,
+        bool $force,
+        bool $withSplitForm,
+        ?callable $progress,
+    ): array {
+        $region = $priceZone->region()->firstOrFail();
+        $versionKey = $this->versionKey($period, (string) $region->code, (int) $priceZone->fgiscs_price_zone_id);
+        $prefix = $this->prefix($period, (int) $region->fgiscs_subject_id, (int) $priceZone->fgiscs_price_zone_id);
+
+        $datasetVersion = EstimateDatasetVersion::query()->updateOrCreate(
+            [
+                'source_type' => EstimateSourceType::FGIS_LABOR_PRICES->value,
+                'version_key' => $versionKey,
+            ],
+            [
+                'bucket' => $bucket,
+                'prefix' => $prefix,
+                'status' => EstimateImportStatus::IMPORTING->value,
+                'files_count' => $withSplitForm ? 2 : 1,
+                'started_at' => now(),
+                'finished_at' => null,
+                'meta' => [
+                    'region_code' => $region->code,
+                    'region_id' => $region->id,
+                    'price_zone_id' => $priceZone->fgiscs_price_zone_id,
+                    'fgiscs_period_id' => $period->fgiscs_period_id,
+                    'regional' => true,
+                    'building_resources' => true,
+                ],
+            ]
+        );
+
+        $regionalVersion = EstimateRegionalPriceVersion::query()->firstOrCreate(
+            [
+                'source' => EstimateSourceType::FGIS_LABOR_PRICES->value,
+                'region_id' => $region->id,
+                'price_zone_id' => $priceZone->id,
+                'period_id' => $period->id,
+                'version_key' => $versionKey,
+            ],
+            [
+                'status' => RegionalPriceStatus::DISCOVERED->value,
+                'files_count' => 0,
+                'rows_read' => 0,
+                'rows_imported' => 0,
+                'errors_count' => 0,
+                'metadata' => [],
+            ]
+        );
+
+        if (!$force && (bool) ($regionalVersion->metadata['building_resources_imported'] ?? false)) {
+            return [
+                'skipped' => true,
+                'reason' => 'building_resources_already_imported',
+                'region' => $region->name,
+                'price_zone' => $priceZone->name,
+                'period' => $period->name,
+                'version_id' => $regionalVersion->id,
+                'version_key' => $versionKey,
+                'status' => $regionalVersion->status->value,
+            ];
+        }
+
+        $downloads = [];
+        $files = [
+            'building-resources.xlsx' => fn () => $this->client->downloadBuildingResources((int) $priceZone->fgiscs_price_zone_id, (int) $period->fgiscs_period_id),
+        ];
+
+        if ($withSplitForm) {
+            $files['building-resources-split-form.xlsx'] = fn () => $this->client->downloadBuildingResourcesSplitForm((int) $priceZone->fgiscs_price_zone_id, (int) $period->fgiscs_period_id);
+        }
+
+        foreach ($files as $fileName => $download) {
+            $fileKey = $prefix . $fileName;
+            $this->report($progress, 'download_started', ['file' => $fileKey]);
+            $downloads[$fileKey] = $download();
+            $this->storageService->disk($bucket)->put($fileKey, $downloads[$fileKey]->content);
+        }
+
+        $regionalVersion->update([
+            'status' => RegionalPriceStatus::DOWNLOADED->value,
+            'files_count' => count($downloads),
+            'metadata' => array_merge($regionalVersion->metadata ?? [], [
+                'building_resources_files' => array_map(
+                    static fn ($download): array => [
+                        'file_name' => $download->fileName,
+                        'content_type' => $download->contentType,
+                    ],
+                    $downloads
+                ),
+            ]),
+        ]);
+
+        $initialStatus = $regionalVersion->status;
+        $stats = $this->importDownloads($downloads, $datasetVersion, $regionalVersion, $progress);
+
+        $datasetVersion->update([
+            'status' => EstimateImportStatus::PARSED->value,
+            'files_count' => count($downloads),
+            'rows_read' => $stats['rows_read'],
+            'rows_imported' => $stats['rows_imported'],
+            'errors_count' => $stats['errors_count'],
+            'finished_at' => now(),
+        ]);
+
+        $regionalVersion->update([
+            'status' => $this->finalStatus($initialStatus),
+            'files_count' => max((int) $regionalVersion->files_count, count($downloads)),
+            'rows_read' => max((int) $regionalVersion->rows_read, $stats['rows_read']),
+            'rows_imported' => (int) EstimateResourcePrice::query()
+                ->where('regional_price_version_id', $regionalVersion->id)
+                ->count(),
+            'errors_count' => $stats['errors_count'],
+            'metadata' => array_merge($regionalVersion->metadata ?? [], [
+                'building_resources_imported' => true,
+                'building_resources_imported_at' => now()->toIso8601String(),
+                'building_resources_stats' => $stats,
+            ]),
+        ]);
+
+        return array_merge($stats, [
+            'status' => $regionalVersion->fresh()->status->value,
+            'region' => $region->name,
+            'price_zone' => $priceZone->name,
+            'period' => $period->name,
+            'version_id' => $regionalVersion->id,
+            'version_key' => $versionKey,
+            'files_count' => count($downloads),
+        ]);
+    }
+
+    /**
+     * @param array<string, \App\BusinessModules\Addons\EstimateGeneration\Normatives\DTOs\FgiscsDownloadDTO> $downloads
+     * @return array{rows_read:int,rows_imported:int,errors_count:int}
+     */
+    private function importDownloads(array $downloads, EstimateDatasetVersion $datasetVersion, EstimateRegionalPriceVersion $regionalVersion, ?callable $progress): array
+    {
+        $regionalVersion->update(['status' => RegionalPriceStatus::PARSING->value]);
+        $rowsRead = 0;
+        $rowsImported = 0;
+        $errorsCount = 0;
+
+        DB::transaction(function () use ($downloads, $datasetVersion, $regionalVersion, $progress, &$rowsRead, &$rowsImported, &$errorsCount): void {
+            EstimateResourcePrice::query()
+                ->where('regional_price_version_id', $regionalVersion->id)
+                ->whereIn('source_price_kind', self::SOURCE_KINDS)
+                ->delete();
+
+            foreach ($downloads as $fileKey => $download) {
+                $path = tempnam(sys_get_temp_dir(), 'fgiscs-building-resources-') . '.xlsx';
+                file_put_contents($path, $download->content);
+
+                try {
+                    foreach ($this->parser->parse($path) as $price) {
+                        $rowsRead++;
+
+                        if (!$price instanceof FgiscsBuildingResourcePriceDTO) {
+                            continue;
+                        }
+
+                        try {
+                            $this->storeRegionalPrice($price, $datasetVersion, $regionalVersion);
+                            $rowsImported++;
+                            $this->reportRowsProgress($progress, $fileKey, $rowsRead, $rowsImported, $errorsCount);
+                        } catch (\Throwable) {
+                            $errorsCount++;
+                        }
+                    }
+                } finally {
+                    if (is_file($path)) {
+                        @unlink($path);
+                    }
+                }
+            }
+        });
+
+        return [
+            'rows_read' => $rowsRead,
+            'rows_imported' => $rowsImported,
+            'errors_count' => $errorsCount,
+        ];
+    }
+
+    private function storeRegionalPrice(FgiscsBuildingResourcePriceDTO $dto, EstimateDatasetVersion $datasetVersion, EstimateRegionalPriceVersion $regionalVersion): void
+    {
+        $resourceCode = trim($dto->code);
+
+        EstimateResourcePrice::query()->updateOrCreate(
+            [
+                'dataset_version_id' => $datasetVersion->id,
+                'regional_price_version_id' => $regionalVersion->id,
+                'resource_code' => $resourceCode,
+                'price_type' => EstimateResourceType::MATERIAL->value,
+            ],
+            [
+                'region_id' => $regionalVersion->region_id,
+                'price_zone_id' => $regionalVersion->price_zone_id,
+                'period_id' => $regionalVersion->period_id,
+                'construction_resource_id' => $this->findConstructionResourceId($resourceCode),
+                'resource_name' => $dto->name,
+                'unit' => $dto->unit,
+                'base_price' => $dto->currentPrice,
+                'source_price_kind' => $dto->sourcePriceKind,
+                'raw_payload' => $dto->rawData,
+            ]
+        );
+    }
+
+    private function findConstructionResourceId(string $code): ?int
+    {
+        return ConstructionResource::query()
+            ->where('ksr_code', $code)
+            ->latest('dataset_version_id')
+            ->value('id');
+    }
+
+    private function resolvePeriod(int $priceZoneId, ?int $periodId): EstimatePricePeriod
+    {
+        if ($periodId !== null) {
+            $this->catalogService->syncPeriods($priceZoneId);
+
+            return EstimatePricePeriod::query()
+                ->where('fgiscs_period_id', $periodId)
+                ->first() ?? throw new RuntimeException('Указанный период ФГИС ЦС не найден.');
+        }
+
+        return $this->catalogService->latestPeriod($priceZoneId);
+    }
+
+    private function finalStatus(RegionalPriceStatus|string|null $status): string
+    {
+        $value = $status instanceof RegionalPriceStatus ? $status->value : (string) $status;
+
+        return in_array($value, [RegionalPriceStatus::ACTIVE->value, RegionalPriceStatus::CHECKED->value], true)
+            ? $value
+            : RegionalPriceStatus::PARSED->value;
+    }
+
+    private function versionKey(EstimatePricePeriod $period, string $regionCode, int $priceZoneId): string
+    {
+        if ($regionCode === FgiscsRegionalCatalogService::DEFAULT_REGION_CODE && $priceZoneId === FgiscsRegionalCatalogService::TATARSTAN_PRICE_ZONE_ID) {
+            return sprintf('%d-q%d-ru-ta', $period->year, $period->quarter);
+        }
+
+        return sprintf('%d-q%d-%s-pz-%d', $period->year, $period->quarter, strtolower($regionCode), $priceZoneId);
+    }
+
+    private function prefix(EstimatePricePeriod $period, int $subjectId, int $priceZoneId): string
+    {
+        return sprintf(
+            'estimate-sources/fgiscs/building-resources/%d-q%d/region-%d/price-zone-%d/',
+            $period->year,
+            $period->quarter,
+            $subjectId,
+            $priceZoneId
+        );
+    }
+
+    private function reportRowsProgress(?callable $progress, string $fileKey, int $rowsRead, int $rowsImported, int $errorsCount): void
+    {
+        if ($rowsRead === 1 || $rowsRead % 1000 === 0) {
+            $this->report($progress, 'rows_progress', [
+                'file' => $fileKey,
+                'rows_read' => $rowsRead,
+                'rows_imported' => $rowsImported,
+                'errors_count' => $errorsCount,
+            ]);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function report(?callable $progress, string $event, array $payload): void
+    {
+        if ($progress !== null) {
+            $progress($event, $payload);
+        }
+    }
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Fgiscs/FgiscsClient.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Fgiscs/FgiscsClient.php
@@ -121,6 +121,71 @@ class FgiscsClient
         );
     }
 
+    public function downloadBuildingResources(int $priceZoneId, int $periodId): FgiscsDownloadDTO
+    {
+        return $this->downloadSpreadsheet(
+            path: '/EstimatedPrice/BuildingResources/Export',
+            priceZoneId: $priceZoneId,
+            periodId: $periodId,
+            errorMessage: 'Не удалось скачать сметные цены строительных ресурсов ФГИС ЦС.',
+            invalidFileMessage: 'ФГИС ЦС вернул не XLSX-файл со сметными ценами строительных ресурсов.',
+        );
+    }
+
+    public function downloadBuildingResourcesSplitForm(int $priceZoneId, int $periodId): FgiscsDownloadDTO
+    {
+        return $this->downloadSpreadsheet(
+            path: '/EstimatedPrice/BuildingResources/ExportSplitForm',
+            priceZoneId: $priceZoneId,
+            periodId: $periodId,
+            errorMessage: 'Не удалось скачать сплит-форму строительных ресурсов ФГИС ЦС.',
+            invalidFileMessage: 'ФГИС ЦС вернул не XLSX-файл со сплит-формой строительных ресурсов.',
+        );
+    }
+
+    private function downloadSpreadsheet(string $path, int $priceZoneId, int $periodId, string $errorMessage, string $invalidFileMessage): FgiscsDownloadDTO
+    {
+        $response = Http::timeout(180)->get(self::BASE_URL . $path, [
+            'priceZoneId' => $priceZoneId,
+            'periodId' => $periodId,
+        ]);
+
+        if (!$response->successful()) {
+            $body = $response->body();
+            $message = is_array($response->json()) && is_string($response->json('message'))
+                ? (string) $response->json('message')
+                : $errorMessage;
+
+            if ($response->status() === 422) {
+                throw new FgiscsDownloadUnavailableException(
+                    message: $message,
+                    statusCode: $response->status(),
+                    responseBody: $body,
+                );
+            }
+
+            throw new RuntimeException(sprintf(
+                '%s HTTP %d: %s',
+                $errorMessage,
+                $response->status(),
+                mb_substr($body, 0, 300),
+            ));
+        }
+
+        $content = $response->body();
+        $contentType = $response->header('Content-Type');
+
+        if (!str_starts_with($content, 'PK') && !str_contains((string) $contentType, 'spreadsheetml')) {
+            throw new RuntimeException($invalidFileMessage);
+        }
+
+        return new FgiscsDownloadDTO(
+            content: $content,
+            contentType: $contentType,
+            fileName: $this->extractFileName($response->header('Content-Disposition')),
+        );
+    }
+
     /**
      * @return array{year:int,quarter:int}|null
      */

--- a/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Fgiscs/FgiscsRegionalPriceUpdateService.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Fgiscs/FgiscsRegionalPriceUpdateService.php
@@ -347,6 +347,7 @@ class FgiscsRegionalPriceUpdateService
             DB::transaction(function () use ($path, $datasetVersion, $regionalVersion, &$rowsRead, &$rowsImported, &$errorsCount): void {
                 EstimateResourcePrice::query()
                     ->where('regional_price_version_id', $regionalVersion->id)
+                    ->where('source_price_kind', 'regional_worker_salary')
                     ->delete();
 
                 foreach ($this->parser->parse($path) as $dto) {

--- a/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Import/FgiscsBuildingResourcePriceSpreadsheetParser.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Normatives/Services/Import/FgiscsBuildingResourcePriceSpreadsheetParser.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import;
+
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\DTOs\FgiscsBuildingResourcePriceDTO;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class FgiscsBuildingResourcePriceSpreadsheetParser
+{
+    private const CHUNK_SIZE = 1000;
+
+    public function parse(string $filePath): iterable
+    {
+        $reader = IOFactory::createReader(IOFactory::identify($filePath));
+        $reader->setReadDataOnly(true);
+
+        $worksheetInfo = $reader->listWorksheetInfo($filePath);
+
+        foreach ($worksheetInfo as $sheetIndex => $sheetInfo) {
+            $totalRows = (int) ($sheetInfo['totalRows'] ?? 0);
+
+            if ($totalRows < 1) {
+                continue;
+            }
+
+            $filter = new FgiscsBuildingResourcePriceChunkReadFilter();
+            $reader->setReadFilter($filter);
+            $reader->setLoadSheetsOnly([(string) $sheetInfo['worksheetName']]);
+
+            for ($startRow = 1; $startRow <= $totalRows; $startRow += self::CHUNK_SIZE) {
+                $filter->setRows($startRow, self::CHUNK_SIZE);
+                $spreadsheet = $reader->load($filePath);
+                $worksheet = $spreadsheet->getSheet(0);
+
+                foreach ($this->readWorksheetChunk($worksheet, $sheetIndex, $startRow) as $price) {
+                    yield $price;
+                }
+
+                $spreadsheet->disconnectWorksheets();
+                unset($spreadsheet);
+            }
+        }
+    }
+
+    private function readWorksheetChunk(Worksheet $worksheet, int $sheetIndex, int $startRow): iterable
+    {
+        $highestColumn = $worksheet->getHighestColumn();
+        $highestRow = $worksheet->getHighestRow();
+        $headerRow = $this->detectHeaderRow($worksheet, $highestColumn);
+
+        if ($headerRow !== null) {
+            yield from $this->readDirectExportRows($worksheet, $highestColumn, $highestRow, $sheetIndex, max($headerRow + 1, $startRow));
+
+            return;
+        }
+
+        yield from $this->readSplitFormRows($worksheet, $highestColumn, $highestRow, $sheetIndex, $startRow);
+    }
+
+    private function readDirectExportRows(Worksheet $worksheet, string $highestColumn, int $highestRow, int $sheetIndex, int $firstDataRow): iterable
+    {
+        for ($row = $firstDataRow; $row <= $highestRow; $row++) {
+            $values = $worksheet->rangeToArray("A{$row}:{$highestColumn}{$row}", null, true, false)[0] ?? [];
+            $code = $this->clean((string) ($values[0] ?? ''));
+
+            if (!$this->isMaterialCode($code)) {
+                continue;
+            }
+
+            $name = $this->clean((string) ($values[1] ?? ''));
+            $unit = $this->clean((string) ($values[2] ?? ''));
+            $currentPrice = $this->toFloat($values[4] ?? null);
+
+            if ($name === '' || $currentPrice === null || $currentPrice <= 0) {
+                continue;
+            }
+
+            yield new FgiscsBuildingResourcePriceDTO(
+                code: $code,
+                name: $name,
+                unit: $unit !== '' ? $unit : null,
+                currentPrice: $currentPrice,
+                sourcePriceKind: 'regional_building_resource_export',
+                rawData: [
+                    'sheet_index' => $sheetIndex,
+                    'row_number' => $row,
+                    'release_price' => $this->toFloat($values[3] ?? null),
+                    'estimated_price' => $currentPrice,
+                ],
+            );
+        }
+    }
+
+    private function readSplitFormRows(Worksheet $worksheet, string $highestColumn, int $highestRow, int $sheetIndex, int $startRow): iterable
+    {
+        for ($row = $startRow; $row <= $highestRow; $row++) {
+            $values = $worksheet->rangeToArray("A{$row}:{$highestColumn}{$row}", null, true, false)[0] ?? [];
+            $code = $this->clean((string) ($values[0] ?? ''));
+
+            if (!$this->isMaterialCode($code)) {
+                continue;
+            }
+
+            $name = $this->clean((string) ($values[1] ?? ''));
+            $unit = $this->clean((string) ($values[2] ?? ''));
+            $basePrice = $this->toFloat($values[4] ?? null);
+            $directPrice = $this->toFloat($values[7] ?? null);
+            $groupIndex = $this->toFloat($values[8] ?? null);
+            $currentPrice = $directPrice ?? ($basePrice !== null && $groupIndex !== null ? round($basePrice * $groupIndex, 4) : null);
+
+            if ($name === '' || $currentPrice === null || $currentPrice <= 0) {
+                continue;
+            }
+
+            yield new FgiscsBuildingResourcePriceDTO(
+                code: $code,
+                name: $name,
+                unit: $unit !== '' ? $unit : null,
+                currentPrice: $currentPrice,
+                sourcePriceKind: $directPrice !== null ? 'regional_building_resource_direct' : 'regional_building_resource_index',
+                rawData: [
+                    'sheet_index' => $sheetIndex,
+                    'row_number' => $row,
+                    'release_price' => $this->toFloat($values[3] ?? null),
+                    'base_price' => $basePrice,
+                    'group_code' => $this->clean((string) ($values[5] ?? '')),
+                    'group_name' => $this->clean((string) ($values[6] ?? '')),
+                    'direct_current_price' => $directPrice,
+                    'group_index' => $groupIndex,
+                ],
+            );
+        }
+    }
+
+    private function detectHeaderRow(Worksheet $worksheet, string $highestColumn): ?int
+    {
+        $limit = min($worksheet->getHighestRow(), 30);
+
+        for ($row = 1; $row <= $limit; $row++) {
+            $values = $worksheet->rangeToArray("A{$row}:{$highestColumn}{$row}", null, true, false)[0] ?? [];
+            $normalized = array_map(fn (mixed $value): string => $this->normalizeHeader((string) $value), $values);
+
+            if (in_array('resource_code', $normalized, true) && in_array('estimated_price', $normalized, true)) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
+    private function isMaterialCode(string $code): bool
+    {
+        return preg_match('/^\d{2}\.\d\.\d{2}\.\d{2}-\d{4}$/', $code) === 1;
+    }
+
+    private function normalizeHeader(string $value): string
+    {
+        $value = strtr(mb_strtolower(trim($value)), [
+            'ё' => 'е',
+            ' ' => '',
+            "\n" => '',
+            "\r" => '',
+            '.' => '',
+            '-' => '',
+            '_' => '',
+            '/' => '',
+            ',' => '',
+            '(' => '',
+            ')' => '',
+        ]);
+
+        return match (true) {
+            str_contains($value, 'кодстроительногоресурса') || $value === 'кодресурса' => 'resource_code',
+            str_contains($value, 'сметнаяцена') => 'estimated_price',
+            default => $value,
+        };
+    }
+
+    private function toFloat(mixed $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = str_replace([' ', ','], ['', '.'], trim((string) $value));
+
+        return is_numeric($normalized) ? (float) $normalized : null;
+    }
+
+    private function clean(string $value): string
+    {
+        return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+    }
+}
+
+final class FgiscsBuildingResourcePriceChunkReadFilter implements IReadFilter
+{
+    private int $startRow = 1;
+
+    private int $endRow = 1;
+
+    public function setRows(int $startRow, int $chunkSize): void
+    {
+        $this->startRow = $startRow;
+        $this->endRow = $startRow + $chunkSize - 1;
+    }
+
+    public function readCell($columnAddress, $row, $worksheetName = ''): bool
+    {
+        return $row <= 30 || ($row >= $this->startRow && $row <= $this->endRow);
+    }
+}

--- a/tests/Unit/FgiscsBuildingResourcePriceSpreadsheetParserTest.php
+++ b/tests/Unit/FgiscsBuildingResourcePriceSpreadsheetParserTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\BusinessModules\Addons\EstimateGeneration\Normatives\Services\Import\FgiscsBuildingResourcePriceSpreadsheetParser;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PHPUnit\Framework\TestCase;
+
+class FgiscsBuildingResourcePriceSpreadsheetParserTest extends TestCase
+{
+    public function test_it_reads_direct_material_prices_from_fgiscs_export(): void
+    {
+        $file = $this->xlsx([
+            ['Код строительного ресурса', 'Наименование', 'Единица измерения', 'Отпускная цена', 'Сметная цена'],
+            ['02.1.01.02-0003', 'Грунт песчаный (пескогрунт)', 'м3', '120.00', '603.20'],
+        ]);
+
+        $prices = iterator_to_array((new FgiscsBuildingResourcePriceSpreadsheetParser())->parse($file));
+
+        $this->assertCount(1, $prices);
+        $this->assertSame('02.1.01.02-0003', $prices[0]->code);
+        $this->assertSame('Грунт песчаный (пескогрунт)', $prices[0]->name);
+        $this->assertSame('м3', $prices[0]->unit);
+        $this->assertSame(603.20, $prices[0]->currentPrice);
+        $this->assertSame('regional_building_resource_export', $prices[0]->sourcePriceKind);
+    }
+
+    public function test_it_reads_split_form_direct_and_indexed_material_prices(): void
+    {
+        $file = $this->xlsx([
+            ['02.1.01.02-0003', 'Грунт песчаный (пескогрунт)', 'м3', '150.00', '514.19', '440', 'Пескогрунты', '603.20', '-'],
+            ['02.2.02.01-0001', 'Антрацит дробленый для загрузки фильтра', 'т', '19310.12', '20094.38', '22', 'Инертные материалы прочие', '-', '1.38'],
+        ]);
+
+        $prices = iterator_to_array((new FgiscsBuildingResourcePriceSpreadsheetParser())->parse($file));
+
+        $this->assertCount(2, $prices);
+        $this->assertSame(603.20, $prices[0]->currentPrice);
+        $this->assertSame('regional_building_resource_direct', $prices[0]->sourcePriceKind);
+
+        $this->assertSame('02.2.02.01-0001', $prices[1]->code);
+        $this->assertSame(27730.2444, $prices[1]->currentPrice);
+        $this->assertSame('regional_building_resource_index', $prices[1]->sourcePriceKind);
+        $this->assertSame('22', $prices[1]->rawData['group_code']);
+        $this->assertSame(1.38, $prices[1]->rawData['group_index']);
+    }
+
+    /**
+     * @param array<int, array<int, string>> $rows
+     */
+    private function xlsx(array $rows): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        foreach ($rows as $rowIndex => $row) {
+            foreach ($row as $columnIndex => $value) {
+                $sheet->setCellValue([$columnIndex + 1, $rowIndex + 1], $value);
+            }
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'fgiscs-building-resources-') . '.xlsx';
+        (new Xlsx($spreadsheet))->save($path);
+        $spreadsheet->disconnectWorksheets();
+
+        return $path;
+    }
+}


### PR DESCRIPTION
﻿## Что изменено

- Добавлена отдельная команда `estimates:regional-prices:sync-fgiscs-building-resources` для импорта региональных сметных цен строительных ресурсов Минстроя.
- `FgiscsClient` теперь умеет скачивать `BuildingResources/Export` и `BuildingResources/ExportSplitForm`.
- Добавлен XLSX-парсер прямых цен и цен через индекс группы из сплит-формы.
- Импорт материалов пишет строки в текущую региональную версию и не удаляет зарплатные цены.
- Существующий импорт зарплат теперь очищает только свои строки, чтобы не стирать материалы при повторном запуске.

## Проверка

- `php artisan test tests/Unit/FgiscsBuildingResourcePriceSpreadsheetParserTest.php`
- `php -l` по измененным PHP-файлам
- `vendor/bin/phpstan analyse ... --memory-limit=1G --no-progress`
- Проверена доступность Минстроя: период `425`, обе XLSX-выгрузки материалов скачиваются как ZIP/XLSX.
