### PR TITLE
[codex] стабилизирован статус разработки модулей

### DIFF
--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Enums\ModuleDevelopmentStatus;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -45,10 +47,20 @@ class Module extends Model
         'is_active' => 'boolean',
         'is_system_module' => 'boolean',
         'can_deactivate' => 'boolean',
-        'development_status' => \App\Enums\ModuleDevelopmentStatus::class,
         'last_scanned_at' => 'datetime',
         'display_order' => 'integer',
     ];
+
+    protected function developmentStatus(): Attribute
+    {
+        return Attribute::make(
+            get: static fn ($value): ModuleDevelopmentStatus => ModuleDevelopmentStatus::tryFrom((string) $value)
+                ?? ModuleDevelopmentStatus::STABLE,
+            set: static fn ($value): string => $value instanceof ModuleDevelopmentStatus
+                ? $value->value
+                : (ModuleDevelopmentStatus::tryFrom((string) $value) ?? ModuleDevelopmentStatus::STABLE)->value,
+        );
+    }
 
     public function activations(): HasMany
     {
@@ -182,9 +194,9 @@ class Module extends Model
     /**
      * Получить объект enum статуса разработки
      */
-    public function getDevelopmentStatusEnum(): \App\Enums\ModuleDevelopmentStatus
+    public function getDevelopmentStatusEnum(): ModuleDevelopmentStatus
     {
-        return $this->development_status ?? \App\Enums\ModuleDevelopmentStatus::STABLE;
+        return $this->development_status ?? ModuleDevelopmentStatus::STABLE;
     }
 
     /**
@@ -192,7 +204,7 @@ class Module extends Model
      */
     public function isStable(): bool
     {
-        return $this->getDevelopmentStatusEnum() === \App\Enums\ModuleDevelopmentStatus::STABLE;
+        return $this->getDevelopmentStatusEnum() === ModuleDevelopmentStatus::STABLE;
     }
 
     /**

--- a/tests/Unit/Billing/PackageCatalogValidatorTest.php
+++ b/tests/Unit/Billing/PackageCatalogValidatorTest.php
@@ -77,6 +77,19 @@ class PackageCatalogValidatorTest extends TestCase
         }
     }
 
+    public function test_legacy_active_module_development_status_falls_back_to_stable(): void
+    {
+        $module = new \App\Models\Module();
+        $module->setRawAttributes([
+            'development_status' => 'active',
+        ]);
+
+        $this->assertSame(
+            ModuleDevelopmentStatus::STABLE,
+            $module->getDevelopmentStatusEnum()
+        );
+    }
+
     public function test_validator_rejects_unknown_module_slug(): void
     {
         $result = $this->validator()->validate(


### PR DESCRIPTION
﻿## GlitchTip

Исправляет `PROHELPER-BACKEND-4L`: http://5.129.220.32:8000/prohelper-backend/issues/149

## Root cause

Команда `modules:scan` падала при чтении старой записи `modules.development_status = active`. Поле было подключено как прямой Laravel enum cast к `App\Enums\ModuleDevelopmentStatus`, поэтому любое legacy-значение вне enum вызывало `ValueError` до нормализации.

## Что изменено

- В `App\Models\Module` прямой enum cast заменён на accessor/mutator `developmentStatus()`.
- Неизвестные старые значения теперь безопасно приводятся к `ModuleDevelopmentStatus::STABLE`.
- Добавлен regression-test для legacy-значения `active`.

## Проверки

- `php -l app\Models\Module.php`
- `php -l tests\Unit\Billing\PackageCatalogValidatorTest.php`
- `php artisan test tests\Unit\Billing\PackageCatalogValidatorTest.php --filter=legacy_active_module_development_status_falls_back_to_stable`
- `vendor\bin\phpstan.bat analyse app\Models\Module.php tests\Unit\Billing\PackageCatalogValidatorTest.php --no-progress --memory-limit=512M`

## Примечание

Полный `PackageCatalogValidatorTest` отдельно показывает уже существующую рассинхронизацию каталога пакетов: ожидается 10 пакетов, фактически 11, и у `workforce-management/base` отсутствуют зависимости `budget-estimates`, `workflow-management`, `time-tracking`. Это не относится к данному исправлению.
