### PR TITLE
[codex] Исправлена передача организации при экспорте склада

### DIFF
--- a/app/BusinessModules/Features/BasicWarehouse/Services/Export/Strategies/BaseWarehouseExportStrategy.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Services/Export/Strategies/BaseWarehouseExportStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\BasicWarehouse\Services\Export\Strategies;
 
 use App\BusinessModules\Features\BasicWarehouse\Services\Export\Contracts\WarehouseExportStrategyInterface;
+use App\Models\Organization;
 use App\Services\Storage\FileService;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
@@ -25,7 +26,7 @@ abstract class BaseWarehouseExportStrategy implements WarehouseExportStrategyInt
     /**
      * Сохранение Spreadsheet в S3
      */
-    protected function saveSpreadsheetToS3(Spreadsheet $spreadsheet, string $path, $organization): string
+    protected function saveSpreadsheetToS3(Spreadsheet $spreadsheet, string $path, Organization|int|string $organization): string
     {
         $writer = new Xlsx($spreadsheet);
         
@@ -33,10 +34,11 @@ abstract class BaseWarehouseExportStrategy implements WarehouseExportStrategyInt
         $writer->save('php://output');
         $content = ob_get_clean();
         
-        $orgId = $organization instanceof \App\Models\Organization ? $organization->id : $organization;
+        $organizationModel = $organization instanceof Organization ? $organization : null;
+        $orgId = $organizationModel?->id ?? $organization;
         $s3Path = "org-{$orgId}/{$path}";
         
-        $this->fileService->disk($organization)->put($s3Path, $content);
+        $this->fileService->disk($organizationModel)->put($s3Path, $content);
 
         return $s3Path;
     }


### PR DESCRIPTION
## Что исправлено

Исправлена ошибка GlitchTip `PROHELPER-BACKEND-Q` / issue `26`: при экспорте складской формы `M15` в `FileService::disk()` передавался числовой идентификатор организации вместо `Organization|null`.

GlitchTip: http://5.129.220.32:8000/prohelper-backend/issues/26

## Root cause

`BaseWarehouseExportStrategy::saveSpreadsheetToS3()` принимал организацию без строгого типа и использовал одно значение сразу для двух задач: формирования `org-{id}` в S3-пути и выбора диска через `FileService::disk()`. Контракт `disk()` принимает только модель организации или `null`, поэтому scalar ID приводил к `TypeError`.

## Что изменено

- Добавлен явный тип `Organization|int|string` для входного значения организации.
- Для S3-пути по-прежнему используется ID организации.
- В `FileService::disk()` теперь передается только `Organization|null`.

## Проверки

- `php -l app/BusinessModules/Features/BasicWarehouse/Services/Export/Strategies/BaseWarehouseExportStrategy.php`
- `vendor/bin/phpstan.bat analyse app/BusinessModules/Features/BasicWarehouse/Services/Export/Strategies/BaseWarehouseExportStrategy.php --memory-limit=512M`

## Примечание

Detail/events GlitchTip для issue `26` во время диагностики трижды вернули `WinError 10061`, поэтому использованы данные списка issues: exception type, message, file и строка вызова.