### PR TITLE
[codex] Исключены активы из отчета остатков ИИ

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateWarehouseStockReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateWarehouseStockReportTool.php
@@ -48,6 +48,7 @@ class GenerateWarehouseStockReportTool implements AIToolInterface
     {
         $requestData = [
             'format' => 'pdf',
+            'asset_type' => 'material',
         ];
 
         if (isset($arguments['warehouse_id'])) {

--- a/app/Http/Requests/Api/V1/Admin/Report/WarehouseStockReportRequest.php
+++ b/app/Http/Requests/Api/V1/Admin/Report/WarehouseStockReportRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Api\V1\Admin\Report;
 
+use App\BusinessModules\Features\BasicWarehouse\Models\Asset;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -28,6 +29,7 @@ class WarehouseStockReportRequest extends FormRequest
                 Rule::exists('materials', 'id')->where('organization_id', $organizationId),
             ],
             'category' => 'nullable|string|max:255',
+            'asset_type' => ['nullable', 'string', Rule::in(array_keys(Asset::getAssetTypes()))],
             'show_critical_only' => 'nullable|in:0,1,true,false',
             'show_reserved' => 'nullable|in:0,1,true,false',
             'show_expired' => 'nullable|in:0,1,true,false',

--- a/app/Services/Report/ReportService.php
+++ b/app/Services/Report/ReportService.php
@@ -972,9 +972,11 @@ class ReportService
         
         $this->logging->business('report.warehouse_stock.requested', [
             'organization_id' => $organizationId,
-            'filters' => $request->only(['warehouse_id', 'material_id', 'category']),
+            'filters' => $request->only(['warehouse_id', 'material_id', 'category', 'asset_type']),
             'user_id' => $request->user()?->id
         ]);
+
+        $assetType = (string) ($request->query('asset_type') ?: 'material');
 
         $query = DB::table('warehouse_balances')
             ->join('materials', 'warehouse_balances.material_id', '=', 'materials.id')
@@ -998,6 +1000,8 @@ class ReportService
                 DB::raw('(warehouse_balances.available_quantity + warehouse_balances.reserved_quantity) as total_quantity'),
                 DB::raw('(warehouse_balances.available_quantity * warehouse_balances.unit_price) as total_value')
             );
+
+        $this->applyWarehouseStockAssetTypeFilter($query, $assetType);
 
         if ($request->filled('warehouse_id')) {
             $query->where('warehouse_balances.warehouse_id', $request->query('warehouse_id'));
@@ -1092,9 +1096,29 @@ class ReportService
             'title' => 'Отчет по остаткам на складах',
             'data' => $stocks->values(),
             'totals' => $totals,
-            'filters' => $request->only(['warehouse_id', 'material_id', 'category', 'show_critical_only']),
+            'filters' => array_merge(
+                $request->only(['warehouse_id', 'material_id', 'category', 'show_critical_only']),
+                ['asset_type' => $assetType]
+            ),
             'generated_at' => Carbon::now(),
         ];
+    }
+
+    private function applyWarehouseStockAssetTypeFilter(\Illuminate\Database\Query\Builder $query, string $assetType): void
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'pgsql') {
+            $query->whereRaw("COALESCE(materials.additional_properties->>'asset_type', 'material') = ?", [$assetType]);
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            $query->whereRaw("COALESCE(json_extract(materials.additional_properties, '$.asset_type'), 'material') = ?", [$assetType]);
+            return;
+        }
+
+        $query->whereRaw("COALESCE(JSON_UNQUOTE(JSON_EXTRACT(materials.additional_properties, '$.asset_type')), 'material') = ?", [$assetType]);
     }
 
     public function getMaterialMovementsReport(Request $request): array | StreamedResponse

--- a/tests/Feature/Reports/WarehouseStockReportTest.php
+++ b/tests/Feature/Reports/WarehouseStockReportTest.php
@@ -2,9 +2,15 @@
 
 namespace Tests\Feature\Reports;
 
-use Tests\TestCase;
+use App\BusinessModules\Features\BasicWarehouse\Models\OrganizationWarehouse;
+use App\BusinessModules\Features\BasicWarehouse\Models\WarehouseBalance;
+use App\Models\Material;
+use App\Models\Organization;
+use App\Models\User;
 use App\Services\Report\ReportService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
 
 class WarehouseStockReportTest extends TestCase
 {
@@ -64,6 +70,89 @@ class WarehouseStockReportTest extends TestCase
         $report = $this->reportService->generateWarehouseStockReport($organizationId, $filters);
         
         $this->assertEquals($filters, $report['filters']);
+    }
+
+    public function test_get_warehouse_stock_report_defaults_to_material_assets_only(): void
+    {
+        [$organization, $warehouse, $material, $tool, $user] = $this->createStockReportContext();
+
+        $this->createBalance((int) $organization->id, (int) $warehouse->id, (int) $material->id, 12);
+        $this->createBalance((int) $organization->id, (int) $warehouse->id, (int) $tool->id, 3);
+
+        $report = $this->reportService->getWarehouseStockReport(
+            $this->makeWarehouseStockRequest($organization, $user)
+        );
+
+        $this->assertSame(['Cement M500'], $report['data']->pluck('material_name')->all());
+        $this->assertSame('material', $report['filters']['asset_type']);
+    }
+
+    public function test_get_warehouse_stock_report_can_filter_tool_assets_explicitly(): void
+    {
+        [$organization, $warehouse, $material, $tool, $user] = $this->createStockReportContext();
+
+        $this->createBalance((int) $organization->id, (int) $warehouse->id, (int) $material->id, 12);
+        $this->createBalance((int) $organization->id, (int) $warehouse->id, (int) $tool->id, 3);
+
+        $report = $this->reportService->getWarehouseStockReport(
+            $this->makeWarehouseStockRequest($organization, $user, ['asset_type' => 'tool'])
+        );
+
+        $this->assertSame(['Screwdriver'], $report['data']->pluck('material_name')->all());
+        $this->assertSame('tool', $report['filters']['asset_type']);
+    }
+
+    private function createStockReportContext(): array
+    {
+        $organization = Organization::factory()->create();
+        $user = User::factory()->create(['current_organization_id' => $organization->id]);
+        $warehouse = OrganizationWarehouse::query()->create([
+            'organization_id' => $organization->id,
+            'name' => 'Main warehouse',
+            'code' => 'MAIN',
+            'warehouse_type' => OrganizationWarehouse::TYPE_CENTRAL,
+            'is_main' => true,
+            'is_active' => true,
+        ]);
+        $material = Material::query()->create([
+            'organization_id' => $organization->id,
+            'name' => 'Cement M500',
+            'code' => 'CEM-500',
+            'additional_properties' => ['asset_type' => 'material'],
+            'is_active' => true,
+        ]);
+        $tool = Material::query()->create([
+            'organization_id' => $organization->id,
+            'name' => 'Screwdriver',
+            'code' => 'TOOL-001',
+            'additional_properties' => ['asset_type' => 'tool'],
+            'is_active' => true,
+        ]);
+
+        return [$organization, $warehouse, $material, $tool, $user];
+    }
+
+    private function createBalance(int $organizationId, int $warehouseId, int $materialId, float $quantity): WarehouseBalance
+    {
+        return WarehouseBalance::query()->create([
+            'organization_id' => $organizationId,
+            'warehouse_id' => $warehouseId,
+            'material_id' => $materialId,
+            'available_quantity' => $quantity,
+            'reserved_quantity' => 0,
+            'unit_price' => 100,
+            'min_stock_level' => 0,
+            'max_stock_level' => 0,
+        ]);
+    }
+
+    private function makeWarehouseStockRequest(Organization $organization, User $user, array $query = []): Request
+    {
+        $request = Request::create('/api/v1/admin/reports/warehouse-stock', 'GET', $query);
+        $request->setUserResolver(fn () => $user);
+        $request->attributes->set('current_organization_id', $organization->id);
+
+        return $request;
     }
 }
 

--- a/tests/Unit/AIAssistant/Reports/GenerateWarehouseStockReportToolTest.php
+++ b/tests/Unit/AIAssistant/Reports/GenerateWarehouseStockReportToolTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AIAssistant\Reports;
+
+use App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools\GenerateWarehouseStockReportTool;
+use App\Models\Organization;
+use App\Models\User;
+use App\Services\Report\ReportService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\TestCase;
+
+final class GenerateWarehouseStockReportToolTest extends TestCase
+{
+    public function test_requests_material_stock_report_only(): void
+    {
+        $organization = Organization::factory()->make(['id' => 77]);
+        $user = User::factory()->make(['id' => 12, 'current_organization_id' => 77]);
+        $reportService = Mockery::mock(ReportService::class);
+
+        $reportService
+            ->shouldReceive('getWarehouseStockReport')
+            ->once()
+            ->with(Mockery::on(static function (Request $request): bool {
+                return $request->query('format') === 'pdf'
+                    && $request->query('asset_type') === 'material'
+                    && (int) $request->attributes->get('current_organization_id') === 77;
+            }))
+            ->andReturn(new StreamedResponse(static function (): void {
+                echo '%PDF';
+            }));
+
+        $disk = Mockery::mock();
+        $disk
+            ->shouldReceive('put')
+            ->once()
+            ->with(Mockery::pattern('/^org-77\/reports\/warehouse_stock_report_\d+\.pdf$/'), '%PDF')
+            ->andReturn(true);
+        $disk
+            ->shouldReceive('temporaryUrl')
+            ->once()
+            ->with(Mockery::type('string'), Mockery::type(\DateTimeInterface::class))
+            ->andReturn('https://storage.example.test/report.pdf');
+
+        Storage::shouldReceive('disk')->twice()->with('s3')->andReturn($disk);
+
+        $result = (new GenerateWarehouseStockReportTool($reportService))->execute([], $user, $organization);
+
+        $this->assertSame('success', $result['status']);
+        $this->assertSame('https://storage.example.test/report.pdf', $result['pdf_url']);
+    }
+}


### PR DESCRIPTION
## Что изменено
- Отчет остатков склада теперь по умолчанию фильтрует позиции по `asset_type=material`.
- AI-инструмент генерации отчета явно передает `asset_type=material`, чтобы в PDF не попадали инструменты и оборудование.
- Добавлены тесты на дефолтную фильтрацию отчета и на параметры AI-инструмента.

## Причина
Активы склада хранятся в общей таблице `materials`, а отчет остатков подписан и используется как отчет по материалам. Без фильтра в него попадали инструменты, например шуруповерты.

## Проверки
- `php -l` для измененных PHP-файлов
- `php artisan test tests\Feature\Reports\WarehouseStockReportTest.php tests\Unit\AIAssistant\Reports\GenerateWarehouseStockReportToolTest.php --stop-on-failure`
- `vendor\bin\phpstan.bat analyse app\Services\Report\ReportService.php app\Http\Requests\Api\V1\Admin\Report\WarehouseStockReportRequest.php app\BusinessModules\Features\AIAssistant\Actions\Reports\Tools\GenerateWarehouseStockReportTool.php --memory-limit=1G --no-progress`