### PR TITLE
fix[lk]: исправлен конфликт единиц материалов

### DIFF
--- a/app/BusinessModules/Features/BudgetEstimates/Services/Import/MaterialMatchingService.php
+++ b/app/BusinessModules/Features/BudgetEstimates/Services/Import/MaterialMatchingService.php
@@ -114,19 +114,18 @@ class MaterialMatchingService
         int $organizationId,
         string $itemType
     ): Material {
+        $measurementUnitId = null;
+        if ($unit) {
+            $measurementUnit = $this->findOrCreateUnit($unit, $organizationId);
+            $measurementUnitId = $measurementUnit->id;
+        }
+
         DB::beginTransaction();
         
         try {
             // Определяем категорию по коду
             $category = $this->detectCategory($code);
             
-            // Находим или создаем единицу измерения
-            $measurementUnitId = null;
-            if ($unit) {
-                $measurementUnit = $this->findOrCreateUnit($unit, $organizationId);
-                $measurementUnitId = $measurementUnit->id;
-            }
-
             // Создаем материал
             $material = Material::create([
                 'organization_id' => $organizationId,
@@ -217,9 +216,11 @@ class MaterialMatchingService
         $unit = $this->findUnitByNameOrShortName($normalized, $organizationId);
 
         if ($unit === null) {
-            $shortName = mb_strlen($unitName) > 10
-                ? mb_substr($unitName, 0, 10)
-                : $unitName;
+            $shortName = trim(
+                mb_strlen($unitName) > 10
+                    ? mb_substr($unitName, 0, 10)
+                    : $unitName
+            );
 
             try {
                 $unit = MeasurementUnit::create([

--- a/tests/Feature/BudgetEstimates/MaterialMatchingServiceTest.php
+++ b/tests/Feature/BudgetEstimates/MaterialMatchingServiceTest.php
@@ -37,4 +37,29 @@ class MaterialMatchingServiceTest extends TestCase
         $this->assertSame($unit->id, $material->measurement_unit_id);
         $this->assertSame($unitsCount, MeasurementUnit::query()->where('organization_id', $organization->id)->count());
     }
+
+    public function test_reuses_existing_measurement_unit_when_truncated_short_name_conflicts(): void
+    {
+        $organization = Organization::factory()->create();
+        $unit = MeasurementUnit::query()->create([
+            'organization_id' => $organization->id,
+            'name' => 'Existing long unit',
+            'short_name' => 'abcdefghij',
+            'type' => 'material',
+        ]);
+        $unitsCount = MeasurementUnit::query()->where('organization_id', $organization->id)->count();
+
+        $service = new MaterialMatchingService(new NormativeCodeService());
+
+        $material = $service->findOrCreate(
+            'FSBC-20.2.07.04-0002',
+            'Cable tray',
+            'abcdefghij extra',
+            100.0,
+            $organization->id
+        );
+
+        $this->assertSame($unit->id, $material->measurement_unit_id);
+        $this->assertSame($unitsCount, MeasurementUnit::query()->where('organization_id', $organization->id)->count());
+    }
 }


### PR DESCRIPTION
## GlitchTip
- Issue: PROHELPER-BACKEND-10 / #32
- Link: http://5.129.220.32:8000/prohelper-backend/issues/32
- Last seen: 2026-05-29T05:19:22.287Z
- Count: 3014

## Root cause
При импорте смет `MaterialMatchingService` мог создавать единицу измерения с `short_name`, который уже существует в организации. Если конфликт возникал после первичного поиска, попытка восстановиться выполнялась внутри общей транзакции создания материала. В PostgreSQL после unique violation транзакция переходит в aborted-состояние, поэтому дальнейший SELECT внутри той же транзакции ненадежен.

## Что изменено
- Разрешение/создание `MeasurementUnit` вынесено до транзакции создания материала.
- `short_name` после обрезки дополнительно нормализуется через `trim()`.
- Добавлен тест на конфликт обрезанного `short_name`, чтобы не создавать дубликаты и переиспользовать существующую единицу.

## Проверки
- `php -l app\\BusinessModules\\Features\\BudgetEstimates\\Services\\Import\\MaterialMatchingService.php`
- `php -l tests\\Feature\\BudgetEstimates\\MaterialMatchingServiceTest.php`
- `vendor\\bin\\phpunit.bat tests\\Feature\\BudgetEstimates\\MaterialMatchingServiceTest.php`
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\BudgetEstimates\\Services\\Import\\MaterialMatchingService.php tests\\Feature\\BudgetEstimates\\MaterialMatchingServiceTest.php --memory-limit=1G`

## Примечание
В рабочем дереве до этой правки уже были несвязанные незакоммиченные изменения по contractor invitations; они в PR не включены.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored MaterialMatchingService to resolve measurement unit creation before starting the database transaction.</li>
<li>Added trimming to the short name generation logic in findOrCreateUnit to prevent potential whitespace issues.</li>
<li>Added a new feature test to verify that existing measurement units are correctly reused when truncated short names conflict.</li>
</ul></div>