### PR TITLE
fix[backend]: исправлена обработка больших запросов

### DIFF
--- a/app/Http/Middleware/CorsMiddleware.php
+++ b/app/Http/Middleware/CorsMiddleware.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Config;
@@ -199,6 +200,7 @@ class CorsMiddleware
                 $e instanceof \Illuminate\Validation\ValidationException ||
                 $e instanceof \Illuminate\Auth\AuthenticationException ||
                 $e instanceof \Illuminate\Auth\Access\AuthorizationException ||
+                $e instanceof PostTooLargeException ||
                 $e instanceof \InvalidArgumentException) { // Для ошибок конфигурации (например, guard не определён)
                 
                 // Сохраняем CORS заголовки в запросе для Handler

--- a/tests/Unit/Http/Middleware/CorsMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/CorsMiddlewareTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Http\Middleware;
+
+use App\Http\Middleware\CorsMiddleware;
+use App\Services\Logging\LoggingService;
+use Illuminate\Http\Exceptions\PostTooLargeException;
+use Illuminate\Http\Request;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class CorsMiddlewareTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_post_too_large_exception_is_forwarded_to_global_handler(): void
+    {
+        $logging = Mockery::mock(LoggingService::class)->shouldIgnoreMissing();
+        $middleware = new CorsMiddleware($logging);
+        $request = Request::create(
+            '/api/v1/admin/design-management/model-versions/1/derivatives',
+            'POST',
+            server: ['HTTP_ORIGIN' => 'https://prohelper.pro']
+        );
+
+        $this->expectException(PostTooLargeException::class);
+
+        try {
+            $middleware->handle($request, static function (): void {
+                throw new PostTooLargeException();
+            });
+        } finally {
+            $headers = $request->attributes->get('cors_headers', []);
+
+            self::assertSame('https://prohelper.pro', $headers['Access-Control-Allow-Origin'] ?? null);
+            self::assertSame('true', $headers['Access-Control-Allow-Credentials'] ?? null);
+        }
+    }
+}


### PR DESCRIPTION
## GlitchTip
- Issue: PROHELPER-BACKEND-6M / issue id 245
- Link: http://5.129.220.32:8000/prohelper-backend/issues/245
- Route: POST /api/v1/admin/design-management/model-versions/1/derivatives
- Exception: Illuminate\Http\Exceptions\PostTooLargeException

## Root cause
`CorsMiddleware` перехватывал исключения из нижней middleware-цепочки, но не относил `PostTooLargeException` к исключениям, которые нужно пробрасывать в глобальный `Handler`. В результате слишком большой запрос к design-management мог уходить в системную ветку CORS middleware вместо существующего 413-ответа через `AdminResponse`.

## Что изменено
- `PostTooLargeException` добавлен в passthrough-ветку `CorsMiddleware`.
- Добавлен unit-тест, который проверяет проброс исключения и сохранение CORS-заголовков для `Handler`.

## Проверки
- `php -l app\\Http\\Middleware\\CorsMiddleware.php`
- `php -l tests\\Unit\\Http\\Middleware\\CorsMiddlewareTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\Http\\Middleware\\CorsMiddlewareTest.php`
- `vendor\\bin\\phpstan.bat analyse app\\Http\\Middleware\\CorsMiddleware.php tests\\Unit\\Http\\Middleware\\CorsMiddlewareTest.php --no-progress --memory-limit=512M`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated CorsMiddleware to include PostTooLargeException in the list of exceptions that preserve CORS headers.</li>
<li>Added a new unit test to verify that PostTooLargeException correctly propagates while maintaining CORS headers.</li>
</ul></div>