### PR TITLE
fix: исправлена повторная выдача RAG-задач

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -21,6 +21,7 @@ class IndexRagSourceJob implements ShouldQueue
         public ?string $sourceType = null,
         public ?int $runId = null
     ) {
+        $this->onConnection($this->connectionName());
         $this->onQueue($this->queueName());
     }
 
@@ -70,5 +71,16 @@ class IndexRagSourceJob implements ShouldQueue
         }
 
         return is_string($queue) && trim($queue) !== '' ? $queue : 'ai-rag';
+    }
+
+    private function connectionName(): string
+    {
+        try {
+            $connection = config('ai-assistant.rag.queue_connection', 'redis_ai_rag');
+        } catch (Throwable) {
+            return 'redis_ai_rag';
+        }
+
+        return is_string($connection) && trim($connection) !== '' ? $connection : 'redis_ai_rag';
     }
 }

--- a/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
+++ b/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
@@ -73,6 +73,7 @@ return [
             'https://ai.api.cloud.yandex.net/foundationModels/v1/textEmbedding'
         ),
         'embedding_dimensions' => $configEnv('AI_RAG_EMBEDDING_DIMENSIONS', 256),
+        'queue_connection' => $configEnv('AI_RAG_QUEUE_CONNECTION', 'redis_ai_rag'),
         'queue' => $configEnv('AI_RAG_QUEUE', 'ai-rag'),
         'scheduled_limit' => $configEnv('AI_RAG_SCHEDULED_LIMIT', 50),
         'stale_after_hours' => $configEnv('AI_RAG_STALE_AFTER_HOURS', 24),

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -18,6 +18,7 @@ return [
         'redis:notifications' => 120,
         'redis:notifications-low' => 300,
         'redis:ai-rag' => 600,
+        'redis_ai_rag:ai-rag' => 600,
     ],
     
     'trim' => [
@@ -116,7 +117,7 @@ return [
                 'memory' => 512,
             ],
             'supervisor-ai-rag' => [
-                'connection' => 'redis',
+                'connection' => env('AI_RAG_QUEUE_CONNECTION', 'redis_ai_rag'),
                 'queue' => [env('AI_RAG_QUEUE', 'ai-rag')],
                 'balance' => 'auto',
                 'autoScalingStrategy' => 'time',
@@ -140,7 +141,7 @@ return [
                 'memory' => 512,
             ],
             'supervisor-ai-rag' => [
-                'connection' => 'redis',
+                'connection' => env('AI_RAG_QUEUE_CONNECTION', 'redis_ai_rag'),
                 'queue' => [env('AI_RAG_QUEUE', 'ai-rag')],
                 'balance' => 'simple',
                 'processes' => 1,

--- a/config/queue.php
+++ b/config/queue.php
@@ -72,6 +72,15 @@ return [
             'after_commit' => false,
         ],
 
+        'redis_ai_rag' => [
+            'driver' => 'redis',
+            'connection' => env('AI_RAG_REDIS_QUEUE_CONNECTION', env('REDIS_QUEUE_CONNECTION', 'default')),
+            'queue' => env('AI_RAG_QUEUE', 'ai-rag'),
+            'retry_after' => (int) env('AI_RAG_QUEUE_RETRY_AFTER', ((int) env('AI_RAG_JOB_TIMEOUT', 1800)) + 300),
+            'block_for' => null,
+            'after_commit' => false,
+        ],
+
         'redis_estimate_generation' => [
             'driver' => 'redis',
             'connection' => env('REDIS_ESTIMATE_GENERATION_QUEUE_CONNECTION', env('REDIS_QUEUE_CONNECTION', 'default')),

--- a/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
+++ b/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
@@ -18,6 +18,7 @@ class IndexRagSourceJobTest extends TestCase
         $this->assertSame(10, $job->organizationId);
         $this->assertSame(20, $job->projectId);
         $this->assertSame('project', $job->sourceType);
+        $this->assertSame('redis_ai_rag', $job->connection);
         $this->assertSame('ai-rag', $job->queue);
 
         $job->handle($indexer);


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-65: http://5.129.220.32:8000/prohelper-backend/issues/228
- PROHELPER-BACKEND-66: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause
`IndexRagSourceJob` работает в очереди `ai-rag` как долгий RAG-indexing job. Horizon для этой очереди настроен с `timeout=AI_RAG_JOB_TIMEOUT` (по умолчанию 1800 секунд), но Redis queue connection использовал общий `retry_after=90`. Из-за этого Laravel мог повторно выдать задачу до завершения первой попытки, быстро набирались 3 попытки и GlitchTip массово получал `MaxAttemptsExceededException`.

## Что изменено
- Добавлен отдельный queue connection `redis_ai_rag` с `retry_after=AI_RAG_JOB_TIMEOUT + 300` по умолчанию.
- `IndexRagSourceJob` теперь явно отправляется на RAG queue connection и очередь `ai-rag`.
- Horizon supervisor для `ai-rag` переведён на тот же connection.
- Добавлен unit assertion, что job использует `redis_ai_rag`.

## Проверки
- `php -l` по изменённым PHP-файлам
- `php artisan test tests\Unit\AIAssistant\Rag\IndexRagSourceJobTest.php`
- `vendor\bin\phpstan analyse app\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob.php config\queue.php config\horizon.php app\BusinessModules\Features\AIAssistant\config\ai-assistant.php tests\Unit\AIAssistant\Rag\IndexRagSourceJobTest.php --memory-limit=1G --no-progress`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a dedicated 'redis_ai_rag' queue connection configuration to the application.</li>
<li>Updated IndexRagSourceJob to use the configurable queue connection.</li>
<li>Configured Horizon to use the new queue connection for the AI RAG supervisor.</li>
<li>Added a unit test to verify the job uses the correct connection.</li>
</ul></div>