### PR TITLE
fix: увеличены повторы RAG-индексации

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -29,7 +29,7 @@ class IndexRagSourceJob implements ShouldQueue
     ) {
         $this->onConnection($this->connectionName());
         $this->onQueue($this->queueName());
-        $this->tries = $this->configInt('ai-assistant.rag.job_tries', 1);
+        $this->tries = $this->configInt('ai-assistant.rag.job_tries', 3);
         $this->timeout = $this->configInt('ai-assistant.rag.job_timeout', 1800);
     }
 

--- a/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
+++ b/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
@@ -75,7 +75,7 @@ return [
         'embedding_dimensions' => $configEnv('AI_RAG_EMBEDDING_DIMENSIONS', 256),
         'queue_connection' => $configEnv('AI_RAG_QUEUE_CONNECTION', 'redis_ai_rag'),
         'queue' => $configEnv('AI_RAG_QUEUE', 'ai-rag'),
-        'job_tries' => $configEnv('AI_RAG_JOB_TRIES', 1),
+        'job_tries' => $configEnv('AI_RAG_JOB_TRIES', 3),
         'job_timeout' => $configEnv('AI_RAG_JOB_TIMEOUT', 1800),
         'scheduled_limit' => $configEnv('AI_RAG_SCHEDULED_LIMIT', 50),
         'stale_after_hours' => $configEnv('AI_RAG_STALE_AFTER_HOURS', 24),

--- a/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
+++ b/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
@@ -21,7 +21,7 @@ class IndexRagSourceJobTest extends TestCase
         $this->assertSame('project', $job->sourceType);
         $this->assertSame('redis_ai_rag', $job->connection);
         $this->assertSame('ai-rag', $job->queue);
-        $this->assertSame(1, $job->tries);
+        $this->assertSame(3, $job->tries);
         $this->assertSame(1800, $job->timeout);
         $this->assertTrue($job->failOnTimeout);
 


### PR DESCRIPTION
## GlitchTip issues

- Исправлено: PROHELPER-BACKEND-65 / issue 228
  - https://5.129.220.32:8000/prohelper-backend/issues/228
- Проверено без дополнительных правок: PROHELPER-BACKEND-6Q / issue 249 уже покрыт текущим origin/main через нормализацию status=pending в pending_approval.
- Проверено без дополнительных правок: PROHELPER-BACKEND-2A / issue 74 уже покрыт текущим origin/main через Carbon::parse для date_from/date_to в ABC/XYZ аналитике.

## Root cause

После предыдущего исправления RAG job получил настраиваемые retry/timeout, но дефолт `ai-assistant.rag.job_tries` остался `1`. На production release `prohelper@20fda30` GlitchTip показывает, что Horizon worker обрабатывал `IndexRagSourceJob` с `maxTries: 1`, поэтому повторная попытка сразу завершалась `Illuminate\Queue\MaxAttemptsExceededException`.

## Что изменено

- Дефолт `AI_RAG_JOB_TRIES` поднят с `1` до `3` в `app/BusinessModules/Features/AIAssistant/config/ai-assistant.php`.
- Fallback в `IndexRagSourceJob` синхронизирован с этим дефолтом.
- Unit-тест RAG job обновлен под ожидаемые 3 попытки.

## Проверки

- `php -l app\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob.php`
- `php -l app\BusinessModules\Features\AIAssistant\config\ai-assistant.php`
- `php -l tests\Unit\AIAssistant\Rag\IndexRagSourceJobTest.php`
- `php artisan test tests\Unit\AIAssistant\Rag\IndexRagSourceJobTest.php`
- `vendor\bin\phpstan analyse app\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob.php app\BusinessModules\Features\AIAssistant\config\ai-assistant.php tests\Unit\AIAssistant\Rag\IndexRagSourceJobTest.php --memory-limit=1G`

Примечание: для локального `composer install` в Windows CLI пришлось использовать `--ignore-platform-req=ext-intl --ignore-platform-req=ext-pcntl --ignore-platform-req=ext-posix`, потому что эти extensions отсутствуют в локальном PHP, но это не меняло lock-файл и не входит в коммит.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Increased the default number of retry attempts for IndexRagSourceJob from 1 to 3.</li>
<li>Updated the ai-assistant configuration to reflect the new default job retry count.</li>
<li>Updated the corresponding unit test to verify the job now correctly uses 3 retry attempts.</li>
</ul></div>