### PR TITLE
fix: добавлен cooldown для неудачной RAG-индексации

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
@@ -46,8 +46,18 @@ class RagIndexingCoordinator
         );
         $runIds = [];
         $organizationIds = [];
+        $failedCutoff = $staleOnly
+            ? now()->subHours(max(1, (int) config('ai-assistant.rag.failed_retry_after_hours', 12)))
+            : null;
 
         foreach ($organizations as $organization) {
+            if (
+                $failedCutoff instanceof Carbon
+                && $this->hasRecentFailedRun($organization->id, $projectId, $sourceType, $failedCutoff)
+            ) {
+                continue;
+            }
+
             $run = $this->queueOrganization($organization->id, $projectId, $sourceType, $mode);
             $runIds[] = $run->id;
             $organizationIds[] = $organization->id;
@@ -270,7 +280,9 @@ class RagIndexingCoordinator
         if ($staleOnly) {
             $freshnessWindow = max(1, $staleAfterHours ?? (int) config('ai-assistant.rag.stale_after_hours', 24));
             $cutoff = now()->subHours($freshnessWindow);
-            $this->applyStaleOnlyConstraint($query, $cutoff, $projectId, $sourceType);
+            $failedRetryAfterHours = max(1, (int) config('ai-assistant.rag.failed_retry_after_hours', 12));
+            $failedCutoff = now()->subHours($failedRetryAfterHours);
+            $this->applyStaleOnlyConstraint($query, $cutoff, $failedCutoff, $projectId, $sourceType);
             $this->orderByOldestRagAttempt($query);
         } else {
             $query->orderBy('id');
@@ -284,6 +296,7 @@ class RagIndexingCoordinator
     private function applyStaleOnlyConstraint(
         Builder $query,
         Carbon $cutoff,
+        Carbon $failedCutoff,
         ?int $projectId,
         ?string $sourceType
     ): void {
@@ -308,6 +321,24 @@ class RagIndexingCoordinator
 
                 $this->applyActiveRunScope($subQuery, $runTable, $projectId, $sourceType);
             })
+            ->whereNotExists(
+                function (QueryBuilder $subQuery) use (
+                    $failedCutoff,
+                    $organizationTable,
+                    $projectId,
+                    $runTable,
+                    $sourceType
+                ): void {
+                    $subQuery
+                        ->selectRaw('1')
+                        ->from($runTable)
+                        ->whereColumn("{$runTable}.organization_id", "{$organizationTable}.id")
+                        ->where("{$runTable}.status", RagIndexRun::STATUS_FAILED)
+                        ->where("{$runTable}.queued_at", '>', $failedCutoff->toDateTimeString());
+
+                    $this->applyRunScope($subQuery, $runTable, $projectId, $sourceType);
+                }
+            )
             ->whereNotExists(
                 function (QueryBuilder $subQuery) use (
                     $cutoff,
@@ -345,6 +376,29 @@ class RagIndexingCoordinator
         } else {
             $query->where("{$runTable}.source_type", $sourceType);
         }
+    }
+
+    private function hasRecentFailedRun(
+        int $organizationId,
+        ?int $projectId,
+        ?string $sourceType,
+        Carbon $failedCutoff
+    ): bool {
+        return RagIndexRun::query()
+            ->where('organization_id', $organizationId)
+            ->where('status', RagIndexRun::STATUS_FAILED)
+            ->where('queued_at', '>', $failedCutoff->toDateTimeString())
+            ->when(
+                $projectId === null,
+                static fn (Builder $query): Builder => $query->whereNull('project_id'),
+                static fn (Builder $query): Builder => $query->where('project_id', $projectId)
+            )
+            ->when(
+                $sourceType === null,
+                static fn (Builder $query): Builder => $query->whereNull('source_type'),
+                static fn (Builder $query): Builder => $query->where('source_type', $sourceType)
+            )
+            ->exists();
     }
 
     private function applyActiveRunScope(

--- a/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
+++ b/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
@@ -79,6 +79,7 @@ return [
         'job_timeout' => $configEnv('AI_RAG_JOB_TIMEOUT', 1800),
         'scheduled_limit' => $configEnv('AI_RAG_SCHEDULED_LIMIT', 50),
         'stale_after_hours' => $configEnv('AI_RAG_STALE_AFTER_HOURS', 24),
+        'failed_retry_after_hours' => $configEnv('AI_RAG_FAILED_RETRY_AFTER_HOURS', 12),
         'max_chunks' => $configEnv('AI_RAG_MAX_CHUNKS', 8),
         'min_similarity' => $configEnv('AI_RAG_MIN_SIMILARITY', 0.72),
         'chunk_chars' => $configEnv('AI_RAG_CHUNK_CHARS', 1200),

--- a/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
+++ b/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
@@ -260,6 +260,41 @@ class AIAssistantRagBackfillCommandTest extends TestCase
         );
     }
 
+    public function test_stale_all_backfill_skips_recently_failed_source_scope(): void
+    {
+        Queue::fake();
+        config(['ai-assistant.rag.failed_retry_after_hours' => 12]);
+
+        $organization = Organization::factory()->create();
+        $sourceTypes = $this->enabledSourceTypes();
+
+        foreach (array_diff($sourceTypes, ['estimate']) as $sourceType) {
+            $this->createIndexRun($organization, RagIndexRun::STATUS_SUCCEEDED, now()->subHours(2), $sourceType);
+        }
+
+        $this->createIndexRun($organization, RagIndexRun::STATUS_FAILED, now()->subMinutes(30), 'estimate');
+
+        $this->assertDatabaseHas('ai_rag_index_runs', [
+            'organization_id' => $organization->id,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_FAILED,
+        ]);
+
+        $result = app(\App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator::class)
+            ->queueAllActiveOrganizations(
+                sourceType: 'estimate',
+                mode: RagIndexRun::MODE_SCHEDULED,
+                staleOnly: true
+            );
+
+        $this->assertNotContains($organization->id, $result['organization_ids']);
+        Queue::assertNotPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->sourceType === 'estimate'
+        );
+    }
+
     public function test_stale_all_backfill_uses_custom_freshness_window(): void
     {
         Queue::fake();


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-65 / issue 228: http://5.129.220.32:8000/prohelper-backend/issues/228
- PROHELPER-BACKEND-66 / issue 229: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause
Scheduled RAG backfill with `--stale` kept selecting the same organization/project/source scope after a recent failed run. For organization 39 and source `estimate`, production runs were failing after retries/timeouts and then being requeued again by the scheduler shortly afterwards, producing a GlitchTip storm of `IndexRagSourceJob has been attempted too many times` from Horizon.

This PR does not pretend to solve the underlying heavy `estimate` indexing workload. It adds a bounded cooldown so recently failed scopes are skipped by stale scheduled backfill instead of being retried every scheduler tick.

## Changes
- Added `ai-assistant.rag.failed_retry_after_hours` / `AI_RAG_FAILED_RETRY_AFTER_HOURS` with a default of 12 hours.
- Excluded recently failed scoped RAG runs from stale organization selection.
- Added a dispatch-time guard so limited stale batches also skip a recent failed scope before queueing a job.
- Added a regression test for skipping a recently failed `estimate` scope.

## Verification
- `php -l app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\RagIndexingCoordinator.php`
- `php -l app\\BusinessModules\\Features\\AIAssistant\\config\\ai-assistant.php`
- `php -l tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php`
- `php artisan test tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php` - 17 passed, 66 assertions
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\RagIndexingCoordinator.php app\\BusinessModules\\Features\\AIAssistant\\config\\ai-assistant.php tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php --memory-limit=1G`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a 'failed_retry_after_hours' configuration to control how long to wait before retrying failed RAG indexing runs.</li>
<li>Updated RagIndexingCoordinator to skip organizations that have had a failed indexing run within the configured retry window.</li>
<li>Added a new test case to verify that the backfill command correctly skips organizations with recently failed runs for specific source types.</li>
</ul></div>