### PR TITLE
fix: устранена гонка создания каталога метрик

### DIFF
--- a/app/Services/Monitoring/PrometheusService.php
+++ b/app/Services/Monitoring/PrometheusService.php
@@ -11,8 +11,12 @@ class PrometheusService
     public function __construct()
     {
         $this->storageDir = storage_path('prometheus');
-        if (!is_dir($this->storageDir)) {
-            mkdir($this->storageDir, 0775, true);
+        if (
+            !is_dir($this->storageDir)
+            && !@mkdir($this->storageDir, 0775, true)
+            && !is_dir($this->storageDir)
+        ) {
+            return;
         }
     }
 
@@ -224,4 +228,4 @@ class PrometheusService
             return;
         }
     }
-} 
+}


### PR DESCRIPTION
﻿## GlitchTip issues

- PROHELPER-BACKEND-74 / issue 259: http://5.129.220.32:8000/prohelper-backend/issues/259
- PROHELPER-BACKEND-75 / issue 260: http://5.129.220.32:8000/prohelper-backend/issues/260

## Root cause

В production под Laravel Octane/RoadRunner несколько процессов могли одновременно создать `storage/prometheus`. Один процесс проходил проверку `is_dir()`, второй успевал создать каталог, после чего первый получал `ErrorException: mkdir(): File exists` в `PrometheusService::__construct()`.

## Что изменено

- Создание каталога Prometheus сделано устойчивым к гонке: `mkdir()` вызывается с подавлением warning, а результат подтверждается повторной проверкой `is_dir()`.
- Если каталог все равно недоступен, сервис мониторинга не валит запрос; существующие операции записи метрик уже работают в best-effort режиме.

## Проверки

- `php -l app\Services\Monitoring\PrometheusService.php`
- `vendor\bin\phpstan.bat analyse app\Services\Monitoring\PrometheusService.php --memory-limit=1G`


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored directory creation logic in PrometheusService constructor to handle potential race conditions or permission issues more gracefully by suppressing errors and verifying directory existence.</li>
</ul></div>