### PR TITLE
fix: обработана доменная ошибка пересчета витрины

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Jobs/RecalculateEpmDataMartSnapshotJob.php
+++ b/app/BusinessModules/Features/Budgeting/Jobs/RecalculateEpmDataMartSnapshotJob.php
@@ -6,6 +6,7 @@ namespace App\BusinessModules\Features\Budgeting\Jobs;
 
 use App\BusinessModules\Features\Budgeting\Services\EpmDataMartRecalculationCoordinator;
 use App\BusinessModules\Features\Budgeting\Services\EpmDataMartRecalculationService;
+use DomainException;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -30,10 +31,19 @@ final class RecalculateEpmDataMartSnapshotJob implements ShouldQueue, ShouldBeUn
 
     public function handle(EpmDataMartRecalculationService $service): void
     {
-        $service->recalculateRun($this->runId, false);
+        try {
+            $service->recalculateRun($this->runId, false);
+        } catch (DomainException $exception) {
+            $this->markFailed($exception);
+        }
     }
 
     public function failed(Throwable $throwable): void
+    {
+        $this->markFailed($throwable);
+    }
+
+    private function markFailed(Throwable $throwable): void
     {
         try {
             app(EpmDataMartRecalculationCoordinator::class)->markFailedById($this->runId, $throwable);

--- a/tests/Unit/Budgeting/EpmDataMartScopeAndJobTest.php
+++ b/tests/Unit/Budgeting/EpmDataMartScopeAndJobTest.php
@@ -111,4 +111,16 @@ final class EpmDataMartScopeAndJobTest extends TestCase
         $this->assertIsString($source);
         $this->assertStringContainsString('recalculateRun($this->runId, false)', $source);
     }
+
+    public function test_job_marks_expected_domain_failures_without_queue_failure(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 3)
+            . '/app/BusinessModules/Features/Budgeting/Jobs/RecalculateEpmDataMartSnapshotJob.php');
+
+        $this->assertIsString($source);
+        $this->assertStringContainsString('catch (DomainException $exception)', $source);
+        $this->assertStringContainsString('$this->markFailed($exception);', $source);
+        $this->assertStringContainsString('public function failed(Throwable $throwable): void', $source);
+        $this->assertStringContainsString('$this->markFailed($throwable);', $source);
+    }
 }


### PR DESCRIPTION
## GlitchTip

Исправляет:
- PROHELPER-BACKEND-76 / issue 261: http://5.129.220.32:8000/prohelper-backend/issues/261
- PROHELPER-BACKEND-77 / issue 262: http://5.129.220.32:8000/prohelper-backend/issues/262

## Root cause

Фоновая job `RecalculateEpmDataMartSnapshotJob` пересчитывала EPM-витрину для `plan_fact` без `budget_version_uuid`. `PlanFactReportService::resolveVersion()` корректно выбрасывал `DomainException` с бизнес-сообщением, run помечался как failed только через Laravel failed job lifecycle, а само исключение считалось необработанным и попадало в failed_jobs/GlitchTip.

## Что изменено

- `RecalculateEpmDataMartSnapshotJob::handle()` теперь перехватывает ожидаемые `DomainException`, помечает run как failed через общий helper и завершает job без проброса исключения.
- Неожиданные `Throwable` по-прежнему идут через стандартный queue retry/failed flow.
- Добавлен регрессионный unit-тест на контракт обработки ожидаемой доменной ошибки.

## Проверки

- `php -l app\\BusinessModules\\Features\\Budgeting\\Jobs\\RecalculateEpmDataMartSnapshotJob.php`
- `php -l tests\\Unit\\Budgeting\\EpmDataMartScopeAndJobTest.php`
- `.\\vendor\\bin\\phpunit.bat tests\\Unit\\Budgeting\\EpmDataMartScopeAndJobTest.php`
- `.\\vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\Budgeting\\Jobs\\RecalculateEpmDataMartSnapshotJob.php tests\\Unit\\Budgeting\\EpmDataMartScopeAndJobTest.php --memory-limit=1G`

Composer dependencies were installed in the isolated worktree with `--no-scripts` and Windows-only platform ignores for `ext-pcntl`/`ext-posix` to run local checks.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added error handling for DomainException in RecalculateEpmDataMartSnapshotJob to mark the job as failed without triggering a full queue failure.</li>
<li>Refactored failure handling into a private markFailed method to centralize error reporting logic.</li>
<li>Added a unit test to verify that DomainException is caught and handled correctly in the job.</li>
</ul></div>