### PR TITLE
fix: исправлена авторизация панели Horizon

### DIFF
--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -17,8 +17,12 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
 
     protected function gate(): void
     {
-        Gate::define('viewHorizon', function ($user) {
-            return $user->isSystemAdmin() || 
+        Gate::define('viewHorizon', function ($user = null) {
+            if (! $user) {
+                return false;
+            }
+
+            return $user->isSystemAdmin() ||
                    $user->hasPermission('notifications.view_analytics');
         });
     }

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -8,7 +8,7 @@ return [
     'use' => 'default',
     'prefix' => env('HORIZON_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_horizon:'),
     
-    'middleware' => ['web', 'auth:api', 'authorize:notifications.view_analytics'],
+    'middleware' => ['web'],
     
     'waits' => [
         'redis_estimate_generation:estimate-generation' => 120,

--- a/tests/Feature/HorizonDashboardConfigurationTest.php
+++ b/tests/Feature/HorizonDashboardConfigurationTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\TestCase as LaravelTestCase;
+
+class HorizonDashboardConfigurationTest extends LaravelTestCase
+{
+    public function test_horizon_dashboard_uses_web_middleware_without_removed_api_guard(): void
+    {
+        $middleware = config('horizon.middleware');
+
+        $this->assertSame(['web'], $middleware);
+        $this->assertNotContains('auth:api', $middleware);
+        $this->assertNotContains('authorize:notifications.view_analytics', $middleware);
+    }
+}


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-7G / issue 271: http://5.129.220.32:8000/prohelper-backend/issues/271
- PROHELPER-BACKEND-7H / issue 272: http://5.129.220.32:8000/prohelper-backend/issues/272

## Root cause
Horizon dashboard route `/horizon/{view?}` used `config/horizon.php` middleware `auth:api`, but the project no longer defines an `api` auth guard. Current guards are explicit (`api_admin`, `api_landing`, `api_mobile`, etc.), so a `GET /horizon/dashboard` request failed with `InvalidArgumentException: Auth guard [api] is not defined` before Horizon could apply its normal dashboard authorization gate.

## What changed
- Removed the obsolete `auth:api` and API-oriented `authorize:notifications.view_analytics` middleware from Horizon routes, leaving the standard `web` middleware.
- Kept access control in `HorizonServiceProvider` through the existing `viewHorizon` gate.
- Hardened the gate for anonymous requests so Horizon returns a denial instead of a null-user fatal.
- Added a regression test for Horizon middleware configuration.

## Verification
- `php -l config\\horizon.php`
- `php -l app\\Providers\\HorizonServiceProvider.php`
- `php -l tests\\Feature\\HorizonDashboardConfigurationTest.php`

Could not run PHPUnit/phpstan in this local worktree because `vendor\\bin\\phpunit.bat` and `vendor\\bin\\phpstan.bat` are not present.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated Horizon authorization gate to handle null users explicitly.</li>
<li>Simplified Horizon middleware configuration by removing 'auth:api' and 'authorize:notifications.view_analytics', leaving only 'web'.</li>
<li>Added a new feature test to verify the Horizon dashboard middleware configuration.</li>
</ul></div>