### PR TITLE
fix: увеличен таймаут индексации RAG

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -15,6 +15,8 @@ class IndexRagSourceJob implements ShouldQueue
 {
     use Queueable;
 
+    private const MIN_TIMEOUT_SECONDS = 7200;
+
     public int $tries;
 
     public int $timeout;
@@ -30,7 +32,10 @@ class IndexRagSourceJob implements ShouldQueue
         $this->onConnection($this->connectionName());
         $this->onQueue($this->queueName());
         $this->tries = $this->configInt('ai-assistant.rag.job_tries', 3);
-        $this->timeout = $this->configInt('ai-assistant.rag.job_timeout', 1800);
+        $this->timeout = max(
+            self::MIN_TIMEOUT_SECONDS,
+            $this->configInt('ai-assistant.rag.job_timeout', self::MIN_TIMEOUT_SECONDS)
+        );
     }
 
     public function handle(RagIndexer $indexer, ?RagIndexingCoordinator $coordinator = null): void

--- a/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
+++ b/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
@@ -76,7 +76,7 @@ return [
         'queue_connection' => $configEnv('AI_RAG_QUEUE_CONNECTION', 'redis_ai_rag'),
         'queue' => $configEnv('AI_RAG_QUEUE', 'ai-rag'),
         'job_tries' => $configEnv('AI_RAG_JOB_TRIES', 3),
-        'job_timeout' => $configEnv('AI_RAG_JOB_TIMEOUT', 1800),
+        'job_timeout' => max(7200, (int) $configEnv('AI_RAG_JOB_TIMEOUT', 7200)),
         'scheduled_limit' => $configEnv('AI_RAG_SCHEDULED_LIMIT', 50),
         'stale_after_hours' => $configEnv('AI_RAG_STALE_AFTER_HOURS', 24),
         'failed_retry_after_hours' => $configEnv('AI_RAG_FAILED_RETRY_AFTER_HOURS', 12),

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -125,7 +125,7 @@ return [
                 'minProcesses' => 1,
                 'maxProcesses' => (int) env('AI_RAG_HORIZON_MAX_PROCESSES', 2),
                 'tries' => 3,
-                'timeout' => (int) env('AI_RAG_JOB_TIMEOUT', 1800),
+                'timeout' => max(7200, (int) env('AI_RAG_JOB_TIMEOUT', 7200)),
                 'memory' => 512,
                 'nice' => 5,
             ],
@@ -159,7 +159,7 @@ return [
                 'balance' => 'simple',
                 'processes' => 1,
                 'tries' => 3,
-                'timeout' => (int) env('AI_RAG_JOB_TIMEOUT', 1800),
+                'timeout' => max(7200, (int) env('AI_RAG_JOB_TIMEOUT', 7200)),
                 'memory' => 512,
             ],
             'supervisor-epm-data-mart' => [

--- a/config/queue.php
+++ b/config/queue.php
@@ -76,7 +76,10 @@ return [
             'driver' => 'redis',
             'connection' => env('AI_RAG_REDIS_QUEUE_CONNECTION', env('REDIS_QUEUE_CONNECTION', 'default')),
             'queue' => env('AI_RAG_QUEUE', 'ai-rag'),
-            'retry_after' => (int) env('AI_RAG_QUEUE_RETRY_AFTER', ((int) env('AI_RAG_JOB_TIMEOUT', 1800)) + 300),
+            'retry_after' => (int) env(
+                'AI_RAG_QUEUE_RETRY_AFTER',
+                max(7200, (int) env('AI_RAG_JOB_TIMEOUT', 7200)) + 300
+            ),
             'block_for' => null,
             'after_commit' => false,
         ],

--- a/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
+++ b/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
@@ -22,7 +22,7 @@ class IndexRagSourceJobTest extends TestCase
         $this->assertSame('redis_ai_rag', $job->connection);
         $this->assertSame('ai-rag', $job->queue);
         $this->assertSame(3, $job->tries);
-        $this->assertSame(1800, $job->timeout);
+        $this->assertSame(7200, $job->timeout);
         $this->assertTrue($job->failOnTimeout);
 
         $job->handle($indexer);


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-65 / issue 228: http://5.129.220.32:8000/prohelper-backend/issues/228
- PROHELPER-BACKEND-66 / issue 229: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause
Свежие события за 2026-06-14/2026-06-15 показывают `Illuminate\Queue\MaxAttemptsExceededException` для `IndexRagSourceJob` на `source_type=estimate`, `organization_id=39`, `project_id=null`, очередь `redis_ai_rag:ai-rag`, release `prohelper@548c3e1`.

Read-only production diagnostics:
- run `77090`: failed, `source_type=estimate`, `queued_at=2026-06-14 19:55:05+03`, `finished_at=2026-06-14 21:40:09+03`, `last_error=IndexRagSourceJob has been attempted too many times`
- run `76190`: аналогичный failed run за 2026-06-14
- организация 39 содержит 258 смет и 1707 разделов смет, все в проекте 53

Фактическая причина: дефолтный RAG timeout 1800 секунд слишком мал для production-sized scheduled индексации смет крупной организации. Job прерывается worker timeout, повторяется и доходит до MaxAttempts.

## Что изменено
- Введена нижняя граница `IndexRagSourceJob` timeout: 7200 секунд.
- Дефолт `ai-assistant.rag.job_timeout` поднят до 7200 секунд и защищён от меньшего env/config значения.
- Horizon supervisor `supervisor-ai-rag` использует тот же minimum timeout.
- Redis `redis_ai_rag.retry_after` оставлен больше timeout: минимум 7200 + 300 секунд, если не задан явный `AI_RAG_QUEUE_RETRY_AFTER`.
- Обновлён unit-тест `IndexRagSourceJobTest`.

## Проверки
- `php -l` для всех изменённых PHP-файлов
- `vendor/bin/phpunit tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php` — OK, 2 tests / 11 assertions
- `vendor/bin/phpstan analyse app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php app/BusinessModules/Features/AIAssistant/config/ai-assistant.php config/queue.php config/horizon.php --memory-limit=1G` — OK

## Примечание
Локально `composer install` потребовал Windows-only обход `--ignore-platform-req=ext-pcntl --ignore-platform-req=ext-posix` для Horizon, lock-файл не менялся.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Increased the minimum timeout for RAG indexing jobs to 7200 seconds (2 hours).</li>
<li>Updated configuration files (ai-assistant.php, horizon.php, queue.php) to enforce the new 7200-second minimum timeout for RAG jobs.</li>
<li>Updated the unit test for IndexRagSourceJob to reflect the increased timeout value.</li>
<li>Adjusted the queue retry_after calculation to account for the new minimum timeout.</li>
</ul></div>