### PR TITLE
fix: дробление плановой RAG-индексации по проектам

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Console/Commands/BackfillRagIndexCommand.php
+++ b/app/BusinessModules/Features/AIAssistant/Console/Commands/BackfillRagIndexCommand.php
@@ -205,19 +205,42 @@ class BackfillRagIndexCommand extends Command
         $queued = 0;
 
         foreach ($sourceRegistry->enabledSourceTypes() as $enabledSourceType) {
-            $result = $coordinator->queueAllActiveOrganizations(
-                (bool) $this->option('include-inactive'),
-                $this->nullableIntOption('limit'),
-                $projectId,
-                $enabledSourceType,
-                RagIndexRun::MODE_SCHEDULED,
-                $staleOnly,
-                $staleAfterHours
-            );
+            $result = $this->shouldQueueByProject($enabledSourceType, $projectId)
+                ? $coordinator->queueAllActiveOrganizationProjects(
+                    (bool) $this->option('include-inactive'),
+                    $this->nullableIntOption('limit'),
+                    $enabledSourceType,
+                    RagIndexRun::MODE_SCHEDULED,
+                    $staleOnly,
+                    $staleAfterHours
+                )
+                : $coordinator->queueAllActiveOrganizations(
+                    (bool) $this->option('include-inactive'),
+                    $this->nullableIntOption('limit'),
+                    $projectId,
+                    $enabledSourceType,
+                    RagIndexRun::MODE_SCHEDULED,
+                    $staleOnly,
+                    $staleAfterHours
+                );
 
             $queued += $result['queued'];
         }
 
         return ['queued' => $queued];
+    }
+
+    private function shouldQueueByProject(string $sourceType, ?int $projectId): bool
+    {
+        if ($projectId !== null) {
+            return false;
+        }
+
+        $sourceTypes = config('ai-assistant.rag.scheduled_project_scoped_source_types', ['estimate']);
+        if (! is_array($sourceTypes)) {
+            return false;
+        }
+
+        return in_array($sourceType, $sourceTypes, true);
     }
 }

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
@@ -9,6 +9,7 @@ use App\BusinessModules\Features\AIAssistant\Models\RagChunk;
 use App\BusinessModules\Features\AIAssistant\Models\RagIndexRun;
 use App\BusinessModules\Features\AIAssistant\Models\RagSource;
 use App\Models\Organization;
+use App\Models\Project;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Carbon;
@@ -67,6 +68,69 @@ class RagIndexingCoordinator
             'queued' => count($runIds),
             'run_ids' => $runIds,
             'organization_ids' => $organizationIds,
+        ];
+    }
+
+    /**
+     * @return array{queued: int, run_ids: array<int, int>, organization_ids: array<int, int>, project_ids: array<int, int>}
+     */
+    public function queueAllActiveOrganizationProjects(
+        bool $includeInactive = false,
+        ?int $limit = null,
+        string $sourceType = 'estimate',
+        string $mode = RagIndexRun::MODE_SCHEDULED,
+        bool $staleOnly = false,
+        ?int $staleAfterHours = null
+    ): array {
+        $organizations = $this->organizationsForBulkIndex(
+            $includeInactive,
+            $limit,
+            false,
+            null,
+            null,
+            $sourceType
+        );
+        $runIds = [];
+        $organizationIds = [];
+        $projectIds = [];
+        $freshCutoff = $staleOnly
+            ? now()->subHours(max(1, $staleAfterHours ?? (int) config('ai-assistant.rag.stale_after_hours', 24)))
+            : null;
+        $failedCutoff = $staleOnly
+            ? now()->subHours(max(1, (int) config('ai-assistant.rag.failed_retry_after_hours', 12)))
+            : null;
+
+        foreach ($organizations as $organization) {
+            foreach ($this->projectIdsForOrganization($organization->id) as $projectId) {
+                if (
+                    $staleOnly
+                    && (
+                        $this->hasActiveRun($organization->id, $projectId, $sourceType)
+                        || (
+                            $freshCutoff instanceof Carbon
+                            && $this->hasFreshSucceededRun($organization->id, $projectId, $sourceType, $freshCutoff)
+                        )
+                        || (
+                            $failedCutoff instanceof Carbon
+                            && $this->hasRecentFailedRun($organization->id, $projectId, $sourceType, $failedCutoff)
+                        )
+                    )
+                ) {
+                    continue;
+                }
+
+                $run = $this->queueOrganization($organization->id, $projectId, $sourceType, $mode);
+                $runIds[] = $run->id;
+                $organizationIds[] = $organization->id;
+                $projectIds[] = $projectId;
+            }
+        }
+
+        return [
+            'queued' => count($runIds),
+            'run_ids' => $runIds,
+            'organization_ids' => $organizationIds,
+            'project_ids' => $projectIds,
         ];
     }
 
@@ -401,6 +465,49 @@ class RagIndexingCoordinator
             ->exists();
     }
 
+    private function hasActiveRun(int $organizationId, ?int $projectId, ?string $sourceType): bool
+    {
+        $query = RagIndexRun::query()
+            ->where('organization_id', $organizationId)
+            ->whereIn('status', [
+                RagIndexRun::STATUS_QUEUED,
+                RagIndexRun::STATUS_RUNNING,
+            ]);
+
+        $this->applyActiveEloquentRunScope($query, $projectId, $sourceType);
+
+        return $query->exists();
+    }
+
+    private function hasFreshSucceededRun(
+        int $organizationId,
+        ?int $projectId,
+        ?string $sourceType,
+        Carbon $freshCutoff
+    ): bool {
+        $query = RagIndexRun::query()
+            ->where('organization_id', $organizationId)
+            ->where('status', RagIndexRun::STATUS_SUCCEEDED)
+            ->where('finished_at', '>', $freshCutoff->toDateTimeString());
+
+        $this->applyActiveEloquentRunScope($query, $projectId, $sourceType);
+
+        return $query->exists();
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function projectIdsForOrganization(int $organizationId): array
+    {
+        return Project::query()
+            ->where('organization_id', $organizationId)
+            ->orderBy('id')
+            ->pluck('id')
+            ->map(static fn (int|string $projectId): int => (int) $projectId)
+            ->all();
+    }
+
     private function applyActiveRunScope(
         QueryBuilder $query,
         string $runTable,
@@ -424,6 +531,29 @@ class RagIndexingCoordinator
                 $scopeQuery
                     ->where("{$runTable}.source_type", $sourceType)
                     ->orWhereNull("{$runTable}.source_type");
+            });
+        }
+    }
+
+    private function applyActiveEloquentRunScope(Builder $query, ?int $projectId, ?string $sourceType): void
+    {
+        if ($projectId === null) {
+            $query->whereNull('project_id');
+        } else {
+            $query->where(static function (Builder $scopeQuery) use ($projectId): void {
+                $scopeQuery
+                    ->where('project_id', $projectId)
+                    ->orWhereNull('project_id');
+            });
+        }
+
+        if ($sourceType === null) {
+            $query->whereNull('source_type');
+        } else {
+            $query->where(static function (Builder $scopeQuery) use ($sourceType): void {
+                $scopeQuery
+                    ->where('source_type', $sourceType)
+                    ->orWhereNull('source_type');
             });
         }
     }

--- a/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
+++ b/app/BusinessModules/Features/AIAssistant/config/ai-assistant.php
@@ -78,6 +78,10 @@ return [
         'job_tries' => $configEnv('AI_RAG_JOB_TRIES', 3),
         'job_timeout' => max(7200, (int) $configEnv('AI_RAG_JOB_TIMEOUT', 7200)),
         'scheduled_limit' => $configEnv('AI_RAG_SCHEDULED_LIMIT', 50),
+        'scheduled_project_scoped_source_types' => array_values(array_filter(array_map(
+            static fn (string $sourceType): string => trim($sourceType),
+            explode(',', (string) $configEnv('AI_RAG_SCHEDULED_PROJECT_SCOPED_SOURCE_TYPES', 'estimate'))
+        ))),
         'stale_after_hours' => $configEnv('AI_RAG_STALE_AFTER_HOURS', 24),
         'failed_retry_after_hours' => $configEnv('AI_RAG_FAILED_RETRY_AFTER_HOURS', 12),
         'max_chunks' => $configEnv('AI_RAG_MAX_CHUNKS', 8),

--- a/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
+++ b/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
@@ -19,6 +19,13 @@ use Tests\TestCase;
 
 class AIAssistantRagBackfillCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai-assistant.rag.scheduled_project_scoped_source_types' => []]);
+    }
+
     public function test_sync_backfill_calls_indexer_with_requested_scope(): void
     {
         $organization = Organization::factory()->create(['id' => 10]);
@@ -141,6 +148,50 @@ class AIAssistantRagBackfillCommandTest extends TestCase
         );
         $this->assertDatabaseCount('ai_rag_index_runs', $expectedJobs);
     }
+
+    public function test_all_backfill_can_queue_configured_source_types_by_project(): void
+    {
+        Queue::fake();
+        config(['ai-assistant.rag.scheduled_project_scoped_source_types' => ['estimate']]);
+
+        $first = Organization::factory()->create();
+        $second = Organization::factory()->create();
+        $firstProject = Project::factory()->create(['organization_id' => $first->id]);
+        $secondProject = Project::factory()->create(['organization_id' => $second->id]);
+        Project::factory()->create(['organization_id' => $second->id]);
+        $sourceTypes = $this->enabledSourceTypes();
+
+        $this->assertContains('estimate', $sourceTypes);
+
+        $expectedJobs = ((count($sourceTypes) - 1) * 2) + 3;
+
+        $this->artisan('ai-assistant:rag-backfill', [
+            '--all' => true,
+        ])
+            ->expectsOutput("Queued RAG indexing jobs: {$expectedJobs}")
+            ->assertExitCode(0);
+
+        Queue::assertPushed(IndexRagSourceJob::class, $expectedJobs);
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $first->id
+                && $job->projectId === $firstProject->id
+                && $job->sourceType === 'estimate'
+        );
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $second->id
+                && $job->projectId === $secondProject->id
+                && $job->sourceType === 'estimate'
+        );
+        Queue::assertNotPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->sourceType === 'estimate'
+                && $job->projectId === null
+        );
+        $this->assertDatabaseCount('ai_rag_index_runs', $expectedJobs);
+    }
+
 
     public function test_all_backfill_can_include_inactive_organizations(): void
     {


### PR DESCRIPTION
## GlitchTip
- Fixes `PROHELPER-BACKEND-65` / issue `228`: http://5.129.220.32:8000/prohelper-backend/issues/228
- Also covers paired issue `PROHELPER-BACKEND-66` / issue `229`: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause
- Scheduled `ai-assistant:rag-backfill --all --stale` already splits work by RAG source type, but heavy `estimate` indexing still ran as one organization-wide queue job.
- Fresh events on release `prohelper@5a8f37a` show `IndexRagSourceJob` still exceeding attempts for `organization_id=39`, `source_type=estimate`, `project_id=null`, queue `ai-rag`.

## Changes
- Added configurable `ai-assistant.rag.scheduled_project_scoped_source_types`, defaulting to `estimate`.
- Scheduled all-source backfill now queues configured heavy source types per project when no explicit `--project_id` is passed.
- Added coordinator guards so project-scoped runs skip active/fresh scopes but are not blocked by a recent failed organization-wide run.
- Added feature-test coverage for project-scoped scheduled queueing.

## Verification
- `php -l app\BusinessModules\Features\AIAssistant\Console\Commands\BackfillRagIndexCommand.php`
- `php -l app\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator.php`
- `php -l app\BusinessModules\Features\AIAssistant\config\ai-assistant.php`
- `php -l tests\Feature\Console\AIAssistantRagBackfillCommandTest.php`
- `vendor\bin\phpstan.bat analyse app\BusinessModules\Features\AIAssistant\Console\Commands\BackfillRagIndexCommand.php app\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator.php --memory-limit=1G`

## Test limitation
- `php artisan test tests\Feature\Console\AIAssistantRagBackfillCommandTest.php --filter=all_backfill` is currently blocked before assertions by an existing SQLite-incompatible CRM migration: `default '{}'::jsonb` in `crm_sources`.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added support for project-scoped RAG indexing for specific source types.</li>
<li>Introduced `queueAllActiveOrganizationProjects` to the `RagIndexingCoordinator` to handle project-level indexing.</li>
<li>Updated `BackfillRagIndexCommand` to conditionally use project-scoped indexing based on configuration.</li>
<li>Added `AI_RAG_SCHEDULED_PROJECT_SCOPED_SOURCE_TYPES` configuration to control which source types are indexed by project.</li>
<li>Added a feature test to verify project-scoped indexing behavior.</li>
</ul></div>