### PR TITLE
fix: дробление старых RAG-задач по проектам

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -47,6 +47,17 @@ class IndexRagSourceJob implements ShouldQueue
             }
         }
 
+        if (
+            $this->runId !== null
+            && $this->projectId === null
+            && $this->sourceType !== null
+            && ($coordinator ??= app(RagIndexingCoordinator::class))->shouldSplitOrganizationSourceByProjects($this->sourceType)
+        ) {
+            $coordinator->splitOrganizationSourceRunByProjects($this->runId, $this->organizationId, $this->sourceType);
+
+            return;
+        }
+
         $indexed = $indexer->indexOrganization($this->organizationId, $this->projectId, $this->sourceType);
 
         if ($this->runId !== null) {

--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\AIAssistant\Jobs;
 
+use App\BusinessModules\Features\AIAssistant\Models\RagIndexRun;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexer;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -40,15 +41,19 @@ class IndexRagSourceJob implements ShouldQueue
 
     public function handle(RagIndexer $indexer, ?RagIndexingCoordinator $coordinator = null): void
     {
+        $run = null;
+
         if ($this->runId !== null) {
             $coordinator ??= app(RagIndexingCoordinator::class);
-            if ($coordinator->markRunning($this->runId) === null) {
+            $run = $coordinator->markRunning($this->runId);
+            if (! $run instanceof RagIndexRun) {
                 return;
             }
         }
 
         if (
-            $this->runId !== null
+            $run instanceof RagIndexRun
+            && $run->mode === RagIndexRun::MODE_SCHEDULED
             && $this->projectId === null
             && $this->sourceType !== null
             && ($coordinator ??= app(RagIndexingCoordinator::class))->shouldSplitOrganizationSourceByProjects($this->sourceType)

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
@@ -189,6 +189,37 @@ class RagIndexingCoordinator
         return $run;
     }
 
+    public function shouldSplitOrganizationSourceByProjects(string $sourceType): bool
+    {
+        $sourceTypes = config('ai-assistant.rag.scheduled_project_scoped_source_types', ['estimate']);
+        if (! is_array($sourceTypes)) {
+            return false;
+        }
+
+        return in_array($sourceType, $sourceTypes, true);
+    }
+
+    public function splitOrganizationSourceRunByProjects(
+        int $runId,
+        int $organizationId,
+        string $sourceType
+    ): int {
+        $queued = 0;
+
+        foreach ($this->projectIdsForOrganization($organizationId) as $projectId) {
+            if ($this->hasExactActiveRun($organizationId, $projectId, $sourceType)) {
+                continue;
+            }
+
+            $this->queueOrganization($organizationId, $projectId, $sourceType, RagIndexRun::MODE_SCHEDULED);
+            $queued++;
+        }
+
+        $this->markSucceeded($runId, 0);
+
+        return $queued;
+    }
+
     public function indexOrganizationSync(
         int $organizationId,
         ?int $projectId = null,
@@ -493,6 +524,27 @@ class RagIndexingCoordinator
         $this->applyActiveEloquentRunScope($query, $projectId, $sourceType);
 
         return $query->exists();
+    }
+
+    private function hasExactActiveRun(int $organizationId, ?int $projectId, ?string $sourceType): bool
+    {
+        return RagIndexRun::query()
+            ->where('organization_id', $organizationId)
+            ->whereIn('status', [
+                RagIndexRun::STATUS_QUEUED,
+                RagIndexRun::STATUS_RUNNING,
+            ])
+            ->when(
+                $projectId === null,
+                static fn (Builder $query): Builder => $query->whereNull('project_id'),
+                static fn (Builder $query): Builder => $query->where('project_id', $projectId)
+            )
+            ->when(
+                $sourceType === null,
+                static fn (Builder $query): Builder => $query->whereNull('source_type'),
+                static fn (Builder $query): Builder => $query->where('source_type', $sourceType)
+            )
+            ->exists();
     }
 
     /**

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
@@ -205,9 +205,15 @@ class RagIndexingCoordinator
         string $sourceType
     ): int {
         $queued = 0;
+        $freshCutoff = now()->subHours(max(1, (int) config('ai-assistant.rag.stale_after_hours', 24)));
+        $failedCutoff = now()->subHours(max(1, (int) config('ai-assistant.rag.failed_retry_after_hours', 12)));
 
         foreach ($this->projectIdsForOrganization($organizationId) as $projectId) {
-            if ($this->hasExactActiveRun($organizationId, $projectId, $sourceType)) {
+            if (
+                $this->hasExactActiveRun($organizationId, $projectId, $sourceType)
+                || $this->hasFreshSucceededRun($organizationId, $projectId, $sourceType, $freshCutoff)
+                || $this->hasRecentFailedRun($organizationId, $projectId, $sourceType, $failedCutoff)
+            ) {
                 continue;
             }
 

--- a/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
+++ b/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
@@ -238,6 +238,110 @@ class AIAssistantRagBackfillCommandTest extends TestCase
         ]);
     }
 
+    public function test_legacy_org_wide_project_scoped_job_skips_fresh_and_recently_failed_projects(): void
+    {
+        Queue::fake();
+        config([
+            'ai-assistant.rag.scheduled_project_scoped_source_types' => ['estimate'],
+            'ai-assistant.rag.stale_after_hours' => 24,
+            'ai-assistant.rag.failed_retry_after_hours' => 12,
+        ]);
+
+        $organization = Organization::factory()->create();
+        $freshProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $failedProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $queuedProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $indexer = new BackfillCommandRecordingRagIndexer(7);
+        $this->app->instance(RagIndexer::class, $indexer);
+
+        RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $freshProject->id,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_SUCCEEDED,
+            'mode' => RagIndexRun::MODE_SCHEDULED,
+            'queued_at' => now()->subHours(2),
+            'started_at' => now()->subHours(2),
+            'finished_at' => now()->subHour(),
+            'indexed_chunks' => 1,
+        ]);
+
+        RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $failedProject->id,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_FAILED,
+            'mode' => RagIndexRun::MODE_SCHEDULED,
+            'queued_at' => now()->subMinutes(30),
+            'started_at' => now()->subMinutes(29),
+            'finished_at' => now()->subMinutes(28),
+            'indexed_chunks' => 0,
+        ]);
+
+        $run = RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => null,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_QUEUED,
+            'mode' => RagIndexRun::MODE_SCHEDULED,
+            'queued_at' => now()->subMinutes(5),
+        ]);
+
+        (new IndexRagSourceJob($organization->id, null, 'estimate', $run->id))->handle(
+            $indexer,
+            app(\App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator::class)
+        );
+
+        $this->assertSame([], $indexer->calls);
+        Queue::assertPushed(IndexRagSourceJob::class, 1);
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $queuedProject->id
+                && $job->sourceType === 'estimate'
+        );
+        Queue::assertNotPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && in_array($job->projectId, [$freshProject->id, $failedProject->id], true)
+                && $job->sourceType === 'estimate'
+        );
+    }
+
+    public function test_manual_org_wide_project_scoped_job_is_indexed_without_split(): void
+    {
+        Queue::fake();
+        config(['ai-assistant.rag.scheduled_project_scoped_source_types' => ['estimate']]);
+
+        $organization = Organization::factory()->create();
+        Project::factory()->count(2)->create(['organization_id' => $organization->id]);
+        $indexer = new BackfillCommandRecordingRagIndexer(7);
+        $this->app->instance(RagIndexer::class, $indexer);
+
+        $run = RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => null,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_QUEUED,
+            'mode' => RagIndexRun::MODE_MANUAL,
+            'queued_at' => now()->subMinutes(5),
+        ]);
+
+        (new IndexRagSourceJob($organization->id, null, 'estimate', $run->id))->handle(
+            $indexer,
+            app(\App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator::class)
+        );
+
+        Queue::assertNothingPushed();
+        $this->assertSame([[$organization->id, null, 'estimate']], $indexer->calls);
+        $this->assertDatabaseHas('ai_rag_index_runs', [
+            'id' => $run->id,
+            'status' => RagIndexRun::STATUS_SUCCEEDED,
+            'indexed_chunks' => 7,
+            'mode' => RagIndexRun::MODE_MANUAL,
+        ]);
+    }
+
     public function test_all_backfill_can_include_inactive_organizations(): void
     {
         Queue::fake();

--- a/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
+++ b/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
@@ -192,6 +192,52 @@ class AIAssistantRagBackfillCommandTest extends TestCase
         $this->assertDatabaseCount('ai_rag_index_runs', $expectedJobs);
     }
 
+    public function test_legacy_org_wide_project_scoped_job_is_requeued_by_project(): void
+    {
+        Queue::fake();
+        config(['ai-assistant.rag.scheduled_project_scoped_source_types' => ['estimate']]);
+
+        $organization = Organization::factory()->create();
+        $firstProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $secondProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $indexer = new BackfillCommandRecordingRagIndexer(7);
+        $this->app->instance(RagIndexer::class, $indexer);
+
+        $run = RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => null,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_QUEUED,
+            'mode' => RagIndexRun::MODE_SCHEDULED,
+            'queued_at' => now()->subMinutes(5),
+        ]);
+
+        (new IndexRagSourceJob($organization->id, null, 'estimate', $run->id))->handle(
+            $indexer,
+            app(\App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator::class)
+        );
+
+        $this->assertSame([], $indexer->calls);
+        Queue::assertPushed(IndexRagSourceJob::class, 2);
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $firstProject->id
+                && $job->sourceType === 'estimate'
+        );
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $secondProject->id
+                && $job->sourceType === 'estimate'
+        );
+        $this->assertDatabaseHas('ai_rag_index_runs', [
+            'id' => $run->id,
+            'status' => RagIndexRun::STATUS_SUCCEEDED,
+            'indexed_chunks' => 0,
+        ]);
+    }
+
     public function test_all_backfill_can_include_inactive_organizations(): void
     {
         Queue::fake();

--- a/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
+++ b/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
@@ -35,16 +35,12 @@ class IndexRagSourceJobTest extends TestCase
     {
         $job = new IndexRagSourceJob(10, 20, 'project', 30);
         $indexer = new RecordingRagIndexer();
-        $coordinator = $this->createMock(RagIndexingCoordinator::class);
-
-        $coordinator
-            ->expects($this->once())
-            ->method('markRunning')
-            ->with(30)
-            ->willReturn(null);
+        $coordinator = new TestRagIndexingCoordinator();
+        $coordinator->markRunningResult = null;
 
         $job->handle($indexer, $coordinator);
 
+        $this->assertSame([30], $coordinator->markRunningCalls);
         $this->assertSame([], $indexer->calls);
     }
 
@@ -52,29 +48,36 @@ class IndexRagSourceJobTest extends TestCase
     {
         $job = new IndexRagSourceJob(10, null, 'estimate', 30);
         $indexer = new RecordingRagIndexer();
-        $coordinator = $this->createMock(RagIndexingCoordinator::class);
-
-        $coordinator
-            ->expects($this->once())
-            ->method('markRunning')
-            ->with(30)
-            ->willReturn(new RagIndexRun());
-
-        $coordinator
-            ->expects($this->once())
-            ->method('shouldSplitOrganizationSourceByProjects')
-            ->with('estimate')
-            ->willReturn(true);
-
-        $coordinator
-            ->expects($this->once())
-            ->method('splitOrganizationSourceRunByProjects')
-            ->with(30, 10, 'estimate')
-            ->willReturn(2);
+        $coordinator = new TestRagIndexingCoordinator();
+        $run = new RagIndexRun();
+        $run->mode = RagIndexRun::MODE_SCHEDULED;
+        $coordinator->markRunningResult = $run;
+        $coordinator->shouldSplit = true;
 
         $job->handle($indexer, $coordinator);
 
+        $this->assertSame([30], $coordinator->markRunningCalls);
+        $this->assertSame(['estimate'], $coordinator->shouldSplitCalls);
+        $this->assertSame([[30, 10, 'estimate']], $coordinator->splitCalls);
         $this->assertSame([], $indexer->calls);
+    }
+
+    public function test_job_keeps_org_wide_manual_run_on_direct_indexing_path(): void
+    {
+        $job = new IndexRagSourceJob(10, null, 'estimate', 30);
+        $indexer = new RecordingRagIndexer();
+        $coordinator = new TestRagIndexingCoordinator();
+        $run = new RagIndexRun();
+        $run->mode = RagIndexRun::MODE_MANUAL;
+        $coordinator->markRunningResult = $run;
+        $coordinator->shouldSplit = true;
+
+        $job->handle($indexer, $coordinator);
+
+        $this->assertSame([30], $coordinator->markRunningCalls);
+        $this->assertSame([], $coordinator->splitCalls);
+        $this->assertSame([[30, 1]], $coordinator->markSucceededCalls);
+        $this->assertSame([[10, null, 'estimate']], $indexer->calls);
     }
 }
 
@@ -94,5 +97,60 @@ final class RecordingRagIndexer extends RagIndexer
         $this->calls[] = [$organizationId, $projectId, $sourceType];
 
         return 1;
+    }
+}
+
+final class TestRagIndexingCoordinator extends RagIndexingCoordinator
+{
+    public ?RagIndexRun $markRunningResult = null;
+
+    public bool $shouldSplit = false;
+
+    /** @var array<int, int> */
+    public array $markRunningCalls = [];
+
+    /** @var array<int, string> */
+    public array $shouldSplitCalls = [];
+
+    /** @var array<int, array{0: int, 1: int, 2: string}> */
+    public array $splitCalls = [];
+
+    /** @var array<int, array{0: int, 1: int}> */
+    public array $markSucceededCalls = [];
+
+    public function __construct()
+    {
+        parent::__construct(new RecordingRagIndexer());
+    }
+
+    public function markRunning(int $runId): ?RagIndexRun
+    {
+        $this->markRunningCalls[] = $runId;
+
+        return $this->markRunningResult;
+    }
+
+    public function shouldSplitOrganizationSourceByProjects(string $sourceType): bool
+    {
+        $this->shouldSplitCalls[] = $sourceType;
+
+        return $this->shouldSplit;
+    }
+
+    public function splitOrganizationSourceRunByProjects(
+        int $runId,
+        int $organizationId,
+        string $sourceType
+    ): int {
+        $this->splitCalls[] = [$runId, $organizationId, $sourceType];
+
+        return 1;
+    }
+
+    public function markSucceeded(int $runId, int $indexedChunks): ?RagIndexRun
+    {
+        $this->markSucceededCalls[] = [$runId, $indexedChunks];
+
+        return new RagIndexRun();
     }
 }

--- a/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
+++ b/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\AIAssistant\Rag;
 
 use App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob;
+use App\BusinessModules\Features\AIAssistant\Models\RagIndexRun;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexer;
 use PHPUnit\Framework\TestCase;
@@ -41,6 +42,35 @@ class IndexRagSourceJobTest extends TestCase
             ->method('markRunning')
             ->with(30)
             ->willReturn(null);
+
+        $job->handle($indexer, $coordinator);
+
+        $this->assertSame([], $indexer->calls);
+    }
+
+    public function test_legacy_org_wide_project_scoped_job_is_split_before_indexing(): void
+    {
+        $job = new IndexRagSourceJob(10, null, 'estimate', 30);
+        $indexer = new RecordingRagIndexer();
+        $coordinator = $this->createMock(RagIndexingCoordinator::class);
+
+        $coordinator
+            ->expects($this->once())
+            ->method('markRunning')
+            ->with(30)
+            ->willReturn(new RagIndexRun());
+
+        $coordinator
+            ->expects($this->once())
+            ->method('shouldSplitOrganizationSourceByProjects')
+            ->with('estimate')
+            ->willReturn(true);
+
+        $coordinator
+            ->expects($this->once())
+            ->method('splitOrganizationSourceRunByProjects')
+            ->with(30, 10, 'estimate')
+            ->willReturn(2);
 
         $job->handle($indexer, $coordinator);
 


### PR DESCRIPTION
## GlitchTip
- Исправляет PROHELPER-BACKEND-65 / issue 228: http://5.129.220.32:8000/prohelper-backend/issues/228
- Связанная grouped issue PROHELPER-BACKEND-66 / issue 229: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause
После дробления плановой RAG-индексации по проектам в очереди оставались старые org-wide задачи `IndexRagSourceJob` с `source_type=estimate` и `project_id=null`. Horizon продолжал брать их из `redis_ai_rag`, они индексировали тяжелый estimate scope всей организации и доходили до `MaxAttemptsExceededException`.

## Что изменено
- `IndexRagSourceJob` перед тяжелой индексацией проверяет org-wide source scope, который должен выполняться по проектам.
- `RagIndexingCoordinator` раскладывает такой run на project-scoped scheduled jobs и помечает исходный run успешным без запуска org-wide индексатора.
- Добавлены unit/feature проверки для legacy payload.

## Проверки
- `php -l app\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob.php`
- `php -l app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\RagIndexingCoordinator.php`
- `php -l tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php`
- `php -l tests\\Unit\\AIAssistant\\Rag\\IndexRagSourceJobTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\AIAssistant\\Rag\\IndexRagSourceJobTest.php`
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob.php app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\RagIndexingCoordinator.php tests\\Unit\\AIAssistant\\Rag\\IndexRagSourceJobTest.php --memory-limit=1G`
- `vendor\\bin\\phpstan.bat analyse tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php --memory-limit=1G`

## Не выполнено
- `vendor\\bin\\phpunit.bat tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php --filter=legacy_org_wide_project_scoped_job_is_requeued_by_project` не дошел до assertions: локальная SQLite test DB падает на существующей CRM migration `default '{}'::jsonb` в `crm_sources`.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented logic in IndexRagSourceJob to split organization-wide RAG indexing jobs into project-specific jobs for configured source types.</li>
<li>Added helper methods to RagIndexingCoordinator to identify project-scoped source types and manage the splitting of indexing runs.</li>
<li>Added a check to prevent duplicate active indexing runs when splitting jobs.</li>
<li>Added feature and unit tests to verify the job splitting behavior and ensure legacy org-wide jobs are correctly requeued by project.</li>
</ul></div>