### PR TITLE
fix: дробление старых RAG-задач по проектам

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -47,6 +47,17 @@ class IndexRagSourceJob implements ShouldQueue
             }
         }
 
+        if (
+            $this->runId !== null
+            && $this->projectId === null
+            && $this->sourceType !== null
+            && ($coordinator ??= app(RagIndexingCoordinator::class))->shouldSplitOrganizationSourceByProjects($this->sourceType)
+        ) {
+            $coordinator->splitOrganizationSourceRunByProjects($this->runId, $this->organizationId, $this->sourceType);
+
+            return;
+        }
+
         $indexed = $indexer->indexOrganization($this->organizationId, $this->projectId, $this->sourceType);
 
         if ($this->runId !== null) {

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
@@ -189,6 +189,37 @@ class RagIndexingCoordinator
         return $run;
     }
 
+    public function shouldSplitOrganizationSourceByProjects(string $sourceType): bool
+    {
+        $sourceTypes = config('ai-assistant.rag.scheduled_project_scoped_source_types', ['estimate']);
+        if (! is_array($sourceTypes)) {
+            return false;
+        }
+
+        return in_array($sourceType, $sourceTypes, true);
+    }
+
+    public function splitOrganizationSourceRunByProjects(
+        int $runId,
+        int $organizationId,
+        string $sourceType
+    ): int {
+        $queued = 0;
+
+        foreach ($this->projectIdsForOrganization($organizationId) as $projectId) {
+            if ($this->hasExactActiveRun($organizationId, $projectId, $sourceType)) {
+                continue;
+            }
+
+            $this->queueOrganization($organizationId, $projectId, $sourceType, RagIndexRun::MODE_SCHEDULED);
+            $queued++;
+        }
+
+        $this->markSucceeded($runId, 0);
+
+        return $queued;
+    }
+
     public function indexOrganizationSync(
         int $organizationId,
         ?int $projectId = null,
@@ -493,6 +524,27 @@ class RagIndexingCoordinator
         $this->applyActiveEloquentRunScope($query, $projectId, $sourceType);
 
         return $query->exists();
+    }
+
+    private function hasExactActiveRun(int $organizationId, ?int $projectId, ?string $sourceType): bool
+    {
+        return RagIndexRun::query()
+            ->where('organization_id', $organizationId)
+            ->whereIn('status', [
+                RagIndexRun::STATUS_QUEUED,
+                RagIndexRun::STATUS_RUNNING,
+            ])
+            ->when(
+                $projectId === null,
+                static fn (Builder $query): Builder => $query->whereNull('project_id'),
+                static fn (Builder $query): Builder => $query->where('project_id', $projectId)
+            )
+            ->when(
+                $sourceType === null,
+                static fn (Builder $query): Builder => $query->whereNull('source_type'),
+                static fn (Builder $query): Builder => $query->where('source_type', $sourceType)
+            )
+            ->exists();
     }
 
     /**

--- a/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
+++ b/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
@@ -192,6 +192,52 @@ class AIAssistantRagBackfillCommandTest extends TestCase
         $this->assertDatabaseCount('ai_rag_index_runs', $expectedJobs);
     }
 
+    public function test_legacy_org_wide_project_scoped_job_is_requeued_by_project(): void
+    {
+        Queue::fake();
+        config(['ai-assistant.rag.scheduled_project_scoped_source_types' => ['estimate']]);
+
+        $organization = Organization::factory()->create();
+        $firstProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $secondProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $indexer = new BackfillCommandRecordingRagIndexer(7);
+        $this->app->instance(RagIndexer::class, $indexer);
+
+        $run = RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => null,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_QUEUED,
+            'mode' => RagIndexRun::MODE_SCHEDULED,
+            'queued_at' => now()->subMinutes(5),
+        ]);
+
+        (new IndexRagSourceJob($organization->id, null, 'estimate', $run->id))->handle(
+            $indexer,
+            app(\App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator::class)
+        );
+
+        $this->assertSame([], $indexer->calls);
+        Queue::assertPushed(IndexRagSourceJob::class, 2);
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $firstProject->id
+                && $job->sourceType === 'estimate'
+        );
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $secondProject->id
+                && $job->sourceType === 'estimate'
+        );
+        $this->assertDatabaseHas('ai_rag_index_runs', [
+            'id' => $run->id,
+            'status' => RagIndexRun::STATUS_SUCCEEDED,
+            'indexed_chunks' => 0,
+        ]);
+    }
+
     public function test_all_backfill_can_include_inactive_organizations(): void
     {
         Queue::fake();

--- a/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
+++ b/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\AIAssistant\Rag;
 
 use App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob;
+use App\BusinessModules\Features\AIAssistant\Models\RagIndexRun;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexer;
 use PHPUnit\Framework\TestCase;
@@ -41,6 +42,35 @@ class IndexRagSourceJobTest extends TestCase
             ->method('markRunning')
             ->with(30)
             ->willReturn(null);
+
+        $job->handle($indexer, $coordinator);
+
+        $this->assertSame([], $indexer->calls);
+    }
+
+    public function test_legacy_org_wide_project_scoped_job_is_split_before_indexing(): void
+    {
+        $job = new IndexRagSourceJob(10, null, 'estimate', 30);
+        $indexer = new RecordingRagIndexer();
+        $coordinator = $this->createMock(RagIndexingCoordinator::class);
+
+        $coordinator
+            ->expects($this->once())
+            ->method('markRunning')
+            ->with(30)
+            ->willReturn(new RagIndexRun());
+
+        $coordinator
+            ->expects($this->once())
+            ->method('shouldSplitOrganizationSourceByProjects')
+            ->with('estimate')
+            ->willReturn(true);
+
+        $coordinator
+            ->expects($this->once())
+            ->method('splitOrganizationSourceRunByProjects')
+            ->with(30, 10, 'estimate')
+            ->willReturn(2);
 
         $job->handle($indexer, $coordinator);
 


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-65 / issue 228: Illuminate\Queue\MaxAttemptsExceededException for App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob
- PROHELPER-BACKEND-66 / issue 229: IndexRagSourceJob has been attempted too many times
- Links: http://5.129.220.32:8000/prohelper-backend/issues/228, http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause
Fresh unresolved GlitchTip aggregate still points to organization-wide RAG jobs with source_type=estimate and project_id=null. Scheduled --all flow already splits configured heavy source types by project, but old queued jobs or manual reindex requests can still reach the worker as a single organization-wide estimate job. That job can exceed Laravel queue attempts/timeouts before completing.

## What changed
- IndexRagSourceJob now detects organization-wide jobs for project-scoped source types before indexing.
- RagIndexingCoordinator requeues such runs as project-scoped scheduled jobs and marks the original run succeeded with zero indexed chunks.
- Duplicate active project-scoped jobs are skipped.
- Added unit and feature coverage for the legacy org-wide estimate job split.

## Verification
- php -l for changed PHP files: OK
- vendor\\bin\\phpunit.bat tests\\Unit\\AIAssistant\\Rag\\IndexRagSourceJobTest.php: OK, 3 tests / 13 assertions
- vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob.php app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\RagIndexingCoordinator.php --memory-limit=1G: OK
- vendor\\bin\\phpunit.bat tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php --filter=legacy_org_wide_project_scoped_job_is_requeued_by_project: blocked by existing SQLite-incompatible CRM migration default '{}'::jsonb before assertions

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented logic in IndexRagSourceJob to split organization-wide RAG indexing jobs into project-specific jobs for configured source types.</li>
<li>Added helper methods to RagIndexingCoordinator to identify project-scoped source types and manage the splitting of indexing runs.</li>
<li>Added a check to prevent duplicate active indexing runs when splitting jobs.</li>
<li>Added feature and unit tests to verify the job splitting functionality and ensure legacy org-wide jobs are correctly requeued.</li>
</ul></div>