### PR TITLE
fix: дробление старых RAG-задач при исчерпании попыток

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\AIAssistant\Jobs;
 
 use App\BusinessModules\Features\AIAssistant\Models\RagIndexRun;
-use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexer;
+use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
@@ -75,7 +75,21 @@ class IndexRagSourceJob implements ShouldQueue
     {
         if ($this->runId !== null) {
             try {
-                app(RagIndexingCoordinator::class)->markFailed($this->runId, $throwable);
+                $coordinator = app(RagIndexingCoordinator::class);
+
+                if ($coordinator->splitScheduledOrganizationSourceRunByProjectsIfNeeded($this->runId)) {
+                    Log::warning('ai_assistant.rag.index_job_split_after_max_attempts', [
+                        'organization_id' => $this->organizationId,
+                        'project_id' => $this->projectId,
+                        'source_type' => $this->sourceType,
+                        'run_id' => $this->runId,
+                        'exception_class' => $throwable::class,
+                    ]);
+
+                    return;
+                }
+
+                $coordinator->markFailed($this->runId, $throwable);
             } catch (Throwable $statusThrowable) {
                 Log::warning('ai_assistant.rag.index_run_status_failed', [
                     'run_id' => $this->runId,

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
@@ -22,8 +22,7 @@ class RagIndexingCoordinator
 {
     public function __construct(
         private readonly RagIndexer $indexer
-    ) {
-    }
+    ) {}
 
     /**
      * @return array{queued: int, run_ids: array<int, int>, organization_ids: array<int, int>}
@@ -226,6 +225,27 @@ class RagIndexingCoordinator
         return $queued;
     }
 
+    public function splitScheduledOrganizationSourceRunByProjectsIfNeeded(int $runId): bool
+    {
+        $run = $this->findRun($runId);
+        if (! $run instanceof RagIndexRun) {
+            return false;
+        }
+
+        if (
+            $run->mode !== RagIndexRun::MODE_SCHEDULED
+            || $run->project_id !== null
+            || ! is_string($run->source_type)
+            || ! $this->shouldSplitOrganizationSourceByProjects($run->source_type)
+        ) {
+            return false;
+        }
+
+        $this->splitOrganizationSourceRunByProjects($run->id, $run->organization_id, $run->source_type);
+
+        return true;
+    }
+
     public function indexOrganizationSync(
         int $organizationId,
         ?int $projectId = null,
@@ -372,8 +392,7 @@ class RagIndexingCoordinator
         ?int $staleAfterHours = null,
         ?int $projectId = null,
         ?string $sourceType = null
-    ): Collection
-    {
+    ): Collection {
         $query = Organization::query()
             ->select(['id'])
             ->when(! $includeInactive, static fn (Builder $query): Builder => $query->where('is_active', true));
@@ -401,8 +420,8 @@ class RagIndexingCoordinator
         ?int $projectId,
         ?string $sourceType
     ): void {
-        $organizationTable = (new Organization())->getTable();
-        $runTable = (new RagIndexRun())->getTable();
+        $organizationTable = (new Organization)->getTable();
+        $runTable = (new RagIndexRun)->getTable();
 
         $query
             ->whereNotExists(function (QueryBuilder $subQuery) use (
@@ -618,8 +637,8 @@ class RagIndexingCoordinator
 
     private function orderByOldestRagAttempt(Builder $query): void
     {
-        $organizationTable = (new Organization())->getTable();
-        $runTable = (new RagIndexRun())->getTable();
+        $organizationTable = (new Organization)->getTable();
+        $runTable = (new RagIndexRun)->getTable();
         $latestAttemptSql = sprintf(
             '(select max(%s.created_at) from %s where %s.organization_id = %s.id)',
             $runTable,

--- a/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
+++ b/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexer;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagSourceRegistry;
 use App\Models\Organization;
 use App\Models\Project;
+use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
@@ -306,6 +307,47 @@ class AIAssistantRagBackfillCommandTest extends TestCase
                 && in_array($job->projectId, [$freshProject->id, $failedProject->id], true)
                 && $job->sourceType === 'estimate'
         );
+    }
+
+    public function test_legacy_org_wide_project_scoped_job_is_requeued_when_attempts_are_exceeded_before_handle(): void
+    {
+        Queue::fake();
+        config(['ai-assistant.rag.scheduled_project_scoped_source_types' => ['estimate']]);
+
+        $organization = Organization::factory()->create();
+        $firstProject = Project::factory()->create(['organization_id' => $organization->id]);
+        $secondProject = Project::factory()->create(['organization_id' => $organization->id]);
+
+        $run = RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => null,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_QUEUED,
+            'mode' => RagIndexRun::MODE_SCHEDULED,
+            'queued_at' => now()->subHours(2),
+        ]);
+
+        (new IndexRagSourceJob($organization->id, null, 'estimate', $run->id))
+            ->failed(new MaxAttemptsExceededException('RAG job exceeded attempts.'));
+
+        Queue::assertPushed(IndexRagSourceJob::class, 2);
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $firstProject->id
+                && $job->sourceType === 'estimate'
+        );
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $secondProject->id
+                && $job->sourceType === 'estimate'
+        );
+        $this->assertDatabaseHas('ai_rag_index_runs', [
+            'id' => $run->id,
+            'status' => RagIndexRun::STATUS_SUCCEEDED,
+            'indexed_chunks' => 0,
+        ]);
     }
 
     public function test_manual_org_wide_project_scoped_job_is_indexed_without_split(): void
@@ -643,8 +685,7 @@ class AIAssistantRagBackfillCommandTest extends TestCase
         string $status,
         ?Carbon $finishedAt = null,
         ?string $sourceType = null
-    ): RagIndexRun
-    {
+    ): RagIndexRun {
         $startedAt = $finishedAt instanceof Carbon
             ? $finishedAt->copy()->subMinute()
             : now()->subMinute();
@@ -685,8 +726,7 @@ final class BackfillCommandRecordingRagIndexer extends RagIndexer
     public function __construct(
         private readonly int $indexedCount,
         private readonly mixed $afterIndex = null
-    ) {
-    }
+    ) {}
 
     public function indexOrganization(int $organizationId, ?int $projectId = null, ?string $sourceType = null): int
     {


### PR DESCRIPTION
## GlitchTip issues

- PROHELPER-BACKEND-65 / issue 228: http://5.129.220.32:8000/prohelper-backend/issues/228
- PROHELPER-BACKEND-66 / issue 229: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause

Старые scheduled org-wide RAG jobs для `source_type=estimate` могли уже иметь исчерпанный лимит попыток. Laravel выбрасывает `MaxAttemptsExceededException` до вызова `handle()`, поэтому split, добавленный в `handle()`, не успевал перевести legacy run в project-scoped jobs.

## Что изменено

- `IndexRagSourceJob::failed()` теперь перед обычным `markFailed()` проверяет, можно ли split-нуть scheduled org-wide project-scoped run.
- `RagIndexingCoordinator` получил guard-метод для безопасного split только для scheduled runs без `project_id` и с source type из `scheduled_project_scoped_source_types`.
- Добавлен регрессионный тест на сценарий `MaxAttemptsExceededException` до `handle()`.

## Проверки

- `php -l` по изменённым PHP-файлам: OK.
- `vendor/bin/phpstan analyse` по `IndexRagSourceJob.php` и `RagIndexingCoordinator.php`: OK.
- `vendor/bin/pint` по изменённым файлам: OK.
- `phpunit tests/Feature/Console/AIAssistantRagBackfillCommandTest.php --filter=attempts_are_exceeded_before_handle`: заблокирован существующей SQLite-несовместимой CRM migration `default '{}'::jsonb` в `crm_sources`, до assertions.

## Дополнительно

Свежие Redis timeout issues PROHELPER-BACKEND-2N/4O проверены, но не исправлялись: detail/events содержат только vendor Predis stack без in-app frames и выглядят как инфраструктурная доступность Redis.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented a fallback mechanism in IndexRagSourceJob to split failed organization-wide RAG indexing jobs into project-specific jobs if max attempts are exceeded.</li>
<li>Added splitScheduledOrganizationSourceRunByProjectsIfNeeded method to RagIndexingCoordinator to handle the logic for splitting scheduled runs.</li>
<li>Refactored several methods in RagIndexingCoordinator to use cleaner constructor and method syntax.</li>
<li>Added a new feature test case to verify that legacy org-wide jobs are correctly split and requeued upon failure.</li>
</ul></div>