### PR TITLE
fix: стабилизирована RAG-индексация смет

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/Sources/EstimateRagSource.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/Sources/EstimateRagSource.php
@@ -97,9 +97,7 @@ final class EstimateRagSource implements RagSourceCollectorInterface
             ->values()
             ->all();
 
-        $items = $estimate->items
-            ->sortByDesc(fn (EstimateItem $item): float => (float) ($item->current_total_amount ?? $item->total_amount ?? 0))
-            ->take(8)
+        $items = $this->topItemsByAmount($estimate->items, 8)
             ->map(fn (EstimateItem $item): string => trim(sprintf(
                 '%s %s %s %s x %s = %s',
                 $this->stringValue($item->position_number),
@@ -152,9 +150,7 @@ final class EstimateRagSource implements RagSourceCollectorInterface
     private function sectionChunk(Estimate $estimate, EstimateSection $section): RagChunkData
     {
         $sectionItems = $this->sectionItems($estimate, $section);
-        $items = $sectionItems
-            ->sortByDesc(fn (EstimateItem $item): float => $this->itemAmount($item))
-            ->take(self::SECTION_ITEMS_LIMIT)
+        $items = $this->topItemsByAmount($sectionItems, self::SECTION_ITEMS_LIMIT)
             ->map(fn (EstimateItem $item): string => $this->itemLine($item))
             ->filter()
             ->values()
@@ -209,7 +205,14 @@ final class EstimateRagSource implements RagSourceCollectorInterface
         return [
             'project',
             'contract',
+            'sections' => static fn ($query) => $query
+                ->orderBy('sort_order')
+                ->orderBy('section_number')
+                ->orderBy('id'),
             'sections.parent',
+            'items' => static fn ($query) => $query
+                ->orderBy('position_number')
+                ->orderBy('id'),
             'items.section',
             'items.workType',
             'items.measurementUnit',
@@ -225,7 +228,14 @@ final class EstimateRagSource implements RagSourceCollectorInterface
     private function sectionRelations(): array
     {
         return [
+            'estimate.sections' => static fn ($query) => $query
+                ->orderBy('sort_order')
+                ->orderBy('section_number')
+                ->orderBy('id'),
             'estimate.sections.parent',
+            'estimate.items' => static fn ($query) => $query
+                ->orderBy('position_number')
+                ->orderBy('id'),
             'estimate.items.section',
             'estimate.items.workType',
             'estimate.items.measurementUnit',
@@ -235,6 +245,9 @@ final class EstimateRagSource implements RagSourceCollectorInterface
             'estimate.project',
             'estimate.contract',
             'parent',
+            'items' => static fn ($query) => $query
+                ->orderBy('position_number')
+                ->orderBy('id'),
             'items.workType',
             'items.measurementUnit',
             'items.normativeRate',
@@ -326,6 +339,24 @@ final class EstimateRagSource implements RagSourceCollectorInterface
     private function sectionItemsTotal(Collection $items): float
     {
         return (float) $items->sum(fn (EstimateItem $item): float => $this->itemAmount($item));
+    }
+
+    /**
+     * @param  Collection<int, EstimateItem>  $items
+     * @return Collection<int, EstimateItem>
+     */
+    private function topItemsByAmount(Collection $items, int $limit): Collection
+    {
+        return $items
+            ->sort(function (EstimateItem $left, EstimateItem $right): int {
+                $amountComparison = $this->itemAmount($right) <=> $this->itemAmount($left);
+
+                return $amountComparison !== 0
+                    ? $amountComparison
+                    : ((int) $left->id <=> (int) $right->id);
+            })
+            ->take($limit)
+            ->values();
     }
 
     private function itemAmount(EstimateItem $item): float

--- a/tests/Unit/AIAssistant/Rag/EstimateRagSourceOrderingTest.php
+++ b/tests/Unit/AIAssistant/Rag/EstimateRagSourceOrderingTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AIAssistant\Rag;
+
+use App\BusinessModules\Features\AIAssistant\DTOs\Rag\RagChunkData;
+use App\BusinessModules\Features\AIAssistant\Services\Rag\Sources\EstimateRagSource;
+use App\Models\Contract;
+use App\Models\Estimate;
+use App\Models\EstimateItem;
+use App\Models\EstimateSection;
+use App\Models\MeasurementUnit;
+use App\Models\Project;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class EstimateRagSourceOrderingTest extends TestCase
+{
+    public function test_equal_amount_items_are_ordered_by_id_for_stable_checksum(): void
+    {
+        $source = new EstimateRagSource();
+        $chunkMethod = new ReflectionMethod($source, 'chunk');
+        $chunkMethod->setAccessible(true);
+
+        $chunk = $chunkMethod->invoke($source, $this->estimateWithItemsInUnstableOrder());
+
+        $this->assertInstanceOf(RagChunkData::class, $chunk);
+        $this->assertLessThan(
+            strpos($chunk->content, 'Equal amount later item'),
+            strpos($chunk->content, 'Equal amount earlier item')
+        );
+    }
+
+    private function estimateWithItemsInUnstableOrder(): Estimate
+    {
+        $estimate = new Estimate([
+            'id' => 101,
+            'organization_id' => 10,
+            'project_id' => 20,
+            'contract_id' => 30,
+            'number' => 'EST-101',
+            'name' => 'Stable estimate',
+            'status' => 'approved',
+            'type' => 'local',
+            'total_amount' => 200000,
+            'total_amount_with_vat' => 240000,
+        ]);
+
+        $estimate->setRelation('project', new Project(['id' => 20, 'name' => 'Stable project']));
+        $estimate->setRelation('contract', new Contract(['id' => 30, 'number' => 'CTR-30']));
+        $estimate->setRelation('sections', new Collection([
+            new EstimateSection([
+                'id' => 501,
+                'estimate_id' => 101,
+                'section_number' => '1',
+                'name' => 'Main section',
+                'section_total_amount' => 200000,
+            ]),
+        ]));
+
+        $unit = new MeasurementUnit(['id' => 40, 'name' => 'm3']);
+
+        $laterItem = new EstimateItem([
+            'estimate_id' => 101,
+            'estimate_section_id' => 501,
+            'position_number' => '0-A',
+            'name' => 'Equal amount later item',
+            'normative_rate_code' => 'RATE-LATER',
+            'quantity' => 20,
+            'quantity_total' => 20,
+            'current_total_amount' => 100000,
+        ]);
+        $laterItem->setAttribute('id', 702);
+        $laterItem->setRelation('measurementUnit', $unit);
+
+        $earlierItem = new EstimateItem([
+            'estimate_id' => 101,
+            'estimate_section_id' => 501,
+            'position_number' => '1-A',
+            'name' => 'Equal amount earlier item',
+            'normative_rate_code' => 'RATE-EARLIER',
+            'quantity' => 20,
+            'quantity_total' => 20,
+            'current_total_amount' => 100000,
+        ]);
+        $earlierItem->setAttribute('id', 701);
+        $earlierItem->setRelation('measurementUnit', $unit);
+
+        $estimate->setRelation('items', new Collection([$laterItem, $earlierItem]));
+
+        return $estimate;
+    }
+}


### PR DESCRIPTION
## GlitchTip

Исправляет свежие unresolved группы:
- PROHELPER-BACKEND-65 / issue 228: http://5.129.220.32:8000/prohelper-backend/issues/228
- PROHELPER-BACKEND-66 / issue 229: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause

После предыдущего дробления org-wide RAG задач ошибка продолжилась на project-scoped scheduled run: production read-only диагностика показала повторные `MaxAttemptsExceededException` для `organization_id=39`, `project_id=53`, `source_type=estimate`. Проект крупный: 258 смет, 1707 разделов, 168735 позиций.

`EstimateRagSource` строил checksum для RAG источников из связанных `sections/items`, но порядок eager-loaded связей и порядок позиций с одинаковой суммой не был полностью детерминирован. Из-за этого уже обработанные источники могли получать новый checksum между запусками, повторно уходить в embedding и не давать долгому scheduled job продвигаться до завершения.

## Что изменено

- Добавлен стабильный order для eager-loaded `sections` и `items` в estimate collector.
- Выбор топ-позиций по сумме теперь имеет tie-break по `id`.
- Добавлен чистый unit-тест без БД на стабильный порядок позиций с одинаковой суммой.

## Проверки

- `php -l app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\Sources\\EstimateRagSource.php`
- `php -l tests\\Unit\\AIAssistant\\Rag\\EstimateRagSourceOrderingTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\AIAssistant\\Rag\\EstimateRagSourceOrderingTest.php`
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\Sources\\EstimateRagSource.php tests\\Unit\\AIAssistant\\Rag\\EstimateRagSourceOrderingTest.php --memory-limit=1G`

DB-зависимый `RagSourceCollectorsTest` локально не проходит до assertions из-за существующей SQLite-несовместимой CRM migration `default '{}'::jsonb` в `crm_sources`.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored item sorting logic in EstimateRagSource to ensure stable ordering by amount and ID.</li>
<li>Introduced a private topItemsByAmount method to centralize and standardize item selection.</li>
<li>Updated estimate and section relationship queries to enforce consistent sorting by sort order, number, and ID.</li>
<li>Added a new unit test to verify that items with equal amounts are consistently ordered by ID.</li>
</ul></div>