### PR TITLE
fix: отфильтрован восстановленный сбой RAG-индексации

### DIFF
--- a/app/Services/Monitoring/GlitchTipReportPolicy.php
+++ b/app/Services/Monitoring/GlitchTipReportPolicy.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Services\Monitoring;
 
 use App\Exceptions\BusinessLogicException;
+use App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob;
 use App\Support\LivewirePayloadExceptionClassifier;
 use Illuminate\Http\Request;
+use Illuminate\Queue\MaxAttemptsExceededException;
 use Predis\Connection\ConnectionException as PredisConnectionException;
 use Sentry\Severity;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -30,6 +32,10 @@ class GlitchTipReportPolicy
         }
 
         if ($this->isTransientQueueWorkerRedisError($exception, $request)) {
+            return false;
+        }
+
+        if ($this->isRecoverableRagOrganizationEstimateMaxAttempts($exception)) {
             return false;
         }
 
@@ -134,6 +140,42 @@ class GlitchTipReportPolicy
         return $request === null
             && $exception instanceof PredisConnectionException
             && str_contains($exception->getMessage(), 'Stream is already at the end');
+    }
+
+    private function isRecoverableRagOrganizationEstimateMaxAttempts(Throwable $exception): bool
+    {
+        if (! $exception instanceof MaxAttemptsExceededException) {
+            return false;
+        }
+
+        $payload = $this->queueJobPayload($exception);
+        $commandName = $payload['data']['commandName'] ?? null;
+        $command = $payload['data']['command'] ?? null;
+
+        if ($commandName !== IndexRagSourceJob::class || ! is_string($command)) {
+            return false;
+        }
+
+        return str_contains($command, 's:9:"projectId";N;')
+            && str_contains($command, 's:10:"sourceType";s:8:"estimate";')
+            && str_contains($command, 's:5:"runId";i:');
+    }
+
+    private function queueJobPayload(MaxAttemptsExceededException $exception): array
+    {
+        $job = $exception->job;
+
+        if (! is_object($job) || ! method_exists($job, 'payload')) {
+            return [];
+        }
+
+        try {
+            $payload = $job->payload();
+        } catch (Throwable) {
+            return [];
+        }
+
+        return is_array($payload) ? $payload : [];
     }
 
     private function matchesConfiguredException(Throwable $exception, array $classes): bool

--- a/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
+++ b/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
@@ -9,6 +9,7 @@ use App\Exceptions\AI\AIParsingException;
 use App\Exceptions\AI\AIQuotaExceededException;
 use App\Exceptions\Billing\InsufficientBalanceException;
 use App\Exceptions\BusinessLogicException;
+use App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob;
 use App\Services\Monitoring\GlitchTipReportPolicy;
 use Filament\Actions\Exceptions\ActionNotResolvableException;
 use Illuminate\Auth\AuthenticationException;
@@ -17,6 +18,7 @@ use Illuminate\Database\QueryException;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\Request;
+use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use PDOException;
@@ -111,6 +113,36 @@ class GlitchTipReportPolicyTest extends TestCase
 
         self::assertFalse($policy->shouldCapture($exception));
         self::assertTrue($policy->shouldCapture($exception, Request::create('/api/v1/admin/dashboard', 'GET')));
+    }
+
+    public function test_skips_recoverable_org_wide_rag_estimate_max_attempts(): void
+    {
+        $policy = new GlitchTipReportPolicy($this->config());
+        $exception = new MaxAttemptsExceededException(
+            IndexRagSourceJob::class.' has been attempted too many times.'
+        );
+        $exception->job = self::queueJob(
+            IndexRagSourceJob::class,
+            'O:66:"App\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob":4:{'
+            .'s:14:"organizationId";i:39;s:9:"projectId";N;s:10:"sourceType";s:8:"estimate";s:5:"runId";i:77091;}'
+        );
+
+        self::assertFalse($policy->shouldCapture($exception));
+    }
+
+    public function test_captures_project_scoped_rag_estimate_max_attempts(): void
+    {
+        $policy = new GlitchTipReportPolicy($this->config());
+        $exception = new MaxAttemptsExceededException(
+            IndexRagSourceJob::class.' has been attempted too many times.'
+        );
+        $exception->job = self::queueJob(
+            IndexRagSourceJob::class,
+            'O:66:"App\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob":4:{'
+            .'s:14:"organizationId";i:39;s:9:"projectId";i:55;s:10:"sourceType";s:8:"estimate";s:5:"runId";i:77091;}'
+        );
+
+        self::assertTrue($policy->shouldCapture($exception));
     }
 
     public static function reportableExceptions(): array
@@ -331,6 +363,26 @@ class GlitchTipReportPolicyTest extends TestCase
             public function hasDataToRead(): bool
             {
                 return false;
+            }
+        };
+    }
+
+    private static function queueJob(string $commandName, string $command): object
+    {
+        return new class($commandName, $command) {
+            public function __construct(
+                private readonly string $commandName,
+                private readonly string $command
+            ) {}
+
+            public function payload(): array
+            {
+                return [
+                    'data' => [
+                        'commandName' => $this->commandName,
+                        'command' => $this->command,
+                    ],
+                ];
             }
         };
     }


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-65 / issue 228: http://5.129.220.32:8000/prohelper-backend/issues/228
- PROHELPER-BACKEND-66 / issue 229: http://5.129.220.32:8000/prohelper-backend/issues/229

## Root cause
Legacy org-wide scheduled RAG estimate jobs can still reach Laravel `MaxAttemptsExceededException`. Current code already recovers this path by splitting the failed org-wide run into project-scoped scheduled jobs, but Laravel still reports the recoverable max-attempts exception to GlitchTip.

## Что изменено
- `GlitchTipReportPolicy` теперь пропускает только recoverable max-attempts для `IndexRagSourceJob`, когда queue payload явно указывает на org-wide `sourceType=estimate`, `projectId=null` и `runId`.
- Project-scoped RAG max-attempts и остальные queue failures остаются reportable.
- Добавлены unit-тесты на suppress/capture границы.

## Проверки
- `php -l app\Services\Monitoring\GlitchTipReportPolicy.php`
- `php -l tests\Unit\Monitoring\GlitchTipReportPolicyTest.php`
- `vendor\bin\phpunit.bat tests\Unit\Monitoring\GlitchTipReportPolicyTest.php`
- `vendor\bin\phpstan.bat analyse app\Services\Monitoring\GlitchTipReportPolicy.php --memory-limit=1G`

## Notes
- GlitchTip API `events/latest` возвращал старое событие 2026-06-15 на release `prohelper@548c3e1`, при этом issue summary показывает lastSeen 2026-06-28 и lastRelease `prohelper@8c683a9`. Поэтому фикс сфокусирован на оставшейся причине шума после уже слитого self-healing split.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated GlitchTipReportPolicy to ignore MaxAttemptsExceededException for specific IndexRagSourceJob scenarios.</li>
<li>Added logic to identify and skip recoverable organization-wide RAG estimate jobs that have exceeded max attempts.</li>
<li>Implemented unit tests to verify that organization-scoped RAG estimate jobs are skipped, while project-scoped ones are still captured.</li>
</ul></div>