### PR TITLE
test[lk]: закреплена типизация фильтра базы знаний

### DIFF
--- a/tests/Unit/Filament/KnowledgeArticleResourceTest.php
+++ b/tests/Unit/Filament/KnowledgeArticleResourceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Filament;
+
+use PHPUnit\Framework\TestCase;
+
+final class KnowledgeArticleResourceTest extends TestCase
+{
+    public function test_surfaces_filter_uses_eloquent_builder_type_hint(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 3).'/app/Filament/Resources/KnowledgeArticleResource.php'
+        );
+
+        self::assertStringContainsString(
+            'use Illuminate\Database\Eloquent\Builder as EloquentBuilder;',
+            $source
+        );
+        self::assertStringContainsString(
+            '->query(fn (EloquentBuilder $query, array $data): EloquentBuilder =>',
+            $source
+        );
+        self::assertStringNotContainsString(
+            '->query(fn (Builder $query, array $data): Builder =>',
+            $source
+        );
+    }
+}


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-7L: http://5.129.220.32:8000/prohelper-backend/issues/276
- PROHELPER-BACKEND-7M: http://5.129.220.32:8000/prohelper-backend/issues/277

## Root cause
В production-релизе `prohelper@aa34006` callback фильтра `surfaces` в `KnowledgeArticleResource` типизировал `$query` как `Builder`, который разрешался в namespace `App\Filament\Resources\Builder`, а Filament передает `Illuminate\Database\Eloquent\Builder`. Это приводило к `TypeError` при открытии таблицы статей базы знаний.

Production-код уже исправлен в `main` коммитом `645b7de7` через явный алиас `EloquentBuilder`. Этот PR добавляет регрессионный тест, чтобы ошибка не вернулась при будущих правках ресурса.

## Что изменено
- Добавлен unit-тест `KnowledgeArticleResourceTest`, который закрепляет импорт `Illuminate\Database\Eloquent\Builder as EloquentBuilder` и типизацию callback фильтра `surfaces`.

## Проверки
- `php -l tests\Unit\Filament\KnowledgeArticleResourceTest.php`
- `vendor\bin\phpunit.bat tests\Unit\Filament\KnowledgeArticleResourceTest.php`
- `vendor\bin\phpstan.bat analyse app\Filament\Resources\KnowledgeArticleResource.php tests\Unit\Filament\KnowledgeArticleResourceTest.php --memory-limit=1G`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new unit test to verify that KnowledgeArticleResource uses the correct Eloquent Builder type hint in its query filter.</li>
</ul></div>