### PR TITLE
fix[lk]: не скрывать timeout RAG-индексации

### DIFF
--- a/app/Services/Monitoring/GlitchTipReportPolicy.php
+++ b/app/Services/Monitoring/GlitchTipReportPolicy.php
@@ -144,7 +144,7 @@ class GlitchTipReportPolicy
 
     private function isRecoverableRagOrganizationEstimateMaxAttempts(Throwable $exception): bool
     {
-        if (! $exception instanceof MaxAttemptsExceededException) {
+        if ($exception::class !== MaxAttemptsExceededException::class) {
             return false;
         }
 

--- a/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
+++ b/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
@@ -19,6 +19,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\Request;
 use Illuminate\Queue\MaxAttemptsExceededException;
+use Illuminate\Queue\TimeoutExceededException;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use PDOException;
@@ -140,6 +141,21 @@ class GlitchTipReportPolicyTest extends TestCase
             IndexRagSourceJob::class,
             'O:66:"App\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob":4:{'
             .'s:14:"organizationId";i:39;s:9:"projectId";i:55;s:10:"sourceType";s:8:"estimate";s:5:"runId";i:77091;}'
+        );
+
+        self::assertTrue($policy->shouldCapture($exception));
+    }
+
+    public function test_captures_org_wide_rag_estimate_timeouts(): void
+    {
+        $policy = new GlitchTipReportPolicy($this->config());
+        $exception = new TimeoutExceededException(
+            IndexRagSourceJob::class.' has timed out.'
+        );
+        $exception->job = self::queueJob(
+            IndexRagSourceJob::class,
+            'O:66:"App\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob":4:{'
+            .'s:14:"organizationId";i:39;s:9:"projectId";N;s:10:"sourceType";s:8:"estimate";s:5:"runId";i:77091;}'
         );
 
         self::assertTrue($policy->shouldCapture($exception));


### PR DESCRIPTION
## Что исправлено
- Suppress recoverable RAG max-attempts теперь применяется только к точному классу `Illuminate\Queue\MaxAttemptsExceededException`.
- `Illuminate\Queue\TimeoutExceededException`, который наследуется от `MaxAttemptsExceededException`, больше не будет случайно подавляться для org-wide `IndexRagSourceJob`.
- Добавлен регрессионный тест на timeout с тем же queue payload.

## Проверки
- `php -l app\Services\Monitoring\GlitchTipReportPolicy.php`
- `php -l tests\Unit\Monitoring\GlitchTipReportPolicyTest.php`
- `.\vendor\bin\phpunit.bat tests\Unit\Monitoring\GlitchTipReportPolicyTest.php`
- `.\vendor\bin\phpstan.bat analyse app\Services\Monitoring\GlitchTipReportPolicy.php tests\Unit\Monitoring\GlitchTipReportPolicyTest.php --memory-limit=1G`
- `git diff --check`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored exception type check in GlitchTipReportPolicy to use class comparison instead of instanceof for stricter validation.</li>
<li>Added a new unit test to verify that TimeoutExceededException is correctly captured for organization-wide RAG estimate jobs.</li>
</ul></div>