### PR TITLE
fix[lk]: дробить RAG-индексацию смет по сущностям

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
+++ b/app/BusinessModules/Features/AIAssistant/Jobs/IndexRagSourceJob.php
@@ -28,7 +28,9 @@ class IndexRagSourceJob implements ShouldQueue
         public int $organizationId,
         public ?int $projectId = null,
         public ?string $sourceType = null,
-        public ?int $runId = null
+        public ?int $runId = null,
+        public ?string $entityType = null,
+        public string|int|null $entityId = null
     ) {
         $this->onConnection($this->connectionName());
         $this->onQueue($this->queueName());
@@ -56,6 +58,7 @@ class IndexRagSourceJob implements ShouldQueue
             && $run->mode === RagIndexRun::MODE_SCHEDULED
             && $this->projectId === null
             && $this->sourceType !== null
+            && $this->entityType === null
             && ($coordinator ??= app(RagIndexingCoordinator::class))->shouldSplitOrganizationSourceByProjects($this->sourceType)
         ) {
             $coordinator->splitOrganizationSourceRunByProjects($this->runId, $this->organizationId, $this->sourceType);
@@ -63,7 +66,22 @@ class IndexRagSourceJob implements ShouldQueue
             return;
         }
 
-        $indexed = $indexer->indexOrganization($this->organizationId, $this->projectId, $this->sourceType);
+        if (
+            $run instanceof RagIndexRun
+            && $run->mode === RagIndexRun::MODE_SCHEDULED
+            && $this->projectId !== null
+            && $this->sourceType === 'estimate'
+            && $this->entityType === null
+        ) {
+            $coordinator ??= app(RagIndexingCoordinator::class);
+            if ($coordinator->splitProjectEstimateRunByEstimates($this->runId, $this->organizationId, $this->projectId) > 0) {
+                return;
+            }
+        }
+
+        $indexed = $this->entityType !== null && $this->entityId !== null
+            ? $indexer->indexEntity($this->organizationId, $this->sourceType, $this->entityType, $this->entityId)
+            : $indexer->indexOrganization($this->organizationId, $this->projectId, $this->sourceType);
 
         if ($this->runId !== null) {
             $coordinator ??= app(RagIndexingCoordinator::class);
@@ -102,6 +120,8 @@ class IndexRagSourceJob implements ShouldQueue
             'organization_id' => $this->organizationId,
             'project_id' => $this->projectId,
             'source_type' => $this->sourceType,
+            'entity_type' => $this->entityType,
+            'entity_id' => $this->entityId,
             'run_id' => $this->runId,
             'exception_class' => $throwable::class,
         ]);

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexer.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexer.php
@@ -105,6 +105,31 @@ class RagIndexer
         return $indexed;
     }
 
+    public function indexEntity(
+        int $organizationId,
+        ?string $sourceType,
+        string $entityType,
+        string|int $entityId
+    ): int {
+        if ($sourceType === null) {
+            return 0;
+        }
+
+        $collector = $this->sourceRegistry->collector($sourceType);
+        if (! $collector instanceof RagSourceCollectorInterface || ! $collector->enabled()) {
+            return 0;
+        }
+
+        $indexed = 0;
+
+        foreach ($collector->collectEntity($organizationId, $entityType, $entityId) as $chunk) {
+            $this->indexChunk($chunk);
+            $indexed++;
+        }
+
+        return $indexed;
+    }
+
     /**
      * @return array<string, RagSourceCollectorInterface>
      */

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/RagIndexingCoordinator.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob;
 use App\BusinessModules\Features\AIAssistant\Models\RagChunk;
 use App\BusinessModules\Features\AIAssistant\Models\RagIndexRun;
 use App\BusinessModules\Features\AIAssistant\Models\RagSource;
+use App\Models\Estimate;
 use App\Models\Organization;
 use App\Models\Project;
 use Illuminate\Database\Eloquent\Builder;
@@ -244,6 +245,29 @@ class RagIndexingCoordinator
         $this->splitOrganizationSourceRunByProjects($run->id, $run->organization_id, $run->source_type);
 
         return true;
+    }
+
+    public function splitProjectEstimateRunByEstimates(int $runId, int $organizationId, int $projectId): int
+    {
+        $queued = 0;
+
+        foreach ($this->estimateIdsForProject($organizationId, $projectId) as $estimateId) {
+            dispatch(new IndexRagSourceJob(
+                $organizationId,
+                $projectId,
+                'estimate',
+                null,
+                'estimate',
+                $estimateId
+            ));
+            $queued++;
+        }
+
+        if ($queued > 0) {
+            $this->markSucceeded($runId, 0);
+        }
+
+        return $queued;
     }
 
     public function indexOrganizationSync(
@@ -582,6 +606,20 @@ class RagIndexingCoordinator
             ->orderBy('id')
             ->pluck('id')
             ->map(static fn (int|string $projectId): int => (int) $projectId)
+            ->all();
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function estimateIdsForProject(int $organizationId, int $projectId): array
+    {
+        return Estimate::query()
+            ->where('organization_id', $organizationId)
+            ->where('project_id', $projectId)
+            ->orderBy('id')
+            ->pluck('id')
+            ->map(static fn (int|string $estimateId): int => (int) $estimateId)
             ->all();
     }
 

--- a/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
+++ b/tests/Feature/Console/AIAssistantRagBackfillCommandTest.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Features\AIAssistant\Models\RagIndexRun;
 use App\BusinessModules\Features\AIAssistant\Models\RagSource;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexer;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagSourceRegistry;
+use App\Models\Estimate;
 use App\Models\Organization;
 use App\Models\Project;
 use Illuminate\Queue\MaxAttemptsExceededException;
@@ -307,6 +308,62 @@ class AIAssistantRagBackfillCommandTest extends TestCase
                 && in_array($job->projectId, [$freshProject->id, $failedProject->id], true)
                 && $job->sourceType === 'estimate'
         );
+    }
+
+    public function test_scheduled_project_estimate_job_is_requeued_by_estimate(): void
+    {
+        Queue::fake();
+
+        $organization = Organization::factory()->create();
+        $project = Project::factory()->create(['organization_id' => $organization->id]);
+        $firstEstimate = Estimate::factory()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+        ]);
+        $secondEstimate = Estimate::factory()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+        ]);
+        $indexer = new BackfillCommandRecordingRagIndexer(7);
+        $this->app->instance(RagIndexer::class, $indexer);
+
+        $run = RagIndexRun::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'source_type' => 'estimate',
+            'status' => RagIndexRun::STATUS_QUEUED,
+            'mode' => RagIndexRun::MODE_SCHEDULED,
+            'queued_at' => now()->subMinutes(5),
+        ]);
+
+        (new IndexRagSourceJob($organization->id, $project->id, 'estimate', $run->id))->handle(
+            $indexer,
+            app(\App\BusinessModules\Features\AIAssistant\Services\Rag\RagIndexingCoordinator::class)
+        );
+
+        $this->assertSame([], $indexer->calls);
+        Queue::assertPushed(IndexRagSourceJob::class, 2);
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $project->id
+                && $job->sourceType === 'estimate'
+                && $job->entityType === 'estimate'
+                && $job->entityId === $firstEstimate->id
+        );
+        Queue::assertPushed(
+            IndexRagSourceJob::class,
+            static fn (IndexRagSourceJob $job): bool => $job->organizationId === $organization->id
+                && $job->projectId === $project->id
+                && $job->sourceType === 'estimate'
+                && $job->entityType === 'estimate'
+                && $job->entityId === $secondEstimate->id
+        );
+        $this->assertDatabaseHas('ai_rag_index_runs', [
+            'id' => $run->id,
+            'status' => RagIndexRun::STATUS_SUCCEEDED,
+            'indexed_chunks' => 0,
+        ]);
     }
 
     public function test_legacy_org_wide_project_scoped_job_is_requeued_when_attempts_are_exceeded_before_handle(): void

--- a/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
+++ b/tests/Unit/AIAssistant/Rag/IndexRagSourceJobTest.php
@@ -79,6 +79,17 @@ class IndexRagSourceJobTest extends TestCase
         $this->assertSame([[30, 1]], $coordinator->markSucceededCalls);
         $this->assertSame([[10, null, 'estimate']], $indexer->calls);
     }
+
+    public function test_job_indexes_requested_entity_scope(): void
+    {
+        $job = new IndexRagSourceJob(10, 20, 'estimate', null, 'estimate', 30);
+        $indexer = new RecordingRagIndexer();
+
+        $job->handle($indexer);
+
+        $this->assertSame([], $indexer->calls);
+        $this->assertSame([[10, 'estimate', 'estimate', 30]], $indexer->entityCalls);
+    }
 }
 
 final class RecordingRagIndexer extends RagIndexer
@@ -88,6 +99,11 @@ final class RecordingRagIndexer extends RagIndexer
      */
     public array $calls = [];
 
+    /**
+     * @var array<int, array{0: int, 1: string|null, 2: string, 3: string|int}>
+     */
+    public array $entityCalls = [];
+
     public function __construct()
     {
     }
@@ -95,6 +111,17 @@ final class RecordingRagIndexer extends RagIndexer
     public function indexOrganization(int $organizationId, ?int $projectId = null, ?string $sourceType = null): int
     {
         $this->calls[] = [$organizationId, $projectId, $sourceType];
+
+        return 1;
+    }
+
+    public function indexEntity(
+        int $organizationId,
+        ?string $sourceType,
+        string $entityType,
+        string|int $entityId
+    ): int {
+        $this->entityCalls[] = [$organizationId, $sourceType, $entityType, $entityId];
 
         return 1;
     }


### PR DESCRIPTION
## GlitchTip
- PROHELPER-BACKEND-65 / issue 228: `IndexRagSourceJob has been attempted too many times`
- PROHELPER-BACKEND-66 / issue 229: связанная default-группа того же RAG MaxAttemptsExceeded
- GlitchTip: http://5.129.220.32:8000/prohelper-backend/issues/228

## Root cause
Scheduled RAG backfill уже дробил `estimate` до project scope, но крупный проект `organization_id=39`, `project_id=53` содержит 258 смет, 1707 разделов и 168735 позиций. Один project-scoped `estimate` job выполнялся около 6 часов и дважды завершался `MaxAttemptsExceeded`.

## Что изменено
- Добавлен entity-scoped путь в `IndexRagSourceJob` и `RagIndexer::indexEntity()`.
- Scheduled project `estimate` run теперь раскладывается на jobs по отдельным сметам через `RagIndexingCoordinator::splitProjectEstimateRunByEstimates()`.
- Ручной/manual project-wide reindex не менялся.
- Добавлены регрессионные тесты на entity job и split scheduled project estimate run.

## Проверки
- `php -l` по измененным PHP-файлам
- `vendor\\bin\\phpunit.bat tests\\Unit\\AIAssistant\\Rag\\IndexRagSourceJobTest.php`
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\AIAssistant\\Jobs\\IndexRagSourceJob.php app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\RagIndexer.php app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\RagIndexingCoordinator.php tests\\Unit\\AIAssistant\\Rag\\IndexRagSourceJobTest.php tests\\Feature\\Console\\AIAssistantRagBackfillCommandTest.php --memory-limit=1G`

Feature-тест `AIAssistantRagBackfillCommandTest` добавлен, но локально не запускался из-за проектного ограничения на DB-сценарии в Codex окружении.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added entity-level indexing support to IndexRagSourceJob and RagIndexer.</li>
<li>Implemented project-to-estimate splitting logic in RagIndexingCoordinator to allow granular RAG indexing.</li>
<li>Updated IndexRagSourceJob to handle entity-specific indexing tasks.</li>
<li>Added feature and unit tests to verify the new entity-based indexing and job splitting functionality.</li>
</ul></div>