### PR TITLE
fix[lk]: обработать сбои OpenAI embeddings для RAG

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/OpenAIRagEmbeddingProvider.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/OpenAIRagEmbeddingProvider.php
@@ -91,7 +91,7 @@ final class OpenAIRagEmbeddingProvider implements RagEmbeddingProviderInterface
         } catch (Throwable $exception) {
             throw new RagEmbeddingUnavailableException($this->assistantMessage(
                 'ai_assistant.rag_embedding_unavailable',
-                'РЎРµСЂРІРёСЃ РїРѕРґРіРѕС‚РѕРІРєРё РєРѕРЅС‚РµРєСЃС‚Р° РІСЂРµРјРµРЅРЅРѕ РЅРµРґРѕСЃС‚СѓРїРµРЅ.'
+                'Сервис подготовки контекста временно недоступен.'
             ), 0, $exception);
         }
 

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/OpenAIRagEmbeddingProvider.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/OpenAIRagEmbeddingProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\AIAssistant\Services\Rag;
 
+use App\BusinessModules\Features\AIAssistant\Exceptions\RagEmbeddingUnavailableException;
 use GuzzleHttp\Client as GuzzleClient;
 use OpenAI;
 use RuntimeException;
@@ -85,7 +86,15 @@ final class OpenAIRagEmbeddingProvider implements RagEmbeddingProviderInterface
             'total_tokens' => 0,
         ];
 
-        $response = $embeddings->create($parameters);
+        try {
+            $response = $embeddings->create($parameters);
+        } catch (Throwable $exception) {
+            throw new RagEmbeddingUnavailableException($this->assistantMessage(
+                'ai_assistant.rag_embedding_unavailable',
+                'РЎРµСЂРІРёСЃ РїРѕРґРіРѕС‚РѕРІРєРё РєРѕРЅС‚РµРєСЃС‚Р° РІСЂРµРјРµРЅРЅРѕ РЅРµРґРѕСЃС‚СѓРїРµРЅ.'
+            ), 0, $exception);
+        }
+
         $this->lastUsage = $this->usageFromResponse($response, $text);
 
         $embedding = $response->embeddings[0]->embedding ?? null;

--- a/tests/Unit/AIAssistant/Rag/OpenAIRagEmbeddingProviderTest.php
+++ b/tests/Unit/AIAssistant/Rag/OpenAIRagEmbeddingProviderTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit\AIAssistant\Rag;
 
+use App\BusinessModules\Features\AIAssistant\Exceptions\RagEmbeddingUnavailableException;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\OpenAIRagEmbeddingProvider;
 use App\BusinessModules\Features\AIAssistant\Services\Rag\RagEmbeddingProviderInterface;
 use Illuminate\Support\Facades\Lang;
 use RuntimeException;
+use Throwable;
 use Tests\TestCase;
 
 class OpenAIRagEmbeddingProviderTest extends TestCase
@@ -85,6 +87,24 @@ class OpenAIRagEmbeddingProviderTest extends TestCase
 
         $provider->embed('Контекст проекта');
     }
+
+    public function test_openai_provider_converts_client_failure_to_unavailable_exception(): void
+    {
+        $clientException = new RuntimeException('temporary provider failure');
+        $provider = new OpenAIRagEmbeddingProvider(
+            client: new FakeOpenAIEmbeddingClient([0.4], $clientException),
+            apiKey: 'test-key',
+            model: 'text-embedding-3-small',
+            dimensions: 3
+        );
+
+        try {
+            $provider->embed('project context');
+            $this->fail('Expected RAG embedding unavailable exception.');
+        } catch (RagEmbeddingUnavailableException $exception) {
+            $this->assertSame($clientException, $exception->getPrevious());
+        }
+    }
 }
 
 final class FakeRagEmbeddingProvider implements RagEmbeddingProviderInterface
@@ -122,9 +142,9 @@ final class FakeOpenAIEmbeddingClient
     /**
      * @param  array<int, float>  $embedding
      */
-    public function __construct(array $embedding)
+    public function __construct(array $embedding, ?Throwable $exception = null)
     {
-        $this->embeddings = new FakeOpenAIEmbeddingsResource($embedding);
+        $this->embeddings = new FakeOpenAIEmbeddingsResource($embedding, $exception);
     }
 
     public function embeddings(): FakeOpenAIEmbeddingsResource
@@ -143,7 +163,10 @@ final class FakeOpenAIEmbeddingsResource
     /**
      * @param  array<int, float>  $embedding
      */
-    public function __construct(private readonly array $embedding) {}
+    public function __construct(
+        private readonly array $embedding,
+        private readonly ?Throwable $exception = null
+    ) {}
 
     /**
      * @param  array<string, mixed>  $parameters
@@ -151,6 +174,10 @@ final class FakeOpenAIEmbeddingsResource
     public function create(array $parameters): object
     {
         $this->lastParameters = $parameters;
+
+        if ($this->exception !== null) {
+            throw $this->exception;
+        }
 
         return (object) [
             'embeddings' => [

--- a/tests/Unit/AIAssistant/Rag/OpenAIRagEmbeddingProviderTest.php
+++ b/tests/Unit/AIAssistant/Rag/OpenAIRagEmbeddingProviderTest.php
@@ -90,6 +90,10 @@ class OpenAIRagEmbeddingProviderTest extends TestCase
 
     public function test_openai_provider_converts_client_failure_to_unavailable_exception(): void
     {
+        Lang::addLines([
+            'ai_assistant.rag_embedding_unavailable' => 'Переведенное сообщение о недоступности подготовки контекста.',
+        ], 'ru');
+
         $clientException = new RuntimeException('temporary provider failure');
         $provider = new OpenAIRagEmbeddingProvider(
             client: new FakeOpenAIEmbeddingClient([0.4], $clientException),
@@ -102,6 +106,7 @@ class OpenAIRagEmbeddingProviderTest extends TestCase
             $provider->embed('project context');
             $this->fail('Expected RAG embedding unavailable exception.');
         } catch (RagEmbeddingUnavailableException $exception) {
+            $this->assertSame('Переведенное сообщение о недоступности подготовки контекста.', $exception->getMessage());
             $this->assertSame($clientException, $exception->getPrevious());
         }
     }


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-7N / issue 278: OpenAI\Exceptions\ErrorException: Something went wrong on our side. Please try again later.
- PROHELPER-BACKEND-7P / issue 280: OpenAI\Exceptions\TransporterException: cURL error 28 timeout for Timeweb embeddings.

Links:
- http://5.129.220.32:8000/prohelper-backend/issues/278
- http://5.129.220.32:8000/prohelper-backend/issues/280

## Root cause
`OpenAIRagEmbeddingProvider::embed()` directly propagated exceptions from `embeddings()->create()`. Temporary provider failures and transport timeouts were reported as application errors instead of the existing domain-level `RagEmbeddingUnavailableException`, which is marked `ShouldntReport` and already used by the Yandex RAG embedding provider.

Issue 282 was also checked during this run. Its production log message shows `UsageTracker::getMonthlyUsage(): Return value must be of type int, string returned`; this is already fixed in `main` by commit `88bae9ef` with a regression test.

## Changes
- Wrapped OpenAI embeddings creation in `try/catch` and converted SDK/transport failures to `RagEmbeddingUnavailableException` while preserving the previous exception.
- Added a unit regression test for OpenAI embedding client failures.

## Checks
- `php -l app\BusinessModules\Features\AIAssistant\Services\Rag\OpenAIRagEmbeddingProvider.php`
- `php -l tests\Unit\AIAssistant\Rag\OpenAIRagEmbeddingProviderTest.php`
- `vendor\bin\phpunit.bat tests\Unit\AIAssistant\Rag\OpenAIRagEmbeddingProviderTest.php` (OK: 5 tests, 14 assertions; project test bootstrap ran local test migrations/cleanup)
- `vendor\bin\phpstan.bat analyse app\BusinessModules\Features\AIAssistant\Services\Rag\OpenAIRagEmbeddingProvider.php tests\Unit\AIAssistant\Rag\OpenAIRagEmbeddingProviderTest.php --memory-limit=1G`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Wrapped OpenAI embedding creation in a try-catch block to handle potential service failures.</li>
<li>Introduced a custom RagEmbeddingUnavailableException to provide clearer error reporting when embedding generation fails.</li>
<li>Updated the unit test suite to verify that client exceptions are correctly caught and re-thrown as RagEmbeddingUnavailableException.</li>
</ul></div>