### PR TITLE
fix[lk]: исключить клиентские ошибки загрузки из GlitchTip

### DIFF
--- a/config/glitchtip.php
+++ b/config/glitchtip.php
@@ -58,6 +58,7 @@ return [
                 \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException::class,
                 \Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException::class,
                 \Illuminate\Database\Eloquent\ModelNotFoundException::class,
+                \Laminas\Diactoros\Exception\UploadedFileErrorException::class,
                 \App\Exceptions\Billing\InsufficientBalanceException::class,
                 \App\Exceptions\AI\AIQuotaExceededException::class,
             ],

--- a/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
+++ b/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
@@ -22,6 +22,7 @@ use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Queue\TimeoutExceededException;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
+use Laminas\Diactoros\Exception\UploadedFileErrorException;
 use PDOException;
 use Predis\Command\CommandInterface;
 use Predis\Connection\ConnectionException;
@@ -182,6 +183,9 @@ class GlitchTipReportPolicyTest extends TestCase
             'authorization' => [fn () => new AuthorizationException()],
             'not found' => [fn () => new NotFoundHttpException()],
             'rate limit' => [fn () => new TooManyRequestsHttpException()],
+            'upload stream error' => [fn () => UploadedFileErrorException::dueToStreamUploadError(
+                'A PHP extension stopped the file upload.'
+            )],
             'balance' => [fn () => new InsufficientBalanceException('not enough')],
             'business logic by default' => [fn () => new BusinessLogicException('expected workflow guard', 409)],
             'ai quota' => [fn () => new AIQuotaExceededException('quota')],
@@ -214,6 +218,7 @@ class GlitchTipReportPolicyTest extends TestCase
                     AuthorizationException::class,
                     NotFoundHttpException::class,
                     TooManyRequestsHttpException::class,
+                    UploadedFileErrorException::class,
                     InsufficientBalanceException::class,
                     AIQuotaExceededException::class,
                 ],


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-72 / issue 257: http://5.129.220.32:8000/prohelper-backend/issues/257
- PROHELPER-BACKEND-1K / issue 52: http://5.129.220.32:8000/prohelper-backend/issues/52

## Root cause
RoadRunner/PSR bridge receives an upload with `UPLOAD_ERR_EXTENSION` and throws `Laminas\Diactoros\Exception\UploadedFileErrorException` before application controllers run. This is a client/upload-layer failure, but GlitchTip treated it as an actionable backend exception. In some events Laravel then attempted to report the exception during worker shutdown and produced a secondary `Target class [config] does not exist` group.

## What changed
- Added `Laminas\Diactoros\Exception\UploadedFileErrorException` to GlitchTip ignored exceptions.
- Added a regression case to `GlitchTipReportPolicyTest` so upload stream errors are not captured.

## Verification
- `php -l config\\glitchtip.php`
- `php -l tests\\Unit\\Monitoring\\GlitchTipReportPolicyTest.php`
- `.\\vendor\\bin\\phpunit.bat tests\\Unit\\Monitoring\\GlitchTipReportPolicyTest.php` (24 tests, 36 assertions)
- `.\\vendor\\bin\\phpstan.bat analyse config\\glitchtip.php tests\\Unit\\Monitoring\\GlitchTipReportPolicyTest.php app\\Services\\Monitoring\\GlitchTipReportPolicy.php --memory-limit=1G`

## Notes
Fresh GlitchTip issues PROHELPER-BACKEND-7N/7P (278/280) for Timeweb/OpenAI embeddings are already fixed in `origin/main` by `f85f1f18` via `RagEmbeddingUnavailableException`; no duplicate PR was created for them.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refined document status logic by removing 'ready' from retryable and ignorable statuses.</li>
<li>Updated document classification logic to flag documents as 'needs_review' if they are 'geometry_only' and lack takeoffs.</li>
<li>Enhanced DrawingGeometryAnalyzer to include specific review reasons for geometry-based documents, such as missing scale or linked dimensions.</li>
<li>Added comprehensive unit and feature tests to validate the new document review and geometry analysis logic.</li>
</ul></div>