### PR TITLE
fix[lk]: добавить повторы для embeddings ассистента

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/OpenAIRagEmbeddingProvider.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/OpenAIRagEmbeddingProvider.php
@@ -6,12 +6,20 @@ namespace App\BusinessModules\Features\AIAssistant\Services\Rag;
 
 use App\BusinessModules\Features\AIAssistant\Exceptions\RagEmbeddingUnavailableException;
 use GuzzleHttp\Client as GuzzleClient;
+use Illuminate\Support\Facades\Log;
 use OpenAI;
+use OpenAI\Exceptions\ErrorException as OpenAIErrorException;
+use OpenAI\Exceptions\RateLimitException;
+use OpenAI\Exceptions\TransporterException;
 use RuntimeException;
 use Throwable;
 
 final class OpenAIRagEmbeddingProvider implements RagEmbeddingProviderInterface
 {
+    private const RETRY_ATTEMPTS = 3;
+    private const RETRY_BASE_DELAY_MS = 500;
+    private const RETRY_MAX_DELAY_MS = 3000;
+
     private ?object $client;
 
     private ?string $apiKey;
@@ -87,7 +95,7 @@ final class OpenAIRagEmbeddingProvider implements RagEmbeddingProviderInterface
         ];
 
         try {
-            $response = $embeddings->create($parameters);
+            $response = $this->createEmbeddingWithRetry($embeddings, $parameters);
         } catch (Throwable $exception) {
             throw new RagEmbeddingUnavailableException($this->assistantMessage(
                 'ai_assistant.rag_embedding_unavailable',
@@ -106,6 +114,80 @@ final class OpenAIRagEmbeddingProvider implements RagEmbeddingProviderInterface
         }
 
         return array_map(static fn (mixed $value): float => (float) $value, array_values($embedding));
+    }
+
+    /**
+     * @param  array<string, mixed>  $parameters
+     */
+    private function createEmbeddingWithRetry(object $embeddings, array $parameters): object
+    {
+        $lastException = null;
+
+        for ($attempt = 1; $attempt <= self::RETRY_ATTEMPTS; $attempt++) {
+            try {
+                return $embeddings->create($parameters);
+            } catch (Throwable $exception) {
+                $lastException = $exception;
+
+                if ($attempt >= self::RETRY_ATTEMPTS || ! $this->shouldRetry($exception)) {
+                    throw $exception;
+                }
+
+                Log::warning('ai_assistant.rag.openai_embedding_retry', [
+                    'attempt' => $attempt,
+                    'max_attempts' => self::RETRY_ATTEMPTS,
+                    'provider' => $this->providerName,
+                    'model' => $this->model,
+                    'exception' => $exception::class,
+                    'status' => $this->exceptionStatus($exception),
+                ]);
+
+                usleep($this->retryDelayMs($attempt) * 1000);
+            }
+        }
+
+        throw $lastException;
+    }
+
+    private function shouldRetry(Throwable $exception): bool
+    {
+        if ($exception instanceof RateLimitException || $exception instanceof TransporterException) {
+            return true;
+        }
+
+        if ($exception instanceof OpenAIErrorException) {
+            $status = $exception->getStatusCode();
+
+            return $status === 429 || $status >= 500;
+        }
+
+        $message = mb_strtolower($exception->getMessage(), 'UTF-8');
+
+        return str_contains($message, 'timed out')
+            || str_contains($message, 'timeout')
+            || str_contains($message, 'temporarily')
+            || str_contains($message, 'try again later')
+            || str_contains($message, 'connection');
+    }
+
+    private function retryDelayMs(int $attempt): int
+    {
+        $delay = self::RETRY_BASE_DELAY_MS * (2 ** max(0, $attempt - 1));
+
+        return min($delay, self::RETRY_MAX_DELAY_MS);
+    }
+
+    private function exceptionStatus(Throwable $exception): ?int
+    {
+        if ($exception instanceof OpenAIErrorException) {
+            return $exception->getStatusCode();
+        }
+
+        if ($exception instanceof RateLimitException) {
+            return $exception->response->getStatusCode();
+        }
+
+        return null;
     }
 
     public function provider(): string

--- a/tests/Unit/AIAssistant/Rag/OpenAIRagEmbeddingProviderTest.php
+++ b/tests/Unit/AIAssistant/Rag/OpenAIRagEmbeddingProviderTest.php
@@ -110,6 +110,23 @@ class OpenAIRagEmbeddingProviderTest extends TestCase
             $this->assertSame($clientException, $exception->getPrevious());
         }
     }
+
+    public function test_openai_provider_retries_transient_embedding_failure(): void
+    {
+        $client = new FakeOpenAIEmbeddingClient(
+            [0.7, 0.8, 0.9],
+            [new RuntimeException('Operation timed out after 45003 milliseconds')]
+        );
+        $provider = new OpenAIRagEmbeddingProvider(
+            client: $client,
+            apiKey: 'test-key',
+            model: 'text-embedding-3-small',
+            dimensions: 3
+        );
+
+        $this->assertSame([0.7, 0.8, 0.9], $provider->embed('project context'));
+        $this->assertSame(2, $client->embeddings->attempts);
+    }
 }
 
 final class FakeRagEmbeddingProvider implements RagEmbeddingProviderInterface
@@ -146,8 +163,9 @@ final class FakeOpenAIEmbeddingClient
 
     /**
      * @param  array<int, float>  $embedding
+     * @param  Throwable|array<int, Throwable>|null  $exception
      */
-    public function __construct(array $embedding, ?Throwable $exception = null)
+    public function __construct(array $embedding, Throwable|array|null $exception = null)
     {
         $this->embeddings = new FakeOpenAIEmbeddingsResource($embedding, $exception);
     }
@@ -165,23 +183,36 @@ final class FakeOpenAIEmbeddingsResource
      */
     public array $lastParameters = [];
 
+    public int $attempts = 0;
+
     /**
      * @param  array<int, float>  $embedding
+     * @param  Throwable|array<int, Throwable>|null  $exception
      */
     public function __construct(
         private readonly array $embedding,
-        private readonly ?Throwable $exception = null
-    ) {}
+        Throwable|array|null $exception = null
+    ) {
+        $this->exceptions = is_array($exception)
+            ? array_values($exception)
+            : ($exception !== null ? [$exception] : []);
+    }
+
+    /**
+     * @var array<int, Throwable>
+     */
+    private array $exceptions;
 
     /**
      * @param  array<string, mixed>  $parameters
      */
     public function create(array $parameters): object
     {
+        $this->attempts++;
         $this->lastParameters = $parameters;
 
-        if ($this->exception !== null) {
-            throw $this->exception;
+        if ($this->exceptions !== []) {
+            throw array_shift($this->exceptions);
         }
 
         return (object) [


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-7N / issue 278: `OpenAI\Exceptions\ErrorException: Something went wrong on our side. Please try again later.`
  - http://5.129.220.32:8000/prohelper-backend/issues/278
- PROHELPER-BACKEND-7P / issue 280: `OpenAI\Exceptions\TransporterException: cURL error 28 ... /embeddings`
  - http://5.129.220.32:8000/prohelper-backend/issues/280

Дополнительно проверено: свежий PROHELPER-BACKEND-7S / issue 283 по `PdfExporterService::download()` уже исправлен в `main` commit `44a7aa6a`, поэтому дублирующая правка для него не создавалась.

## Root cause
Timeweb/OpenAI-compatible embeddings иногда возвращает временный 5xx/timeout. `OpenAIRagEmbeddingProvider` сразу пробрасывал сбой как недоступность RAG embeddings без повторной попытки, из-за чего кратковременная деградация провайдера попадала в GlitchTip.

## Что изменено
- Добавлен bounded retry для OpenAI embeddings: 3 попытки с коротким exponential backoff.
- Повторяются только временные классы ошибок: `TransporterException`, rate limit, 429/5xx и типичные timeout/temporary сообщения.
- Логируется только технический контекст retry без текста запроса и без секретов.
- Добавлен unit-тест на успешный retry после временного timeout.

## Проверки
- `php -l app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\OpenAIRagEmbeddingProvider.php`
- `php -l tests\\Unit\\AIAssistant\\Rag\\OpenAIRagEmbeddingProviderTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\AIAssistant\\Rag\\OpenAIRagEmbeddingProviderTest.php` (6 tests, 17 assertions)
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\AIAssistant\\Services\\Rag\\OpenAIRagEmbeddingProvider.php tests\\Unit\\AIAssistant\\Rag\\OpenAIRagEmbeddingProviderTest.php --memory-limit=1G`

Примечание: PHPUnit в этом проекте при запуске unit-файла поднимает тестовые migrations из `phpunit.xml`; production БД не затрагивалась.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented a retry mechanism for OpenAI embedding requests in OpenAIRagEmbeddingProvider.</li>
<li>Added logic to handle transient failures such as rate limits (429), server errors (5xx), and connection timeouts.</li>
<li>Configured exponential backoff for retries with a maximum of 3 attempts.</li>
<li>Updated unit tests to verify that the provider correctly retries on transient failures.</li>
</ul></div>