### PR TITLE
fix[lk]: отключить почтовый канал просроченных платежей

### DIFF
--- a/app/BusinessModules/Core/Payments/Notifications/PaymentOverdueNotification.php
+++ b/app/BusinessModules/Core/Payments/Notifications/PaymentOverdueNotification.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\BusinessModules\Core\Payments\Notifications;
 
 use App\BusinessModules\Core\Payments\Models\PaymentDocument;
@@ -19,7 +21,7 @@ class PaymentOverdueNotification extends Notification implements ShouldQueue
 
     public function via($notifiable): array
     {
-        return ['mail', 'database'];
+        return ['database'];
     }
 
     public function toMail($notifiable): MailMessage

--- a/tests/Unit/BusinessModules/Core/Payments/PaymentOverdueNotificationTest.php
+++ b/tests/Unit/BusinessModules/Core/Payments/PaymentOverdueNotificationTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BusinessModules\Core\Payments;
+
+use App\BusinessModules\Core\Payments\Models\PaymentDocument;
+use App\BusinessModules\Core\Payments\Notifications\PaymentOverdueNotification;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentOverdueNotificationTest extends TestCase
+{
+    public function test_overdue_notification_uses_database_channel_only(): void
+    {
+        $notification = new PaymentOverdueNotification(new PaymentDocument(), 10);
+
+        self::assertSame(['database'], $notification->via(null));
+    }
+}


### PR DESCRIPTION
## GlitchTip
- PROHELPER-BACKEND-7V / issue 286: `PaymentOverdueNotification has been attempted too many times`
- PROHELPER-BACKEND-80 / issue 287: grouped default event for the same queued notification
- Related root event: PROHELPER-BACKEND-7T / issue 284, SMTP 550 for sender domain `xn--1-xtbgmf.xn--p1ai`

Links:
- http://5.129.220.32:8000/prohelper-backend/issues/286
- http://5.129.220.32:8000/prohelper-backend/issues/287
- http://5.129.220.32:8000/prohelper-backend/issues/284

## Root cause
The daily overdue payment scheduler creates queued `PaymentOverdueNotification` jobs at 09:00. The notification used both `mail` and `database` channels. SMTP rejects the configured sender domain with 550 `domain not verified`, so the queued notification retries until Laravel raises `MaxAttemptsExceededException`.

## Changes
- Switched `PaymentOverdueNotification` to the `database` channel only, preserving in-app overdue alerts and stopping mail transport retries from failing the queue.
- Added a unit regression test for the notification channel contract.
- Added `declare(strict_types=1);` to the touched notification file.

## Verification
- `php -l app\\BusinessModules\\Core\\Payments\\Notifications\\PaymentOverdueNotification.php`
- `php -l tests\\Unit\\BusinessModules\\Core\\Payments\\PaymentOverdueNotificationTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\BusinessModules\\Core\\Payments\\PaymentOverdueNotificationTest.php`
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Core\\Payments\\Notifications\\PaymentOverdueNotification.php tests\\Unit\\BusinessModules\\Core\\Payments\\PaymentOverdueNotificationTest.php --memory-limit=1G`

## Note
Email delivery for these overdue alerts should be restored separately after the SMTP sender domain is verified or a verified sender is configured.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Modified PaymentOverdueNotification to remove the 'mail' channel, keeping only 'database' notifications.</li>
<li>Added strict type declarations to PaymentOverdueNotification.</li>
<li>Created a new unit test to verify that PaymentOverdueNotification correctly uses only the database channel.</li>
</ul></div>