### PR TITLE
test[lk]: закрепить дату платежного документа закупки

### DIFF
--- a/tests/Feature/Api/V1/Admin/ProcurementChainControllerTest.php
+++ b/tests/Feature/Api/V1/Admin/ProcurementChainControllerTest.php
@@ -123,6 +123,10 @@ final class ProcurementChainControllerTest extends TestCase
             'payer_organization_id' => $context->organization->id,
             'payee_contractor_id' => Contractor::query()->where('inn', '7700000000')->value('id'),
         ]);
+        $this->assertSame(
+            now()->toDateString(),
+            PaymentDocument::query()->findOrFail($firstResponse->json('data.id'))->document_date?->toDateString()
+        );
     }
 
     public function test_purchase_order_payment_document_uses_material_purchase_limit_for_procurement_contract(): void


### PR DESCRIPTION
## GlitchTip
- Issue: PROHELPER-BACKEND-83 / #290 (`payment_document.create_failed`)
- Related historical issue: PROHELPER-BACKEND-6B / #234 (`payment_document.create_failed`)
- Links:
  - http://5.129.220.32:8000/prohelper-backend/issues/290
  - http://5.129.220.32:8000/prohelper-backend/issues/234

## Root cause
???????????? ?????????? ????????? ?? ?????? ??????? ??????, ????? payload ?? ???????? ???????????? `document_date`: `PaymentValidationService` ???????? ???????? ? ??????? `???? "???? ?????????" ???????????.` ?????? issue #290 ?????? ? ??????? `af38165`/`9bf1285`; ??????? `main` ??? ???????? ?????????? `document_date`, ?? ???? ?? ????????? ???? ????????.

## ??? ????????
- ????????? ????????????? ???????? ? API workflow ???????? ?????????? ????????? ?? ?????? ???????.
- ???? ?????? ???? ?????????, ??? ????????? payment document ???????? `document_date` ??????? ?????.

## ????????
- RED: ???????? ????? `document_date` ?? `PurchaseOrderPaymentDocumentService`, ???? ???? ? 422 ?????? 201.
- `php -l tests\Feature\Api\V1\Admin\ProcurementChainControllerTest.php`
- `php -l app\BusinessModules\Features\Procurement\Services\PurchaseOrderPaymentDocumentService.php`
- `vendor\bin\phpunit.bat tests\Feature\Api\V1\Admin\ProcurementChainControllerTest.php --filter=payment_document_endpoint_is_idempotent_and_uses_supplier_contractor` - OK (1 test, 6 assertions)
- `vendor\bin\phpstan.bat analyse app\BusinessModules\Features\Procurement\Services\PurchaseOrderPaymentDocumentService.php tests\Feature\Api\V1\Admin\ProcurementChainControllerTest.php --memory-limit=1G` - OK


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added an assertion to verify that the payment document date matches the current date in the idempotency test for the procurement chain controller.</li>
</ul></div>