### PR TITLE
fix[lk]: отключить автоинвойс без бюджетных измерений

### DIFF
--- a/app/BusinessModules/Features/Procurement/Listeners/CreateInvoiceFromPurchaseOrder.php
+++ b/app/BusinessModules/Features/Procurement/Listeners/CreateInvoiceFromPurchaseOrder.php
@@ -28,6 +28,15 @@ class CreateInvoiceFromPurchaseOrder
             return;
         }
 
+        if ($this->accessController->hasModuleAccess($order->organization_id, 'budgeting')) {
+            Log::info('procurement.skip_invoice_creation', [
+                'purchase_order_id' => $order->id,
+                'reason' => 'budgeting_dimensions_required',
+            ]);
+
+            return;
+        }
+
         $module = app(\App\BusinessModules\Features\Procurement\ProcurementModule::class);
         $settings = $module->getSettings($order->organization_id);
 

--- a/tests/Unit/BusinessModules/Features/Procurement/CreateInvoiceFromPurchaseOrderTest.php
+++ b/tests/Unit/BusinessModules/Features/Procurement/CreateInvoiceFromPurchaseOrderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BusinessModules\Features\Procurement;
+
+use App\BusinessModules\Features\Procurement\Events\PurchaseOrderCreated;
+use App\BusinessModules\Features\Procurement\Listeners\CreateInvoiceFromPurchaseOrder;
+use App\BusinessModules\Features\Procurement\Models\PurchaseOrder;
+use App\Modules\Core\AccessController;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+final class CreateInvoiceFromPurchaseOrderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_listener_skips_auto_creation_when_budgeting_requires_manual_dimensions(): void
+    {
+        $order = new PurchaseOrder();
+        $order->forceFill([
+            'id' => 77,
+            'organization_id' => 15,
+        ]);
+
+        $accessController = Mockery::mock(AccessController::class);
+        $accessController
+            ->shouldReceive('hasModuleAccess')
+            ->once()
+            ->with(15, 'payments')
+            ->andReturnTrue();
+        $accessController
+            ->shouldReceive('hasModuleAccess')
+            ->once()
+            ->with(15, 'budgeting')
+            ->andReturnTrue();
+
+        $logger = Mockery::mock();
+        $logger
+            ->shouldReceive('info')
+            ->once()
+            ->with('procurement.skip_invoice_creation', [
+                'purchase_order_id' => 77,
+                'reason' => 'budgeting_dimensions_required',
+            ]);
+
+        $container = new Container();
+        $container->instance('log', $logger);
+        Facade::setFacadeApplication($container);
+
+        (new CreateInvoiceFromPurchaseOrder($accessController))->handle(new PurchaseOrderCreated($order));
+
+        $this->addToAssertionCount(3);
+    }
+}


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-83 / issue 290: `payment_document.create_failed`, count 26, lastSeen 2026-07-09T19:08:40Z
- PROHELPER-BACKEND-84 / issue 291: `payment_document.create_failed`, lastSeen 2026-07-08T18:30:50Z
- PROHELPER-BACKEND-85 / issue 292: `procurement.invoice.auto_create_failed`, lastSeen 2026-07-08T18:30:50Z

Links:
- http://5.129.220.32:8000/prohelper-backend/issues/290
- http://5.129.220.32:8000/prohelper-backend/issues/291
- http://5.129.220.32:8000/prohelper-backend/issues/292

## Root cause
GlitchTip detail/events for these log-based issues did not include stack traces or event payloads, but the paired log keys point to the procurement auto invoice flow. `CreateInvoiceFromPurchaseOrder` called `PurchaseOrderPaymentDocumentService::createOrOpen()` without user-provided budget dimensions. When the `budgeting` module is active, `PaymentBudgetLimitService` requires a budget article and responsibility center for outgoing payment documents and turns that automatic background creation into `payment_document.create_failed`, then the listener logs `procurement.invoice.auto_create_failed`.

## Changes
- Auto invoice listener now skips automatic payment document creation when budgeting is active, leaving the order in the manual `create_or_open_payment_document` step where the UI can collect budget dimensions.
- Added a unit regression test that verifies the listener exits before reaching payment document creation in this state.

## Checks
- `php -l app\\BusinessModules\\Features\\Procurement\\Listeners\\CreateInvoiceFromPurchaseOrder.php`
- `php -l tests\\Unit\\BusinessModules\\Features\\Procurement\\CreateInvoiceFromPurchaseOrderTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\BusinessModules\\Features\\Procurement\\CreateInvoiceFromPurchaseOrderTest.php` OK (1 test, 3 assertions)
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Features\\Procurement\\Listeners\\CreateInvoiceFromPurchaseOrder.php tests\\Unit\\BusinessModules\\Features\\Procurement\\CreateInvoiceFromPurchaseOrderTest.php --memory-limit=1G`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Modified the CreateInvoiceFromPurchaseOrder listener to skip automatic invoice creation if the organization has 'budgeting' module access.</li>
<li>Added a log entry when invoice creation is skipped due to budgeting requirements.</li>
<li>Added a new unit test to verify that the listener correctly skips invoice creation when budgeting access is enabled.</li>
</ul></div>