### PR TITLE
fix[lk]: блокировать старый почтовый канал просроченных платежей

### DIFF
--- a/app/BusinessModules/Core/Payments/Notifications/PaymentOverdueNotification.php
+++ b/app/BusinessModules/Core/Payments/Notifications/PaymentOverdueNotification.php
@@ -24,6 +24,11 @@ class PaymentOverdueNotification extends Notification implements ShouldQueue
         return ['database'];
     }
 
+    public function shouldSend(object $notifiable, string $channel): bool
+    {
+        return $channel !== 'mail';
+    }
+
     public function toMail($notifiable): MailMessage
     {
         $urgency = $this->overdueDays > 30 ? 'срочно' : ($this->overdueDays > 7 ? 'важно' : '');
@@ -58,4 +63,3 @@ class PaymentOverdueNotification extends Notification implements ShouldQueue
         ];
     }
 }
-

--- a/tests/Unit/BusinessModules/Core/Payments/PaymentOverdueNotificationTest.php
+++ b/tests/Unit/BusinessModules/Core/Payments/PaymentOverdueNotificationTest.php
@@ -16,4 +16,12 @@ final class PaymentOverdueNotificationTest extends TestCase
 
         self::assertSame(['database'], $notification->via(null));
     }
+
+    public function test_overdue_notification_blocks_legacy_mail_channel(): void
+    {
+        $notification = new PaymentOverdueNotification(new PaymentDocument(), 10);
+
+        self::assertFalse($notification->shouldSend(new \stdClass(), 'mail'));
+        self::assertTrue($notification->shouldSend(new \stdClass(), 'database'));
+    }
 }


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-8A / issue 297: `Expected response code 250 but got code 550`, first/lastSeen 2026-07-12 09:00:11-14 UTC, count 11, https://5.129.220.32:8000/prohelper-backend/issues/297
- Связанный SMTP exception: PROHELPER-BACKEND-7T / issue 284, https://5.129.220.32:8000/prohelper-backend/issues/284

## Root cause
- Issue 297 не отдаёт events/stack в GlitchTip, но время совпадает с daily `ProcessOverduePaymentsJob` в 09:00.
- Текущий код уже отправляет `PaymentOverdueNotification` только в `database`, но старые queued `SendQueuedNotifications` могли быть сериализованы до PR #126 с каналом `mail`.
- Laravel 11 проверяет `shouldSend(object $notifiable, string $channel)` в момент обработки queued notification, поэтому это место подходит для блокировки legacy mail-channel без изменения database-уведомлений.

## Что изменено
- `PaymentOverdueNotification::shouldSend()` теперь отклоняет канал `mail` и разрешает остальные каналы.
- Добавлен unit regression test для legacy mail-channel и database-channel.

## Проверки
- `php -l` по измененным PHP-файлам
- `vendor/bin/phpunit tests/Unit/BusinessModules/Core/Payments/PaymentOverdueNotificationTest.php` после временного worktree autoload dump: OK, 2 tests, 3 assertions
- `vendor/bin/phpstan analyse app/BusinessModules/Core/Payments/Notifications/PaymentOverdueNotification.php tests/Unit/BusinessModules/Core/Payments/PaymentOverdueNotificationTest.php --memory-limit=1G`: OK
- `git diff --check`: OK

## Примечания
- Production file уже содержит `via() => ['database']`; этот PR закрывает именно старые queued payload, где канал `mail` мог быть сохранён до предыдущего фикса.
- GlitchTip detail/events для issue 297/284 вернули пустой список events, поэтому route/request context недоступен через API.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a shouldSend method to PaymentOverdueNotification to explicitly block the 'mail' channel.</li>
<li>Updated unit tests to verify that the notification correctly blocks the 'mail' channel while allowing the 'database' channel.</li>
</ul></div>