### PR TITLE
fix[lk]: снизить уровень лога отказа отправки платежа

### DIFF
--- a/app/BusinessModules/Core/Payments/Services/PaymentDocumentService.php
+++ b/app/BusinessModules/Core/Payments/Services/PaymentDocumentService.php
@@ -257,6 +257,16 @@ class PaymentDocumentService
             DB::commit();
             return $document->fresh();
 
+        } catch (\DomainException $e) {
+            DB::rollBack();
+
+            Log::warning('payment_document.submit_rejected', [
+                'document_id' => $document->id,
+                'status' => $document->status?->value,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
         } catch (\Exception $e) {
             DB::rollBack();
             
@@ -1264,4 +1274,3 @@ class PaymentDocumentService
         return 'ordered';
     }
 }
-

--- a/tests/Unit/BusinessModules/Core/Payments/PaymentDocumentServiceTest.php
+++ b/tests/Unit/BusinessModules/Core/Payments/PaymentDocumentServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BusinessModules\Core\Payments;
+
+use App\BusinessModules\Core\Payments\Models\PaymentDocument;
+use App\BusinessModules\Core\Payments\Services\ApprovalWorkflowService;
+use App\BusinessModules\Core\Payments\Services\PaymentAuditService;
+use App\BusinessModules\Core\Payments\Services\PaymentBudgetLimitService;
+use App\BusinessModules\Core\Payments\Services\PaymentDocumentService;
+use App\BusinessModules\Core\Payments\Services\PaymentDocumentStateMachine;
+use App\BusinessModules\Core\Payments\Services\PaymentValidationService;
+use App\BusinessModules\Features\Budgeting\Services\BudgetLimitCheckService;
+use App\Domain\Authorization\Services\ModulePermissionChecker;
+use DomainException;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentDocumentServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_submit_does_not_log_expected_domain_transition_as_error(): void
+    {
+        $document = new PaymentDocument();
+        $document->id = 160;
+        $document->amount = 1000;
+
+        $app = new Container();
+        Facade::setFacadeApplication($app);
+
+        $db = Mockery::mock();
+        $db->shouldReceive('beginTransaction')->once();
+        $db->shouldReceive('rollBack')->once();
+        $app->instance('db', $db);
+
+        $log = Mockery::mock();
+        $log->shouldReceive('error')
+            ->with('payment_document.submit_failed', Mockery::any())
+            ->never();
+        $log->shouldReceive('warning')
+            ->with('payment_document.submit_rejected', Mockery::on(
+                static fn (array $context): bool => ($context['document_id'] ?? null) === 160
+                    && ($context['error'] ?? null) === "Недопустимый переход из статуса 'Оплачен' в 'Отправлен'"
+            ))
+            ->once();
+        $app->instance('log', $log);
+
+        $validator = Mockery::mock(PaymentValidationService::class);
+        $validator->shouldReceive('validateBeforeSubmission')
+            ->once()
+            ->with($document)
+            ->andThrow(new DomainException("Недопустимый переход из статуса 'Оплачен' в 'Отправлен'"));
+
+        $stateMachine = Mockery::mock(PaymentDocumentStateMachine::class);
+        $stateMachine->shouldReceive('submit')
+            ->never();
+
+        $service = new PaymentDocumentService(
+            $stateMachine,
+            Mockery::mock(ApprovalWorkflowService::class),
+            $validator,
+            new PaymentBudgetLimitService(
+                new BudgetLimitCheckService(),
+                Mockery::mock(ModulePermissionChecker::class),
+            ),
+            Mockery::mock(PaymentAuditService::class),
+        );
+
+        $this->expectException(DomainException::class);
+
+        $service->submit($document);
+    }
+}


### PR DESCRIPTION
## GlitchTip
- Исправлено: PROHELPER-BACKEND-5D / issue 204
- Ссылка: http://5.129.220.32:8000/prohelper-backend/issues/204

## Root cause
`PaymentDocumentService::submit()` логировал ожидаемые доменные отказы через `Log::error('payment_document.submit_failed')`. Для повторной отправки уже оплаченного документа контроллер возвращал 422, но error-level лог попадал в GlitchTip как production issue.

## Что изменено
- Для `DomainException` в submit-flow добавлен отдельный rollback + `Log::warning('payment_document.submit_rejected')`.
- Системные исключения по-прежнему логируются как `payment_document.submit_failed` с error-level.
- Добавлен unit-тест, закрепляющий, что ожидаемый доменный отказ не пишет `submit_failed` в error.

## Проверки
- `php -l app\\BusinessModules\\Core\\Payments\\Services\\PaymentDocumentService.php`
- `php -l tests\\Unit\\BusinessModules\\Core\\Payments\\PaymentDocumentServiceTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\BusinessModules\\Core\\Payments\\PaymentDocumentServiceTest.php`
- `vendor\\bin\\phpstan.bat analyse app\\BusinessModules\\Core\\Payments\\Services\\PaymentDocumentService.php tests\\Unit\\BusinessModules\\Core\\Payments\\PaymentDocumentServiceTest.php --memory-limit=1G`
- `git diff --check`

## Не включено
- Свежие SMTP issues 297/284/286/287 уже покрыты слитым PR #130; последние события были до merge #130.
- PROHELPER-BACKEND-8B / issue 298 не имел detail/events в API, поэтому без дополнительного лог-контекста правка не делалась.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a specific catch block for DomainException in PaymentDocumentService::submit to handle domain-related submission rejections.</li>
<li>Implemented logging for rejected payment document submissions at the warning level instead of treating them as general exceptions.</li>
<li>Added a new unit test file PaymentDocumentServiceTest to verify that domain-specific submission rejections are logged correctly as warnings.</li>
</ul></div>