### PR TITLE
feat[lk]: включена тестовая оплата пакетами

### DIFF
--- a/app/Services/Billing/CommercialPaymentProviderPolicy.php
+++ b/app/Services/Billing/CommercialPaymentProviderPolicy.php
@@ -18,6 +18,10 @@ final class CommercialPaymentProviderPolicy
         }
 
         $allowedIds = array_map('intval', (array) config('services.yookassa.test_organization_ids', []));
+        if ($allowedIds === []) {
+            return;
+        }
+
         if (! in_array($organizationId, $allowedIds, true)) {
             throw new PaymentGatewayConfigurationException(trans_message('billing.provider.test_unavailable'));
         }

--- a/app/Services/Billing/CommercialRenewalService.php
+++ b/app/Services/Billing/CommercialRenewalService.php
@@ -14,6 +14,7 @@ use App\Models\CommercialPayment;
 use App\Models\CommercialRenewalCycle;
 use App\Models\OrganizationCommercialAccount;
 use App\Models\OrganizationPackageSubscription;
+use App\Modules\Core\AccessController;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Query\JoinClause;
@@ -40,6 +41,7 @@ final class CommercialRenewalService
         private readonly CommercialWebhookProcessor $webhookProcessor,
         private readonly CommercialPaymentProviderPolicy $providerPolicy,
         private readonly CommercialContourChangeCancellationService $contourChangeCancellation,
+        private readonly AccessController $accessController,
     ) {}
 
     public function process(CarbonInterface $at, int $limit = 100): array
@@ -49,7 +51,7 @@ final class CommercialRenewalService
         if (Schema::hasTable('notifications')) {
             $this->notifications->processRenewalLifecycle($now);
         }
-        $ids = OrganizationCommercialAccount::query()
+        $accounts = OrganizationCommercialAccount::query()
             ->from('organization_commercial_accounts as accounts')
             ->leftJoin('commercial_renewal_cycles as current_cycle', function (JoinClause $join): void {
                 $join->on('current_cycle.commercial_account_id', '=', 'accounts.id')
@@ -90,7 +92,7 @@ final class CommercialRenewalService
             ->orderBy('current_cycle.last_attempt_at')
             ->orderBy('accounts.id')
             ->limit(max(1, $limit))
-            ->pluck('accounts.id');
+            ->get(['accounts.id', 'accounts.organization_id']);
         $counts = [
             'processed' => 0,
             'created_cycles' => 0,
@@ -100,9 +102,11 @@ final class CommercialRenewalService
             'suspended' => 0,
         ];
 
-        foreach ($ids as $id) {
+        foreach ($accounts as $candidate) {
+            $id = (int) $candidate->id;
             try {
-                $phase = $this->prepare((int) $id, $now);
+                $phase = $this->prepare($id, $now);
+                $this->accessController->clearAccessCache((int) $candidate->organization_id);
                 $counts['processed']++;
                 foreach (['created_cycles', 'created_attempts', 'canceled_changes', 'suspended'] as $key) {
                     $counts[$key] += (int) ($phase[$key] ?? 0);

--- a/app/Services/Billing/CommercialWebhookService.php
+++ b/app/Services/Billing/CommercialWebhookService.php
@@ -21,6 +21,7 @@ use App\Models\CommercialWebhookEvent;
 use App\Models\OrganizationCommercialAccount;
 use App\Models\OrganizationPackageSubscription;
 use App\Models\User;
+use App\Modules\Core\AccessController;
 use App\Services\Contractor\ContractorReferralRewardService;
 use App\Services\Modules\PackageCatalogService;
 
@@ -33,6 +34,7 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
         private readonly PackageCatalogService $catalog,
         private readonly CommercialWebhookTransactionRunner $transactions,
         private readonly ContractorReferralRewardService $referralRewards,
+        private readonly AccessController $accessController,
     ) {}
 
     public function process(YooKassaWebhookNotification $notification, string $sourceIp): string
@@ -59,12 +61,16 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
         PaymentGatewayResult $authoritative,
     ): string {
         $fingerprint = $this->fingerprint($notification, $authoritative->status);
+        $organizationId = null;
+        $entitlementsChanged = false;
 
-        return $this->transactions->run($fingerprint, function () use (
+        $result = $this->transactions->run($fingerprint, function () use (
             $notification,
             $sourceIp,
             $authoritative,
             $fingerprint,
+            &$organizationId,
+            &$entitlementsChanged,
         ): string {
             if ($this->isDuplicate($fingerprint)) {
                 return 'duplicate';
@@ -73,6 +79,7 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
             $payment = $this->resolvePaymentForUpdate($notification, $authoritative);
 
             $order = CommercialOrder::query()->whereKey($payment->commercial_order_id)->lockForUpdate()->firstOrFail();
+            $organizationId = (int) $order->organization_id;
             $account = OrganizationCommercialAccount::query()
                 ->whereKey($order->commercial_account_id)
                 ->where('organization_id', $order->organization_id)
@@ -130,6 +137,7 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
                     return $this->record($notification, $sourceIp, $fingerprint, $authoritative->status, 'manual_review');
                 }
                 $this->activate($order, $payment, $account, $packageRows, $authoritative);
+                $entitlementsChanged = true;
                 if ($order->kind === 'purchase') {
                     $order->refresh();
                     $payment->refresh();
@@ -186,6 +194,7 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
                             ])->save();
                         }
                     }
+                    $entitlementsChanged = true;
                     if (! $wasInGrace) {
                         $this->notify($order, 'commercial_grace_started_'.$order->public_id, 'billing.renewal.grace_started');
                     }
@@ -200,6 +209,12 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
 
             return $this->record($notification, $sourceIp, $fingerprint, $authoritative->status, 'processed');
         });
+
+        if ($entitlementsChanged && $organizationId !== null) {
+            $this->accessController->clearAccessCache($organizationId);
+        }
+
+        return $result;
     }
 
     public function processAuthoritativeRefund(
@@ -209,13 +224,17 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
         PaymentGatewayResult $authoritativePayment,
     ): string {
         $fingerprint = $this->fingerprint($notification, $refund->status);
+        $organizationId = null;
+        $entitlementsChanged = false;
 
-        return $this->transactions->run($fingerprint, function () use (
+        $result = $this->transactions->run($fingerprint, function () use (
             $notification,
             $sourceIp,
             $refund,
             $authoritativePayment,
             $fingerprint,
+            &$organizationId,
+            &$entitlementsChanged,
         ): string {
             if ($this->isDuplicate($fingerprint)) {
                 return 'duplicate';
@@ -232,6 +251,7 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
             }
 
             $order = CommercialOrder::query()->whereKey($payment->commercial_order_id)->lockForUpdate()->firstOrFail();
+            $organizationId = (int) $order->organization_id;
             OrganizationCommercialAccount::query()
                 ->whereKey($order->commercial_account_id)
                 ->where('organization_id', $order->organization_id)
@@ -337,6 +357,7 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
                         'canceled_at' => now(),
                     ])->save();
                 }
+                $entitlementsChanged = true;
             }
 
             $this->notify(
@@ -348,6 +369,12 @@ final class CommercialWebhookService implements CommercialWebhookProcessor
 
             return $this->record($notification, $sourceIp, $fingerprint, $refund->status, $result);
         });
+
+        if ($entitlementsChanged && $organizationId !== null) {
+            $this->accessController->clearAccessCache($organizationId);
+        }
+
+        return $result;
     }
 
     private function activate(

--- a/tests/Feature/Billing/CommercialRenewalServiceTest.php
+++ b/tests/Feature/Billing/CommercialRenewalServiceTest.php
@@ -22,6 +22,7 @@ use App\Services\Billing\CommercialRenewalService;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use RuntimeException;
 use Tests\TestCase;
@@ -84,10 +85,10 @@ final class CommercialRenewalServiceTest extends TestCase
         $this->assertSame(1, $this->gateway->creates);
     }
 
-    public function test_test_store_allowlist_denial_creates_no_renewal_state_or_provider_call(): void
+    public function test_non_empty_test_store_allowlist_denial_creates_no_renewal_state_or_provider_call(): void
     {
         config()->set('services.yookassa.mode', 'yookassa_test');
-        config()->set('services.yookassa.test_organization_ids', []);
+        config()->set('services.yookassa.test_organization_ids', [$this->account->organization_id + 1]);
         $at = CarbonImmutable::parse('2026-07-31 03:00:00', 'Europe/Moscow');
 
         $result = app(CommercialRenewalService::class)->process($at, 50);
@@ -280,8 +281,11 @@ final class CommercialRenewalServiceTest extends TestCase
             ])->save();
             $service->process($periodEnd->addDays($day));
         }
+        $cacheKey = "org_effective_active_modules_v2_{$this->account->organization_id}";
+        Cache::put($cacheKey, ['stale'], 60);
         $service->process(CarbonImmutable::parse('2026-08-07 03:00', 'Europe/Moscow'));
 
+        $this->assertFalse(Cache::has($cacheKey));
         $this->assertSame('suspended', $this->account->fresh()->status->value);
         $this->assertSame('expired', OrganizationPackageSubscription::query()->sole()->status->value);
         $this->assertSame(7, CommercialPayment::query()->count());

--- a/tests/Feature/Billing/CommercialWebhookServiceTest.php
+++ b/tests/Feature/Billing/CommercialWebhookServiceTest.php
@@ -26,6 +26,7 @@ use App\Services\Billing\CommercialReconciliationService;
 use App\Services\Billing\CommercialRefundService;
 use App\Services\Billing\CommercialWebhookService;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
@@ -99,9 +100,12 @@ class CommercialWebhookServiceTest extends TestCase
             'ends_at' => now()->addDays(3),
         ]);
         $this->gateway->payment = $this->paymentResult(saved: true);
+        $cacheKey = "org_effective_active_modules_v2_{$this->organization->id}";
+        Cache::put($cacheKey, ['stale'], 60);
 
         $service = app(CommercialWebhookService::class);
         $this->assertSame('processed', $service->process($this->notification('payment.succeeded', 'payment-id', 'succeeded'), '185.71.76.1'));
+        $this->assertFalse(Cache::has($cacheKey));
         $this->assertSame('duplicate', $service->process($this->notification('payment.succeeded', 'payment-id', 'succeeded'), '185.71.76.1'));
 
         $order = $this->order->fresh();

--- a/tests/Unit/Billing/CommercialPaymentProviderPolicyTest.php
+++ b/tests/Unit/Billing/CommercialPaymentProviderPolicyTest.php
@@ -12,14 +12,14 @@ final class CommercialPaymentProviderPolicyTest extends TestCase
 {
     public function refreshDatabase(): void {}
 
-    public function test_test_mode_empty_allowlist_denies_all_organizations(): void
+    public function test_test_mode_empty_allowlist_accepts_any_organization(): void
     {
         config()->set('services.yookassa.mode', 'yookassa_test');
         config()->set('services.yookassa.test_organization_ids', []);
 
-        $this->expectException(PaymentGatewayConfigurationException::class);
-
         app(CommercialPaymentProviderPolicy::class)->assertCanCharge(42);
+
+        $this->assertTrue(true);
     }
 
     public function test_test_mode_rejects_nonmatching_and_accepts_matching_organization(): void


### PR DESCRIPTION
## Что изменено
- тестовый магазин ЮKassa доступен всем организациям
- доступ обновляется сразу после оплаты, возврата и завершения льготного периода
- сохранены ежедневные повторы и фиксированная дата продления

## Проверки
- 67 тестов, 397 утверждений
- PHP syntax: без ошибок
- PHPStan: без ошибок

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated AccessController to clear access caches when commercial entitlements change.</li>
<li>Updated CommercialRenewalService to clear organization access cache after processing renewals.</li>
<li>Updated CommercialWebhookService to clear organization access cache after processing payments and refunds.</li>
<li>Added a safety check in CommercialPaymentProviderPolicy to return early if no test organization IDs are configured.</li>
</ul></div>