### PR TITLE
fix[lk]: ускорена проверка оплаты

### DIFF
--- a/app/Services/Billing/CommercialBillingQueryService.php
+++ b/app/Services/Billing/CommercialBillingQueryService.php
@@ -11,11 +11,14 @@ use App\Models\Organization;
 use App\Models\OrganizationCommercialAccount;
 use App\Models\OrganizationPackageSubscription;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 final class CommercialBillingQueryService
 {
     public function __construct(
         private readonly CommercialOfferCalculator $calculator,
+        private readonly CommercialReconciliationService $reconciliation,
     ) {}
 
     public function quote(Organization $organization, array $input): array
@@ -44,6 +47,23 @@ final class CommercialBillingQueryService
             ->where('public_id', $publicId)
             ->with(['payments', 'refunds'])
             ->firstOrFail();
+
+        $latestPayment = $order->payments->sortBy('attempt_number')->last();
+        if ($order->status->value === 'pending_payment'
+            && $latestPayment?->provider_payment_id !== null
+            && in_array($latestPayment->provider_status, ['created', 'pending', 'waiting_for_capture', 'unknown'], true)) {
+            try {
+                $this->reconciliation->reconcilePayment((int) $latestPayment->getKey());
+                $order->refresh()->load(['payments', 'refunds']);
+            } catch (Throwable $exception) {
+                Log::warning('Commercial payment status refresh failed.', [
+                    'order_id' => $order->public_id,
+                    'organization_id' => $order->organization_id,
+                    'payment_id' => $latestPayment->getKey(),
+                    'exception' => $exception::class,
+                ]);
+            }
+        }
 
         return $this->orderPayload($order, false);
     }

--- a/app/Services/Billing/CommercialReconciliationService.php
+++ b/app/Services/Billing/CommercialReconciliationService.php
@@ -56,6 +56,13 @@ final class CommercialReconciliationService
         return $counts;
     }
 
+    public function reconcilePayment(int $paymentId): bool
+    {
+        return Cache::lock("commercial:reconcile:payment:{$paymentId}", 120)->get(
+            fn (): bool => $this->payment($paymentId),
+        ) === true;
+    }
+
     private function attempt(string $type, int $id, array &$counts): void
     {
         try {

--- a/tests/Feature/Api/V1/Landing/CommercialCheckoutControllerTest.php
+++ b/tests/Feature/Api/V1/Landing/CommercialCheckoutControllerTest.php
@@ -420,6 +420,51 @@ class CommercialCheckoutControllerTest extends TestCase
             ->assertNotFound();
     }
 
+    public function test_pending_order_status_is_refreshed_from_provider_immediately(): void
+    {
+        [$order, $payment] = $this->commercialOrder(
+            $this->organization,
+            $this->commercialAccount(),
+            'pending_payment',
+        );
+        $providerPaymentId = 'provider-return-payment';
+        $payment->forceFill([
+            'provider_payment_id' => $providerPaymentId,
+            'provider_status' => 'pending',
+        ])->save();
+        $this->gateway->paymentResults[$providerPaymentId] = new PaymentGatewayResult(
+            id: $providerPaymentId,
+            status: 'succeeded',
+            confirmationUrl: null,
+            paymentMethodId: null,
+            paymentMethodSaved: false,
+            safeResponse: ['id' => $providerPaymentId, 'status' => 'succeeded'],
+            paid: true,
+            test: true,
+            amountMinor: 790000,
+            currency: 'RUB',
+            metadata: [
+                'order_id' => $order->public_id,
+                'organization_id' => (string) $this->organization->id,
+            ],
+        );
+
+        $response = $this->authenticatedAs($this->owner)
+            ->getJson('/api/v1/landing/billing/commercial/orders/'.$order->public_id);
+
+        $this->assertSame([$providerPaymentId], $this->gateway->requestedPaymentIds);
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.status', 'paid')
+            ->assertJsonPath('data.payment_status', 'succeeded');
+
+        $this->assertDatabaseHas('organization_package_subscriptions', [
+            'organization_id' => $this->organization->id,
+            'package_slug' => 'machinery',
+            'status' => 'active',
+        ]);
+    }
+
     public function test_history_is_paginated_newest_first_tenant_isolated_and_safe(): void
     {
         $account = $this->commercialAccount();
@@ -918,7 +963,7 @@ class CommercialCheckoutControllerTest extends TestCase
     private function createSchema(): void
     {
         foreach ([
-            'commercial_refunds', 'commercial_contour_changes', 'commercial_payments', 'commercial_renewal_cycles', 'commercial_orders', 'organization_package_subscriptions',
+            'notifications', 'commercial_webhook_events', 'commercial_refunds', 'commercial_contour_changes', 'commercial_payments', 'commercial_renewal_cycles', 'commercial_orders', 'organization_package_subscriptions',
             'organization_commercial_accounts', 'organization_module_activations', 'modules',
             'role_conditions', 'user_role_assignments',
             'organization_custom_roles', 'authorization_contexts', 'organization_user', 'users', 'organizations',
@@ -1036,6 +1081,34 @@ class CommercialCheckoutControllerTest extends TestCase
             $table->timestamp('cancel_at')->nullable();
             $table->timestamp('canceled_at')->nullable();
             $table->foreignId('source_order_id')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('commercial_webhook_events', function (Blueprint $table): void {
+            $table->id();
+            $table->string('provider');
+            $table->string('event_name');
+            $table->string('object_id');
+            $table->string('authoritative_status')->nullable();
+            $table->string('processing_result');
+            $table->string('source_ip');
+            $table->string('fingerprint')->unique();
+            $table->json('safe_payload')->nullable();
+            $table->timestamp('processed_at');
+            $table->timestamps();
+        });
+        Schema::create('notifications', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->string('notifiable_type');
+            $table->unsignedBigInteger('notifiable_id');
+            $table->unsignedBigInteger('organization_id')->nullable();
+            $table->string('notification_type');
+            $table->string('priority');
+            $table->json('channels');
+            $table->json('delivery_status');
+            $table->json('data');
+            $table->json('metadata')->nullable();
+            $table->timestamp('read_at')->nullable();
             $table->timestamps();
         });
         Schema::create('modules', function (Blueprint $table): void {
@@ -1180,6 +1253,10 @@ class ControllerCheckoutGatewayFake implements PaymentGatewayInterface
 {
     public array $createdPayments = [];
 
+    public array $paymentResults = [];
+
+    public array $requestedPaymentIds = [];
+
     public int $createPaymentCalls = 0;
 
     public int $failuresRemaining = 0;
@@ -1212,7 +1289,9 @@ class ControllerCheckoutGatewayFake implements PaymentGatewayInterface
 
     public function getPayment(string $paymentId): PaymentGatewayResult
     {
-        throw new \RuntimeException('Not used.');
+        $this->requestedPaymentIds[] = $paymentId;
+
+        return $this->paymentResults[$paymentId] ?? throw new RuntimeException('Payment result is not configured.');
     }
 
     public function getRefund(string $refundId): RefundGatewayResult


### PR DESCRIPTION
После возврата из ЮKassa незавершённый платёж сразу сверяется с провайдером. Подтверждение больше не зависит только от webhook; успешная оплата активирует пакеты при первой проверке.\n\nПроверено: 3 API-теста / 19 assertions, 3 reconciliation-теста, 4 webhook-теста, PHP syntax, PHPStan.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented automatic payment status reconciliation in CommercialBillingQueryService when fetching a pending order.</li>
<li>Added a reconcilePayment method to CommercialReconciliationService with cache locking to prevent concurrent reconciliation attempts.</li>
<li>Added new database tables 'commercial_webhook_events' and 'notifications' to the test schema.</li>
<li>Updated the test gateway fake to support payment result configuration and tracking of requested payment IDs.</li>
<li>Added a feature test to verify that pending order statuses are refreshed from the provider upon retrieval.</li>
</ul></div>