### PR TITLE
fix[lk]: восстановить чтение checkpoint envelope

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Pipeline/PipelineStageOutput.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Pipeline/PipelineStageOutput.php
@@ -58,6 +58,8 @@ final readonly class PipelineStageOutput
 
     public static function fromEnvelope(array $envelope, string $expectedVersion): self
     {
+        $envelope = self::normalizeEnvelope($envelope);
+
         if (array_keys($envelope) !== ['stage', 'schema_version', 'input_version', 'dependency_versions', 'artifact']
             || ! is_string($envelope['stage']) || ! is_int($envelope['schema_version'])
             || ! is_string($envelope['input_version']) || ! is_array($envelope['dependency_versions'])
@@ -94,5 +96,28 @@ final readonly class PipelineStageOutput
             'dependency_versions' => $this->dependencyVersions,
             'artifact' => $this->artifact->toArray(),
         ];
+    }
+
+    private static function normalizeEnvelope(array $envelope): array
+    {
+        if (isset($envelope['schema_version']) && is_string($envelope['schema_version'])) {
+            $envelope['schema_version'] = self::numericStringToInt($envelope['schema_version']);
+        }
+        if (isset($envelope['artifact']) && is_array($envelope['artifact'])
+            && isset($envelope['artifact']['bytes']) && is_string($envelope['artifact']['bytes'])) {
+            $envelope['artifact']['bytes'] = self::numericStringToInt($envelope['artifact']['bytes']);
+        }
+
+        return $envelope;
+    }
+
+    private static function numericStringToInt(string $value): int|string
+    {
+        if ($value === '' || preg_match('/\A(?:0|[1-9][0-9]*)\z/', $value) !== 1) {
+            return $value;
+        }
+        $integer = (int) $value;
+
+        return (string) $integer === $value ? $integer : $value;
     }
 }

--- a/tests/Unit/EstimateGeneration/Pipeline/PipelineArtifactEnvelopeTest.php
+++ b/tests/Unit/EstimateGeneration/Pipeline/PipelineArtifactEnvelopeTest.php
@@ -36,6 +36,29 @@ final class PipelineArtifactEnvelopeTest extends TestCase
     }
 
     #[Test]
+    public function persisted_output_accepts_jsonb_numeric_strings_without_changing_version(): void
+    {
+        $definition = PipelineDefinitionGraph::standard()->get(ProcessingStage::UnderstandDocuments);
+        $input = 'sha256:'.str_repeat('a', 64);
+        $reference = new PipelineArtifactReference(
+            's3_json_v1',
+            'org-2/estimate-generation/sessions/1/pipeline/attempts/123e4567-e89b-12d3-a456-426614174000/understand_documents.json',
+            'sha256:'.str_repeat('c', 64),
+            973,
+            'version-1',
+        );
+        $output = PipelineStageOutput::create($definition, $input, [], $reference);
+        $envelope = $output->envelope();
+        $envelope['schema_version'] = (string) $envelope['schema_version'];
+        $envelope['artifact']['bytes'] = (string) $envelope['artifact']['bytes'];
+
+        $restored = PipelineStageOutput::fromEnvelope($envelope, $output->version);
+
+        self::assertSame($output->version, $restored->version);
+        self::assertSame(973, $restored->artifact->bytes);
+    }
+
+    #[Test]
     public function wrong_dependency_manifest_is_rejected_before_hydration(): void
     {
         $definition = PipelineDefinitionGraph::standard()->get(ProcessingStage::UnderstandObject);


### PR DESCRIPTION
## GlitchTip issues
- PROHELPER-BACKEND-AL / issue 372: `InvalidArgumentException: Persisted pipeline output envelope is invalid.`
- Связанное log-based issue PROHELPER-BACKEND-AM / issue 373: `Persisted pipeline output envelope is invalid.`
- GlitchTip: http://5.129.220.32:8000/prohelper-backend/issues/372

## Root cause
`GenerateEstimateDraftJob` падал при чтении completed pipeline checkpoint в `PipelineStageOutput::fromEnvelope()`: persisted `output_payload` приходил с числовыми полями `schema_version` и `artifact.bytes` как JSON/string values (`1`, `973`). Строгая проверка `is_int()` отклоняла envelope до восстановления stage output, хотя `output_version` был рассчитан по нормализованной integer-форме и оставался корректным.

## Что изменено
- `PipelineStageOutput::fromEnvelope()` теперь нормализует только безопасные unsigned integer strings для `schema_version` и `artifact.bytes` перед строгой валидацией.
- Hash/version-контроль не ослаблен: после нормализации output пересоздается через `create()` и сверяется с `expectedVersion`.
- Добавлен regression-test на GlitchTip-сценарий с numeric strings без изменения версии checkpoint.

## Проверки
- RED: `vendor\bin\phpunit.bat tests\Unit\EstimateGeneration\Pipeline\PipelineArtifactEnvelopeTest.php --filter persisted_output_accepts_jsonb_numeric_strings_without_changing_version` падал на `Persisted pipeline output envelope is invalid.`
- GREEN: `vendor\bin\phpunit.bat tests\Unit\EstimateGeneration\Pipeline\PipelineArtifactEnvelopeTest.php --filter persisted_output_accepts_jsonb_numeric_strings_without_changing_version`
- `vendor\bin\phpunit.bat tests\Unit\EstimateGeneration\Pipeline\PipelineArtifactEnvelopeTest.php`
- `vendor\bin\phpunit.bat tests\Unit\EstimateGeneration\Pipeline\PipelineStageOutputTest.php tests\Unit\EstimateGeneration\Pipeline\PipelineArtifactEnvelopeTest.php`
- `php -l app\BusinessModules\Addons\EstimateGeneration\Pipeline\PipelineStageOutput.php`
- `php -l tests\Unit\EstimateGeneration\Pipeline\PipelineArtifactEnvelopeTest.php`
- `vendor\bin\phpstan.bat analyse app\BusinessModules\Addons\EstimateGeneration\Pipeline\PipelineStageOutput.php tests\Unit\EstimateGeneration\Pipeline\PipelineArtifactEnvelopeTest.php --memory-limit=1G`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added normalization logic to PipelineStageOutput to handle numeric strings in schema_version and artifact bytes.</li>
<li>Implemented a helper method to safely convert numeric strings to integers when appropriate.</li>
<li>Added a unit test to verify that PipelineStageOutput correctly handles JSONB-style numeric strings in the envelope.</li>
</ul></div>