### PR TITLE
fix[lk]: игнорировать устаревшую гонку генерации сметы

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Generation/RunEstimateGenerationDraft.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Generation/RunEstimateGenerationDraft.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Addons\EstimateGeneration\Application\Generation;
 
+use App\BusinessModules\Addons\EstimateGeneration\Domain\Workflow\StaleEstimateGenerationState;
 use App\BusinessModules\Addons\EstimateGeneration\Jobs\GenerateEstimateDraftJob;
 use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationSession;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureExecutionSnapshot;
@@ -31,7 +32,12 @@ final readonly class RunEstimateGenerationDraft
             return;
         }
 
-        $run = $this->pipeline->run($snapshot);
+        try {
+            $run = $this->pipeline->run($snapshot);
+        } catch (StaleEstimateGenerationState) {
+            return;
+        }
+
         if (! $run->dispatchNext) {
             return;
         }

--- a/tests/Feature/EstimateGeneration/EstimateGenerationQueueTest.php
+++ b/tests/Feature/EstimateGeneration/EstimateGenerationQueueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\EstimateGeneration;
 
+use App\BusinessModules\Addons\EstimateGeneration\Application\Generation\RunEstimateGenerationDraft;
 use App\BusinessModules\Addons\EstimateGeneration\Domain\Workflow\StaleEstimateGenerationState;
 use App\BusinessModules\Addons\EstimateGeneration\Domain\Workflow\EstimateGenerationStatus;
 use App\BusinessModules\Addons\EstimateGeneration\Http\Controllers\EstimateGenerationActionController;
@@ -147,7 +148,7 @@ class EstimateGenerationQueueTest extends TestCase
         $pipeline->shouldNotReceive('run');
 
         $job = new GenerateEstimateDraftJob($session->id, $session->state_version, 'test-attempt', $this->snapshot($session, 'test-attempt'));
-        $job->handle($pipeline);
+        $job->handle(new RunEstimateGenerationDraft($pipeline));
 
         $session->refresh();
 
@@ -163,7 +164,7 @@ class EstimateGenerationQueueTest extends TestCase
             ->andThrow(new StaleEstimateGenerationState((int) $session->id, (int) $session->state_version));
 
         $job = new GenerateEstimateDraftJob($session->id, $session->state_version, 'test-attempt', $this->snapshot($session, 'test-attempt'));
-        $job->handle($pipeline);
+        $job->handle(new RunEstimateGenerationDraft($pipeline));
 
         $session->refresh();
 
@@ -194,7 +195,7 @@ class EstimateGenerationQueueTest extends TestCase
             });
 
         $job = new GenerateEstimateDraftJob($session->id, $session->state_version, 'test-attempt', $this->snapshot($session, 'test-attempt'));
-        $job->handle($pipeline);
+        $job->handle(new RunEstimateGenerationDraft($pipeline));
         self::assertStringNotContainsString(
             'notifyFinished(',
             file_get_contents(base_path('app/BusinessModules/Addons/EstimateGeneration/Jobs/GenerateEstimateDraftJob.php')),

--- a/tests/Feature/EstimateGeneration/EstimateGenerationQueueTest.php
+++ b/tests/Feature/EstimateGeneration/EstimateGenerationQueueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\EstimateGeneration;
 
+use App\BusinessModules\Addons\EstimateGeneration\Domain\Workflow\StaleEstimateGenerationState;
 use App\BusinessModules\Addons\EstimateGeneration\Domain\Workflow\EstimateGenerationStatus;
 use App\BusinessModules\Addons\EstimateGeneration\Http\Controllers\EstimateGenerationActionController;
 use App\BusinessModules\Addons\EstimateGeneration\Http\Controllers\EstimateGenerationSessionController;
@@ -151,6 +152,24 @@ class EstimateGenerationQueueTest extends TestCase
         $session->refresh();
 
         $this->assertSame(EstimateGenerationStatus::ReadyToApply, $session->status);
+    }
+
+    public function test_generation_job_ignores_stale_pipeline_race(): void
+    {
+        [, , $session] = $this->makeGenerationSession('generating');
+        $pipeline = Mockery::mock(DraftPipelineEntrypoint::class);
+        $pipeline->shouldReceive('run')
+            ->once()
+            ->andThrow(new StaleEstimateGenerationState((int) $session->id, (int) $session->state_version));
+
+        $job = new GenerateEstimateDraftJob($session->id, $session->state_version, 'test-attempt', $this->snapshot($session, 'test-attempt'));
+        $job->handle($pipeline);
+
+        $session->refresh();
+
+        $this->assertSame(EstimateGenerationStatus::Generating, $session->status);
+        $this->assertNull($session->last_error);
+        $this->assertNull($session->failure_code);
     }
 
     public function test_generation_job_leaves_finished_notification_to_transactional_outbox(): void


### PR DESCRIPTION
## GlitchTip
- Исправлено: PROHELPER-BACKEND-8P / issue 312
- Ссылка: http://5.129.220.32:8000/prohelper-backend/issues/312
- Симптом: `StaleEstimateGenerationState` из `EloquentPipelineCheckpointStore` в `GenerateEstimateDraftJob`, queue `redis_estimate_generation`, `horizon:work`.

## Root cause
`GenerateEstimateDraftJob` проверял stale-состояние перед запуском, но версия/статус сессии могли измениться уже после pre-check и до выполнения pipeline stage. В этом случае `DraftPipelineEntrypoint` пробрасывал `StaleEstimateGenerationState` наружу, job считался ошибочным и попадал в GlitchTip, хотя это нормальный поздний проигрыш optimistic-lock гонки.

## Что изменено
- `RunEstimateGenerationDraft` теперь перехватывает `StaleEstimateGenerationState` из pipeline и завершает job без retry/error-report.
- Добавлен regression test на позднюю stale-гону внутри pipeline run.

## Проверки
- `php -l app\BusinessModules\Addons\EstimateGeneration\Application\Generation\RunEstimateGenerationDraft.php`
- `php -l tests\Feature\EstimateGeneration\EstimateGenerationQueueTest.php`
- `vendor\bin\phpstan.bat analyse app\BusinessModules\Addons\EstimateGeneration\Application\Generation\RunEstimateGenerationDraft.php tests\Feature\EstimateGeneration\EstimateGenerationQueueTest.php --configuration=phpstan.neon.dist --memory-limit=1G`

## Ограничение локальной проверки
- `vendor\bin\phpunit.bat tests\Feature\EstimateGeneration\EstimateGenerationQueueTest.php --filter=ignores_stale_pipeline_race` локально заблокирован существующей SQLite-несовместимой migration `BasicWarehouse` с `BTRIM` до выполнения теста.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added exception handling for StaleEstimateGenerationState in RunEstimateGenerationDraft to gracefully handle race conditions during pipeline execution.</li>
<li>Added a new feature test case to verify that the generation job correctly ignores stale pipeline states without marking the session as failed.</li>
</ul></div>