### PR TITLE
fix[lk]: защитить reconciliation от отсутствующей связи договора

### DIFF
--- a/app/Services/LegalArchive/Integrations/LegalDocumentReconciliationService.php
+++ b/app/Services/LegalArchive/Integrations/LegalDocumentReconciliationService.php
@@ -359,7 +359,7 @@ final class LegalDocumentReconciliationService
     private function organizationId(Model $entity): int
     {
         $organizationId = $entity->getAttribute('organization_id')
-            ?? $entity->getRelation('contract')?->getAttribute('organization_id');
+            ?? $this->contractRelation($entity)?->getAttribute('organization_id');
 
         if (! is_numeric($organizationId) || (int) $organizationId < 1) {
             throw new InvalidArgumentException('Legal archive source has no organization.');
@@ -371,9 +371,20 @@ final class LegalDocumentReconciliationService
     private function projectId(Model $entity): ?int
     {
         $projectId = $entity->getAttribute('project_id')
-            ?? $entity->getRelation('contract')?->getAttribute('project_id');
+            ?? $this->contractRelation($entity)?->getAttribute('project_id');
 
         return is_numeric($projectId) && (int) $projectId > 0 ? (int) $projectId : null;
+    }
+
+    private function contractRelation(Model $entity): ?Model
+    {
+        if (! $entity->relationLoaded('contract')) {
+            return null;
+        }
+
+        $contract = $entity->getRelation('contract');
+
+        return $contract instanceof Model ? $contract : null;
     }
 
     private function title(Model $entity, string $sourceType): string

--- a/tests/Unit/LegalArchive/LegalDocumentReconciliationProjectIdTest.php
+++ b/tests/Unit/LegalArchive/LegalDocumentReconciliationProjectIdTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\LegalArchive;
+
+use App\Models\Contract;
+use App\Services\LegalArchive\Integrations\LegalDocumentReconciliationService;
+use ErrorException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class LegalDocumentReconciliationProjectIdTest extends TestCase
+{
+    public function test_contract_without_project_id_does_not_require_contract_relation(): void
+    {
+        $service = (new ReflectionClass(LegalDocumentReconciliationService::class))->newInstanceWithoutConstructor();
+        $method = new \ReflectionMethod($service, 'projectId');
+
+        set_error_handler(static function (int $severity, string $message, string $file, int $line): never {
+            throw new ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            self::assertNull($method->invoke($service, new Contract([
+                'id' => 10,
+                'organization_id' => 14,
+            ])));
+        } finally {
+            restore_error_handler();
+        }
+    }
+}


### PR DESCRIPTION
## GlitchTip

Исправлены:
- PROHELPER-BACKEND-EK / issue 499: http://5.129.220.32:8000/prohelper-backend/issues/499
- PROHELPER-BACKEND-EL / issue 500: http://5.129.220.32:8000/prohelper-backend/issues/500

## Root cause

Плановая команда `legal-archive:reconcile --limit=100` создавала dossier для договоров без `project_id`. `LegalDocumentReconciliationService::projectId()` после чтения `project_id` напрямую вызывал `$entity->getRelation('contract')`, хотя для модели `Contract` связь `contract` не существует и не загружена. В production warning `Undefined array key contract` попадал в GlitchTip как unresolved issue.

## Что изменено

- Чтение связанного договора вынесено в безопасный helper, который вызывает `getRelation('contract')` только после `relationLoaded('contract')`.
- Добавлен regression-test на договор без `project_id`, который конвертирует PHP warning в `ErrorException` и закрепляет отсутствие обращения к незагруженной связи.

## Проверки

- `php -l app\Services\LegalArchive\Integrations\LegalDocumentReconciliationService.php`
- `php -l tests\Unit\LegalArchive\LegalDocumentReconciliationProjectIdTest.php`
- `vendor\bin\phpunit.bat tests\Unit\LegalArchive\LegalDocumentReconciliationProjectIdTest.php` (RED падал на `Undefined array key contract`, GREEN OK)
- `vendor\bin\phpunit.bat tests\Feature\LegalArchive\LegalDocumentReconciliationTest.php tests\Unit\LegalArchive\LegalDocumentReconciliationProjectIdTest.php` (9 tests, 28 assertions)
- `vendor\bin\phpstan.bat analyse app\Services\LegalArchive\Integrations\LegalDocumentReconciliationService.php tests\Unit\LegalArchive\LegalDocumentReconciliationProjectIdTest.php --memory-limit=1G`
- `git diff --check`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored organizationId and projectId methods in LegalDocumentReconciliationService to use a new contractRelation helper method.</li>
<li>Added a contractRelation helper method to safely retrieve and validate the 'contract' relation on a model.</li>
<li>Added a new unit test to verify that the reconciliation service handles contracts without a project_id correctly.</li>
</ul></div>