### PR TITLE
fix[lk]: расширить source type юридического архива

### DIFF
--- a/database/migrations/2026_07_19_000520_add_legal_document_access_constraints.php
+++ b/database/migrations/2026_07_19_000520_add_legal_document_access_constraints.php
@@ -61,7 +61,7 @@ CHECK (anchor IS NULL OR (jsonb_typeof(anchor) = 'object' AND anchor ?& ARRAY['t
 SQL;
 
         return [
-            'legal_documents_source_type_check' => ['legal_archive_documents', "CHECK (source_type IS NULL OR source_type IN ('project','contract','supplementary_agreement','performance_act','purchase_order','payment_document','commercial_proposal')) NOT VALID"],
+            'legal_documents_source_type_check' => ['legal_archive_documents', "CHECK (source_type IS NULL OR source_type IN ('project','contract','supplementary_agreement','performance_act','purchase_order','payment_document','commercial_proposal','crm_deal','estimate','executive_document')) NOT VALID"],
             'legal_document_party_snapshot_sets_version_fk' => ['legal_document_party_snapshot_sets', 'FOREIGN KEY (document_version_id, document_id, organization_id) REFERENCES legal_archive_document_versions (id, document_id, organization_id) ON DELETE RESTRICT NOT VALID'],
             'legal_document_party_snapshot_sets_captured_by_fk' => ['legal_document_party_snapshot_sets', 'FOREIGN KEY (captured_by_user_id) REFERENCES users (id) ON DELETE RESTRICT NOT VALID'],
             'legal_document_parties_document_fk' => ['legal_document_parties', 'FOREIGN KEY (document_id, organization_id) REFERENCES legal_archive_documents (id, organization_id) ON DELETE CASCADE NOT VALID'],

--- a/database/migrations/2026_07_26_000001_extend_legal_document_source_type_constraint.php
+++ b/database/migrations/2026_07_26_000001_extend_legal_document_source_type_constraint.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'legal_archive_documents';
+    private const CONSTRAINT = 'legal_documents_source_type_check';
+    private const REPLACEMENT = 'legal_documents_source_type_check_v2';
+    private const DEFINITION = "CHECK (source_type IS NULL OR source_type IN ('project','contract','supplementary_agreement','performance_act','purchase_order','payment_document','commercial_proposal','crm_deal','estimate','executive_document'))";
+
+    public function up(): void
+    {
+        if (Schema::getConnection()->getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        if ($this->constraintMatches(self::CONSTRAINT)) {
+            return;
+        }
+
+        if (! $this->constraintMatches(self::REPLACEMENT)) {
+            DB::statement('ALTER TABLE '.self::TABLE.' DROP CONSTRAINT IF EXISTS '.self::REPLACEMENT);
+            DB::unprepared('ALTER TABLE '.self::TABLE.' ADD CONSTRAINT '.self::REPLACEMENT.' '.self::DEFINITION.' NOT VALID');
+        }
+
+        DB::statement('ALTER TABLE '.self::TABLE.' VALIDATE CONSTRAINT '.self::REPLACEMENT);
+        DB::statement('ALTER TABLE '.self::TABLE.' DROP CONSTRAINT IF EXISTS '.self::CONSTRAINT);
+        DB::statement('ALTER TABLE '.self::TABLE.' RENAME CONSTRAINT '.self::REPLACEMENT.' TO '.self::CONSTRAINT);
+    }
+
+    public function down(): void
+    {
+        throw new RuntimeException('legal_document_access_migrations_are_forward_only');
+    }
+
+    private function constraintMatches(string $name): bool
+    {
+        $actual = DB::selectOne(
+            <<<'SQL'
+SELECT pg_get_constraintdef(c.oid, true) AS definition,
+       c.condeferrable::integer AS deferrable,
+       c.condeferred::integer AS deferred
+FROM pg_constraint c
+JOIN pg_class table_class ON table_class.oid = c.conrelid
+JOIN pg_namespace namespace ON namespace.oid = table_class.relnamespace
+WHERE namespace.nspname = current_schema()
+  AND table_class.relname = ?
+  AND c.conname = ?
+SQL,
+            [self::TABLE, $name],
+        );
+
+        return $actual !== null
+            && ! (bool) $actual->deferrable
+            && ! (bool) $actual->deferred
+            && $this->normalize($actual->definition) === $this->normalize(self::DEFINITION);
+    }
+
+    private function normalize(mixed $definition): string
+    {
+        $normalized = strtolower((string) $definition);
+        $normalized = str_replace('not valid', '', $normalized);
+        $normalized = (string) preg_replace('/::[a-z_ ]+(?:\[\])?/', '', $normalized);
+        $normalized = (string) preg_replace('/["\s()]+/', '', $normalized);
+        $normalized = str_replace(['=anyarray[', ']'], ['in', ''], $normalized);
+
+        return $normalized;
+    }
+};

--- a/tests/Unit/LegalArchive/LegalDocumentAccessSchemaTest.php
+++ b/tests/Unit/LegalArchive/LegalDocumentAccessSchemaTest.php
@@ -23,6 +23,17 @@ final class LegalDocumentAccessSchemaTest extends TestCase
             'estimate',
             'executive_document',
         ], array_column(LegalDocumentSourceType::cases(), 'value'));
+
+        $root = __DIR__.'/../../../';
+        $initialConstraints = file_get_contents($root.'database/migrations/2026_07_19_000520_add_legal_document_access_constraints.php');
+        $replacementConstraint = file_get_contents($root.'database/migrations/2026_07_26_000001_extend_legal_document_source_type_constraint.php');
+        self::assertIsString($initialConstraints);
+        self::assertIsString($replacementConstraint);
+
+        foreach (LegalDocumentSourceType::values() as $sourceType) {
+            self::assertStringContainsString("'{$sourceType}'", $initialConstraints);
+            self::assertStringContainsString("'{$sourceType}'", $replacementConstraint);
+        }
     }
 
     public function test_schema_is_online_safe_and_enforces_tenant_owned_composite_references(): void


### PR DESCRIPTION
﻿## GlitchTip issues
- PROHELPER-BACKEND-EP / issue 504: http://5.129.220.32:8000/prohelper-backend/issues/504
- PROHELPER-BACKEND-EQ / issue 505: http://5.129.220.32:8000/prohelper-backend/issues/505

## Root cause
`LegalDocumentSourceType` already allowed operational legal archive sources `crm_deal`, `estimate`, and `executive_document`, and production accepted requests with `executive_document`. The PostgreSQL check constraint `legal_documents_source_type_check` still contained the older closed list, so inserts into `legal_archive_documents` failed with SQLSTATE 23514 during document reconciliation/finalization.

## What changed
- Extended the original legal archive source type constraint definition for new environments.
- Added a forward-only migration that installs and validates a replacement constraint before swapping it into the canonical constraint name.
- Added a unit contract assertion that every `LegalDocumentSourceType` enum value is present in both constraint migrations.

## Validation
- `php -l database\\migrations\\2026_07_19_000520_add_legal_document_access_constraints.php`
- `php -l database\\migrations\\2026_07_26_000001_extend_legal_document_source_type_constraint.php`
- `php -l tests\\Unit\\LegalArchive\\LegalDocumentAccessSchemaTest.php`
- `vendor\\bin\\phpunit.bat tests\\Unit\\LegalArchive\\LegalDocumentAccessSchemaTest.php --filter=supported_source_types`
- `vendor\\bin\\phpstan.bat analyse database\\migrations\\2026_07_19_000520_add_legal_document_access_constraints.php database\\migrations\\2026_07_26_000001_extend_legal_document_source_type_constraint.php tests\\Unit\\LegalArchive\\LegalDocumentAccessSchemaTest.php --memory-limit=1G`
- `git diff --check`


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Extended the 'legal_documents_source_type_check' database constraint to include 'crm_deal', 'estimate', and 'executive_document' types.</li>
<li>Added a new migration to safely update the existing constraint in a production-safe manner using a temporary constraint and validation.</li>
<li>Updated unit tests to verify that all supported legal document source types are correctly included in both the initial and updated migration files.</li>
</ul></div>