### PR TITLE
fix[lk]: исправить binding сервиса дочерних организаций

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -191,7 +191,8 @@ class AppServiceProvider extends ServiceProvider
             return new ChildOrganizationUserService(
                 $app->make(\App\Domain\Authorization\Services\CustomRoleService::class),
                 $app->make(\App\Domain\Authorization\Services\AuthorizationService::class),
-                $app->make(\App\Services\UserInvitationService::class)
+                $app->make(\App\Services\UserInvitationService::class),
+                $app->make(\App\Domain\Authorization\Services\RoleScanner::class)
             );
         });
 

--- a/tests/Unit/Providers/AppServiceProviderTest.php
+++ b/tests/Unit/Providers/AppServiceProviderTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Providers;
+
+use PHPUnit\Framework\TestCase;
+
+class AppServiceProviderTest extends TestCase
+{
+    public function test_child_organization_user_service_binding_passes_role_scanner(): void
+    {
+        $provider = file_get_contents(
+            dirname(__DIR__, 3) . '/app/Providers/AppServiceProvider.php'
+        );
+
+        $this->assertIsString($provider);
+        $this->assertStringContainsString(
+            '$app->make(\App\Domain\Authorization\Services\RoleScanner::class)',
+            $provider
+        );
+    }
+}


### PR DESCRIPTION
## GlitchTip
- PROHELPER-BACKEND-FC / issue 523: http://5.129.220.32:8000/prohelper-backend/issues/523
- PROHELPER-BACKEND-FD / issue 524: http://5.129.220.32:8000/prohelper-backend/issues/524

## Root cause
`ChildOrganizationUserService::__construct()` ожидает `RoleScanner` четвёртым аргументом, но ручной singleton в `AppServiceProvider` всё ещё передавал только три зависимости. При разрешении сервиса из контейнера Laravel выбрасывал `ArgumentCountError`.

## Что изменено
- В binding `ChildOrganizationUserService` добавлена зависимость `RoleScanner`.
- Добавлен unit-тест, фиксирующий наличие этой зависимости в ручной регистрации сервиса без запуска миграций.

## Проверки
- `php -l app\Providers\AppServiceProvider.php`
- `php -l tests\Unit\Providers\AppServiceProviderTest.php`
- `.\vendor\bin\phpunit.bat tests\Unit\Providers\AppServiceProviderTest.php`
- `.\vendor\bin\phpstan.bat analyse app\Providers\AppServiceProvider.php tests\Unit\Providers\AppServiceProviderTest.php --memory-limit=1G`

## Примечания
- Свежие high-count issues 504/505 совпадают с уже открытым PR #142 и не дублировались.
- Labels `codex` и `codex-automation` отсутствуют в репозитории; добавлены доступные `glitchtip` и `backend`.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated AppServiceProvider to inject RoleScanner into ChildOrganizationUserService.</li>
<li>Added a new unit test to verify the correct binding of RoleScanner in AppServiceProvider.</li>
</ul></div>