### PR TITLE
fix[lk]: исправить чтение evidence геометрии документов

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/DTO/VisionAnalysisData.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/DTO/VisionAnalysisData.php
@@ -211,10 +211,21 @@ final readonly class VisionAnalysisData
 
         $normalized = [];
         foreach ($evidence as $key => $item) {
-            if (! is_string($key) || ! is_array($item) || ! self::hasExactKeys($item, ['locator'])) {
+            if (! is_string($key) || ! is_array($item)) {
                 throw new VisionContractException('invalid_evidence');
             }
-            $normalized[] = ['key' => $key, 'locator' => $item['locator']];
+            if (self::hasExactKeys($item, ['locator'])) {
+                $normalized[] = ['key' => $key, 'locator' => $item['locator']];
+
+                continue;
+            }
+            if (self::hasExactKeys($item, ['page_id', 'page_number', 'processing_unit_id', 'source_version', 'coordinate_space'])) {
+                $normalized[] = ['key' => $key, 'locator' => $item];
+
+                continue;
+            }
+
+            throw new VisionContractException('invalid_evidence');
         }
 
         return $normalized;

--- a/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
+++ b/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
@@ -172,6 +172,28 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
     }
 
     #[Test]
+    public function it_accepts_evidence_keyed_by_reference_with_inline_locator_fields_from_the_provider(): void
+    {
+        Http::fake(['*' => Http::response($this->response([
+            'evidence' => [
+                'page-1' => [
+                    'page_id' => 17,
+                    'page_number' => 2,
+                    'processing_unit_id' => 19,
+                    'source_version' => 'sha256:'.str_repeat('a', 64),
+                    'coordinate_space' => 'normalized_derivative_v1',
+                ],
+            ],
+        ]))]);
+
+        $analysis = $this->provider()->analyze($this->input());
+
+        self::assertSame('page-1', $analysis->evidence[0]->key);
+        self::assertSame(17, $analysis->evidence[0]->locator['page_id']);
+        self::assertSame('page-1', $analysis->visualAttributes['roof_type']['evidence_ref']);
+    }
+
+    #[Test]
     #[DataProvider('maxElementCases')]
     public function effective_element_limit_is_rendered_hashed_and_enforced(int $maxElements): void
     {


### PR DESCRIPTION
## GlitchTip

- PROHELPER-BACKEND-9G / issue 335: http://5.129.220.32:8000/prohelper-backend/issues/335
- PROHELPER-BACKEND-9H / issue 336: http://5.129.220.32:8000/prohelper-backend/issues/336

## Root cause

Timeweb vision provider can return keyed `evidence` as an object where the evidence key points directly to locator fields (`page_id`, `page_number`, `processing_unit_id`, `source_version`, `coordinate_space`). `VisionAnalysisData::normalizeEvidencePayload()` accepted only keyed objects with a nested `locator`, so valid provider output failed with `VisionContractException: invalid_evidence`, then surfaced as `document_geometry_processing_failed` in `ProcessEstimateGenerationUnitJob`.

## Что изменено

- `VisionAnalysisData` now normalizes both supported keyed evidence forms while preserving exact-key validation.
- Added a regression test for the production payload shape from GlitchTip.

## Проверки

- `php -l app\BusinessModules\Addons\EstimateGeneration\Vision\DTO\VisionAnalysisData.php`
- `php -l tests\Unit\EstimateGeneration\Vision\TimewebVisionProviderTest.php`
- `.\vendor\bin\phpunit.bat tests\Unit\EstimateGeneration\Vision\TimewebVisionProviderTest.php --filter=it_accepts_evidence_keyed_by_reference_with_inline_locator_fields_from_the_provider`
- `.\vendor\bin\phpunit.bat tests\Unit\EstimateGeneration\Vision\TimewebVisionProviderTest.php`
- `.\vendor\bin\phpstan.bat analyse app\BusinessModules\Addons\EstimateGeneration\Vision\DTO\VisionAnalysisData.php tests\Unit\EstimateGeneration\Vision\TimewebVisionProviderTest.php --memory-limit=1G`
- `git diff --check`

Note: `composer install --no-scripts --ignore-platform-req=ext-pcntl --ignore-platform-req=ext-posix` was run in the temporary worktree because ignored `vendor/` is not copied into git worktrees on Windows. Composer reported existing unrelated PSR-4 warnings.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated VisionAnalysisData::normalizeEvidencePayload to support a new evidence locator format containing page and coordinate metadata.</li>
<li>Added a new unit test case in TimewebVisionProviderTest to verify the provider correctly handles evidence with inline locator fields.</li>
</ul></div>