### PR TITLE
fix[backend]: исправлен порядок миграций и PostgreSQL-ограничения

### DIFF
--- a/database/migrations/2025_11_01_000011_increase_quantity_precision_in_estimate_items.php
+++ b/database/migrations/2025_11_01_000011_increase_quantity_precision_in_estimate_items.php
@@ -1,61 +1,52 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         if (DB::getDriverName() === 'sqlite') {
             return;
         }
 
-        // 1. В PostgreSQL нельзя менять тип колонки, если от нее зависит Materialized View.
         DB::statement('DROP MATERIALIZED VIEW IF EXISTS mv_normative_rates_usage CASCADE');
 
-        // 2. Очищаем данные от NULL, так как decimal колонки в сметах должны быть числовыми
         DB::table('estimate_items')->whereNull('quantity')->update(['quantity' => 0]);
         DB::table('estimate_items')->whereNull('unit_price')->update(['unit_price' => 0]);
         DB::table('estimate_items')->whereNull('current_unit_price')->update(['current_unit_price' => 0]);
 
-        Schema::table('estimate_items', function (Blueprint $table) {
-            // Расширяем до 8 знаков после запятой, чтобы ловить доли копеек из Гранд-Сметы
+        Schema::table('estimate_items', function (Blueprint $table): void {
             $table->decimal('quantity', 20, 8)->default(0)->change();
             $table->decimal('unit_price', 20, 4)->default(0)->change();
             $table->decimal('current_unit_price', 20, 4)->default(0)->change();
         });
 
-        // 3. Воссоздаем Materialized View mv_normative_rates_usage
-        DB::statement("
+        DB::statement(<<<'SQL'
             CREATE MATERIALIZED VIEW mv_normative_rates_usage AS
-            SELECT 
-                nr.id as rate_id,
+            SELECT
+                nr.id AS rate_id,
                 nr.collection_id,
                 nr.code,
                 nr.name,
-                COUNT(DISTINCT ei.estimate_id) as used_in_estimates,
-                COUNT(ei.id) as usage_count,
-                SUM(ei.quantity) as total_quantity,
-                MAX(ei.updated_at) as last_used_at
+                COUNT(DISTINCT ei.estimate_id) AS used_in_estimates,
+                COUNT(ei.id) AS usage_count,
+                SUM(ei.quantity) AS total_quantity,
+                MAX(ei.updated_at) AS last_used_at
             FROM normative_rates nr
             LEFT JOIN estimate_items ei ON ei.normative_rate_id = nr.id AND ei.deleted_at IS NULL
-            GROUP BY nr.id, nr.collection_id, nr.code, nr.name;
-        ");
+            GROUP BY nr.id, nr.collection_id, nr.code, nr.name
+            SQL);
 
-        // 4. Воссоздаем индексы для вьюхи
         DB::statement('CREATE UNIQUE INDEX IF NOT EXISTS mv_normative_rates_usage_rate_idx ON mv_normative_rates_usage(rate_id)');
         DB::statement('CREATE INDEX IF NOT EXISTS mv_normative_rates_usage_collection_idx ON mv_normative_rates_usage(collection_id, usage_count DESC)');
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         if (DB::getDriverName() === 'sqlite') {
@@ -64,27 +55,27 @@ return new class extends Migration
 
         DB::statement('DROP MATERIALIZED VIEW IF EXISTS mv_normative_rates_usage CASCADE');
 
-        Schema::table('estimate_items', function (Blueprint $table) {
+        Schema::table('estimate_items', function (Blueprint $table): void {
             $table->decimal('quantity', 18, 4)->change();
             $table->decimal('unit_price', 15, 2)->change();
             $table->decimal('current_unit_price', 15, 2)->change();
         });
 
-        DB::statement("
+        DB::statement(<<<'SQL'
             CREATE MATERIALIZED VIEW mv_normative_rates_usage AS
-            SELECT 
-                nr.id as rate_id,
+            SELECT
+                nr.id AS rate_id,
                 nr.collection_id,
                 nr.code,
                 nr.name,
-                COUNT(DISTINCT ei.estimate_id) as used_in_estimates,
-                COUNT(ei.id) as usage_count,
-                SUM(ei.quantity) as total_quantity,
-                MAX(ei.updated_at) as last_used_at
+                COUNT(DISTINCT ei.estimate_id) AS used_in_estimates,
+                COUNT(ei.id) AS usage_count,
+                SUM(ei.quantity) AS total_quantity,
+                MAX(ei.updated_at) AS last_used_at
             FROM normative_rates nr
             LEFT JOIN estimate_items ei ON ei.normative_rate_id = nr.id AND ei.deleted_at IS NULL
-            GROUP BY nr.id, nr.collection_id, nr.code, nr.name;
-        ");
+            GROUP BY nr.id, nr.collection_id, nr.code, nr.name
+            SQL);
 
         DB::statement('CREATE UNIQUE INDEX IF NOT EXISTS mv_normative_rates_usage_rate_idx ON mv_normative_rates_usage(rate_id)');
         DB::statement('CREATE INDEX IF NOT EXISTS mv_normative_rates_usage_collection_idx ON mv_normative_rates_usage(collection_id, usage_count DESC)');

--- a/database/migrations/2026_08_01_000001_create_report_saved_view_versions.php
+++ b/database/migrations/2026_08_01_000001_create_report_saved_view_versions.php
@@ -161,7 +161,7 @@ return new class extends Migration
             END;
             $$;
             SQL);
-        DB::statement(<<<'SQL'
+        DB::unprepared(<<<'SQL'
             ALTER TABLE report_saved_view_versions
                 ADD CONSTRAINT report_saved_view_versions_content_shape_check
                 CHECK (
@@ -186,7 +186,7 @@ return new class extends Migration
                     AND report_saved_view_version_columns_are_valid(content_json -> 'columns') IS TRUE
                 )
             SQL);
-        DB::statement(<<<'SQL'
+        DB::unprepared(<<<'SQL'
             ALTER TABLE report_saved_view_versions
                 ADD CONSTRAINT report_saved_view_versions_content_schema_binding_check
                 CHECK (
@@ -195,7 +195,7 @@ return new class extends Migration
                     AND ((content_json ->> 'schema_version') = presentation_schema_version::text) IS TRUE
                 )
             SQL);
-        DB::statement(<<<'SQL'
+        DB::unprepared(<<<'SQL'
             ALTER TABLE report_saved_view_versions
                 ADD CONSTRAINT report_saved_view_versions_content_code_binding_check
                 CHECK (
@@ -204,7 +204,7 @@ return new class extends Migration
                     AND ((content_json ->> 'report_code') = report_code) IS TRUE
                 )
             SQL);
-        DB::statement(<<<'SQL'
+        DB::unprepared(<<<'SQL'
             ALTER TABLE report_saved_view_versions
                 ADD CONSTRAINT report_saved_view_versions_content_contract_binding_check
                 CHECK (

--- a/database/migrations/2026_08_01_000020_create_report_publication_registry.php
+++ b/database/migrations/2026_08_01_000020_create_report_publication_registry.php
@@ -199,7 +199,7 @@ return new class extends Migration
                     AND ((candidate_definition_json -> 'readiness' ->> 'publication') = 'candidate') IS TRUE
                 )
             SQL);
-        DB::statement(<<<'SQL'
+        DB::unprepared(<<<'SQL'
             ALTER TABLE report_publications
                 ADD CONSTRAINT report_publications_proof_shape_check
                 CHECK (
@@ -235,7 +235,7 @@ return new class extends Migration
                     AND ((proof_json -> 'ci' ->> 'commit_sha') = release_git_sha) IS TRUE
                 )
             SQL);
-        DB::statement(<<<'SQL'
+        DB::unprepared(<<<'SQL'
             ALTER TABLE report_publications
                 ADD CONSTRAINT report_publications_release_artifact_shape_check
                 CHECK ((

--- a/tests/Unit/EstimateItemsPrecisionMigrationOrderTest.php
+++ b/tests/Unit/EstimateItemsPrecisionMigrationOrderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class EstimateItemsPrecisionMigrationOrderTest extends TestCase
+{
+    public function test_precision_migration_runs_after_estimate_item_columns_exist(): void
+    {
+        $directory = dirname(__DIR__, 2).'/database/migrations/';
+        $migration = $directory.'2025_11_01_000011_increase_quantity_precision_in_estimate_items.php';
+
+        self::assertFileExists($migration);
+        self::assertFileDoesNotExist(
+            $directory.'2024_02_22_000000_increase_quantity_precision_in_estimate_items.php',
+        );
+        foreach ([
+            '2025_10_21_120200_create_estimate_items_table.php',
+            '2025_10_21_184941_add_extended_price_columns_to_estimate_items_table.php',
+            '2025_11_01_000001_create_normative_bases_tables.php',
+            '2025_11_01_000003_extend_estimate_items_table.php',
+            '2025_11_01_000010_add_estimate_performance_indices.php',
+        ] as $prerequisite) {
+            self::assertLessThan(basename($migration), $prerequisite);
+        }
+        self::assertStringContainsString("Schema::table('estimate_items'", (string) file_get_contents($migration));
+        self::assertStringContainsString("current_unit_price", (string) file_get_contents($migration));
+    }
+}


### PR DESCRIPTION
Исправляет порядок миграции точности позиций сметы для чистой PostgreSQL-схемы и выполняет статические DDL с JSON-оператором ?& без PDO-подстановки параметров. Добавлен регрессионный тест порядка миграций.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored VisionAnalysisData DTO to enforce a stricter evidence contract, removing support for legacy inline locator fields.</li>
<li>Renamed and updated the database migration for increasing quantity precision in estimate items, ensuring it runs after necessary table creation.</li>
<li>Updated multiple database migrations to use DB::unprepared for complex SQL constraints, improving reliability.</li>
<li>Added a new unit test to verify the correct execution order of the estimate items precision migration.</li>
</ul></div>