### PR TITLE
fix[backend]: учтена схема журнала при backfill сметы

### DIFF
--- a/database/migrations/2026_04_29_000002_add_estimate_links_to_journal_materials_and_site_requests.php
+++ b/database/migrations/2026_04_29_000002_add_estimate_links_to_journal_materials_and_site_requests.php
@@ -85,9 +85,11 @@ return new class extends Migration
             });
         }
 
-        $this->backfillJournalMaterialEstimateItems();
-        $this->backfillJournalEquipmentEstimateItems();
-        $this->backfillJournalWorkerEstimateItems();
+        if (Schema::hasColumn('construction_journal_entries', 'estimate_id')) {
+            $this->backfillJournalMaterialEstimateItems();
+            $this->backfillJournalEquipmentEstimateItems();
+            $this->backfillJournalWorkerEstimateItems();
+        }
 
         Schema::table('journal_materials', function (Blueprint $table): void {
             $table->index('estimate_item_id', 'journal_materials_estimate_item_idx');


### PR DESCRIPTION
Пропускает data-backfill связи со сметой, пока у construction_journal_entries отсутствует estimate_id в чистой исторической схеме.