### PR TITLE
fix: совместимость миграций Site Requests

### DIFF
--- a/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000032_create_site_request_statuses_table.php
+++ b/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000032_create_site_request_statuses_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('site_request_statuses')) {
+            return;
+        }
+
         Schema::create('site_request_statuses', function (Blueprint $table) {
             $table->id();
 
@@ -66,4 +70,3 @@ return new class extends Migration
         Schema::dropIfExists('site_request_statuses');
     }
 };
-

--- a/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000033_create_site_request_status_transitions_table.php
+++ b/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000033_create_site_request_status_transitions_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('site_request_status_transitions')) {
+            return;
+        }
+
         Schema::create('site_request_status_transitions', function (Blueprint $table) {
             $table->id();
 
@@ -60,4 +64,3 @@ return new class extends Migration
         Schema::dropIfExists('site_request_status_transitions');
     }
 };
-

--- a/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000034_create_site_request_templates_table.php
+++ b/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000034_create_site_request_templates_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('site_request_templates')) {
+            return;
+        }
+
         Schema::create('site_request_templates', function (Blueprint $table) {
             $table->id();
 
@@ -63,4 +67,3 @@ return new class extends Migration
         Schema::dropIfExists('site_request_templates');
     }
 };
-

--- a/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000035_create_site_request_history_table.php
+++ b/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000035_create_site_request_history_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('site_request_history')) {
+            return;
+        }
+
         Schema::create('site_request_history', function (Blueprint $table) {
             $table->id();
 
@@ -57,4 +61,3 @@ return new class extends Migration
         Schema::dropIfExists('site_request_history');
     }
 };
-

--- a/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000036_create_site_request_calendar_events_table.php
+++ b/app/BusinessModules/Features/SiteRequests/migrations/2025_01_01_000036_create_site_request_calendar_events_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('site_request_calendar_events')) {
+            return;
+        }
+
         Schema::create('site_request_calendar_events', function (Blueprint $table) {
             $table->id();
 
@@ -83,4 +87,3 @@ return new class extends Migration
         Schema::dropIfExists('site_request_calendar_events');
     }
 };
-

--- a/app/BusinessModules/Features/SiteRequests/migrations/2025_11_21_000003_add_payment_document_id_to_site_requests.php
+++ b/app/BusinessModules/Features/SiteRequests/migrations/2025_11_21_000003_add_payment_document_id_to_site_requests.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasColumn('site_requests', 'payment_document_id')) {
+            return;
+        }
+
         Schema::table('site_requests', function (Blueprint $table) {
             $table->foreignId('payment_document_id')
                 ->nullable()
@@ -35,4 +39,3 @@ return new class extends Migration
         });
     }
 };
-

--- a/database/migrations/2025_11_21_000004_create_payment_document_estimate_splits_table.php
+++ b/database/migrations/2025_11_21_000004_create_payment_document_estimate_splits_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('payment_document_estimate_splits')) {
+            return;
+        }
+
         Schema::create('payment_document_estimate_splits', function (Blueprint $table) {
             $table->id();
             $table->foreignId('payment_document_id')
@@ -42,4 +46,3 @@ return new class extends Migration
         Schema::dropIfExists('payment_document_estimate_splits');
     }
 };
-

--- a/tests/Unit/SiteRequestsMigrationOrderTest.php
+++ b/tests/Unit/SiteRequestsMigrationOrderTest.php
@@ -43,4 +43,29 @@ final class SiteRequestsMigrationOrderTest extends TestCase
             '2025_11_21_000002_create_payment_documents_table.php',
         );
     }
+
+    public function test_renamed_migrations_do_not_recreate_existing_production_schema(): void
+    {
+        $migrations = [
+            '2025_01_01_000032_create_site_request_statuses_table.php' => "Schema::hasTable('site_request_statuses')",
+            '2025_01_01_000033_create_site_request_status_transitions_table.php' => "Schema::hasTable('site_request_status_transitions')",
+            '2025_01_01_000034_create_site_request_templates_table.php' => "Schema::hasTable('site_request_templates')",
+            '2025_01_01_000035_create_site_request_history_table.php' => "Schema::hasTable('site_request_history')",
+            '2025_01_01_000036_create_site_request_calendar_events_table.php' => "Schema::hasTable('site_request_calendar_events')",
+            '2025_11_21_000003_add_payment_document_id_to_site_requests.php' => "Schema::hasColumn('site_requests', 'payment_document_id')",
+        ];
+
+        $directory = dirname(__DIR__, 2).'/app/BusinessModules/Features/SiteRequests/migrations/';
+
+        foreach ($migrations as $migration => $guard) {
+            self::assertStringContainsString($guard, (string) file_get_contents($directory.$migration));
+        }
+
+        self::assertStringContainsString(
+            "Schema::hasTable('payment_document_estimate_splits')",
+            (string) file_get_contents(
+                dirname(__DIR__, 2).'/database/migrations/2025_11_21_000004_create_payment_document_estimate_splits_table.php',
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Переименованные миграции Site Requests и разбиения платёжных документов теперь безопасно пропускают уже существующую production-схему и сохраняют создание на чистой базе. Добавлена статическая регрессия.