### PR TITLE
fix: порядок ключей журнала закупок

### DIFF
--- a/app/BusinessModules/Features/Procurement/migrations/2026_08_01_000002_create_procurement_award_source.php
+++ b/app/BusinessModules/Features/Procurement/migrations/2026_08_01_000002_create_procurement_award_source.php
@@ -39,7 +39,7 @@ return new class extends Migration
         });
 
         Schema::create('procurement_award_evidence_events', function (Blueprint $table): void {
-            $table->uuid('id')->primary();
+            $table->uuid('id');
             $table->foreignId('organization_id')->constrained('organizations')->restrictOnDelete();
             $table->foreignId('project_id')->nullable()->constrained('projects')->restrictOnDelete();
             $table->foreignId('purchase_request_id')->constrained('purchase_requests')->restrictOnDelete();
@@ -76,6 +76,7 @@ return new class extends Migration
             $table->foreignId('purchase_order_id')->nullable()->constrained('purchase_orders')->restrictOnDelete();
             $table->timestampTz('created_at', 6);
 
+            $table->primary('id', 'proc_award_evidence_events_pk');
             $table->foreign('predecessor_event_id', 'proc_award_event_predecessor_fk')
                 ->references('id')
                 ->on('procurement_award_evidence_events')

--- a/tests/Unit/Procurement/Reporting/Award/ProcurementAwardMigrationContractTest.php
+++ b/tests/Unit/Procurement/Reporting/Award/ProcurementAwardMigrationContractTest.php
@@ -56,6 +56,17 @@ final class ProcurementAwardMigrationContractTest extends TestCase
         self::assertStringNotContainsString('cursor()', $migration);
     }
 
+    public function test_event_primary_key_is_registered_before_its_self_referencing_foreign_key(): void
+    {
+        $migration = $this->migration();
+
+        self::assertStringContainsString("\$table->primary('id', 'proc_award_evidence_events_pk')", $migration);
+        self::assertLessThan(
+            strpos($migration, "\$table->foreign('predecessor_event_id'"),
+            strpos($migration, "\$table->primary('id', 'proc_award_evidence_events_pk')"),
+        );
+    }
+
     private function migration(): string
     {
         $source = file_get_contents(


### PR DESCRIPTION
Первичный ключ журнала событий закупок теперь регистрируется до самоссылочного внешнего ключа PostgreSQL. Добавлена статическая регрессия порядка.