### PR TITLE
fix: ключи готовности и rollback публикаций

### DIFF
--- a/app/BusinessModules/Features/ScheduleManagement/migrations/2026_08_01_000040_create_lookahead_readiness_source.php
+++ b/app/BusinessModules/Features/ScheduleManagement/migrations/2026_08_01_000040_create_lookahead_readiness_source.php
@@ -190,7 +190,7 @@ return new class extends Migration
         });
 
         Schema::create('lookahead_readiness_events', function (Blueprint $table): void {
-            $table->uuid('event_id')->primary();
+            $table->uuid('event_id');
             $table->unsignedBigInteger('organization_id');
             $table->unsignedBigInteger('project_id');
             $table->unsignedBigInteger('schedule_id');
@@ -210,6 +210,7 @@ return new class extends Migration
             $table->char('schedule_revision_hash', 64);
             $table->timestampTz('created_at');
 
+            $table->primary('event_id', 'lookahead_readiness_events_pk');
             $table->unique(['organization_id', 'idempotency_key'], 'lookahead_event_idempotency_unique');
             $table->index(['organization_id', 'project_id', 'schedule_id', 'occurred_at', 'event_id'], 'lookahead_event_cursor_idx');
             $table->index(['commitment_task_id', 'occurred_at', 'event_id'], 'lookahead_event_task_cursor_idx');

--- a/database/migrations/2026_08_01_000020_create_report_publication_registry.php
+++ b/database/migrations/2026_08_01_000020_create_report_publication_registry.php
@@ -1085,8 +1085,6 @@ return new class extends Migration
             END;
             $$;
             SQL);
-        DB::statement('SET ROLE most_report_publication_owner');
-
         try {
             DB::statement('DROP FUNCTION IF EXISTS report_publication_mark_outbox_delivered(text, timestamptz)');
             DB::statement('DROP FUNCTION IF EXISTS report_publication_configure_feature(text, text, text, text, jsonb, jsonb)');
@@ -1114,7 +1112,6 @@ return new class extends Migration
             DB::statement('DROP FUNCTION IF EXISTS report_publication_positive_unique_ids(jsonb)');
             DB::statement('DROP FUNCTION IF EXISTS report_publication_release_checks_match(jsonb, jsonb)');
         } finally {
-            DB::statement('RESET ROLE');
             DB::unprepared(<<<'SQL'
                 DO $$
                 BEGIN


### PR DESCRIPTION
Первичный ключ событий готовности регистрируется до самоссылочной связи; rollback реестра публикаций не переключается на роль без владения объектами.