### PR TITLE
fix[reports]: учитывать wildcard-права в авторизации

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Access/LaravelCurrentReportAbacEvaluator.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Access/LaravelCurrentReportAbacEvaluator.php
@@ -11,6 +11,7 @@ use App\Domain\Authorization\Enums\ConditionType;
 use App\Domain\Authorization\Models\OrganizationCustomRole;
 use App\Domain\Authorization\Models\RoleCondition;
 use App\Domain\Authorization\Models\UserRoleAssignment;
+use App\Domain\Authorization\ValueObjects\PermissionSet;
 use DateTimeImmutable;
 use Illuminate\Support\Facades\DB;
 use Throwable;
@@ -100,18 +101,7 @@ final class LaravelCurrentReportAbacEvaluator implements CurrentReportAbacEvalua
             if (! is_array($decoded)) {
                 continue;
             }
-            $permissions = $decoded['system_permissions'] ?? [];
-            foreach (($decoded['module_permissions'] ?? []) as $module => $modulePermissions) {
-                if (! is_string($module) || ! is_array($modulePermissions)) {
-                    continue;
-                }
-                foreach ($modulePermissions as $modulePermission) {
-                    if (is_string($modulePermission)) {
-                        $permissions[] = $module.'.'.$modulePermission;
-                    }
-                }
-            }
-            if (in_array($permission, $permissions, true)) {
+            if (PermissionSet::fromJsonRole($decoded)->hasPermission($permission)) {
                 return true;
             }
         }

--- a/tests/Feature/Reporting/Access/LaravelCurrentReportAbacEvaluatorTest.php
+++ b/tests/Feature/Reporting/Access/LaravelCurrentReportAbacEvaluatorTest.php
@@ -53,6 +53,22 @@ final class LaravelCurrentReportAbacEvaluatorTest extends TestCase
         ));
     }
 
+    public function test_system_role_wildcard_grants_reporting_permission(): void
+    {
+        $assignment = new UserRoleAssignment([
+            'role_slug' => 'web_admin',
+            'role_type' => UserRoleAssignment::TYPE_SYSTEM,
+        ]);
+        $method = new ReflectionMethod(LaravelCurrentReportAbacEvaluator::class, 'roleGrants');
+
+        self::assertTrue($method->invoke(
+            new LaravelCurrentReportAbacEvaluator,
+            $assignment,
+            'reports.view',
+            1,
+        ));
+    }
+
     public static function malformedTimeConditions(): array
     {
         return [


### PR DESCRIPTION
Исправляет проверку системных ролей в новом контуре отчетов: wildcard-права из определений ролей, включая reports.*, теперь корректно применяются при проверке reports.view и связанных операций. Добавлен регрессионный тест для web_admin.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored permission evaluation in LaravelCurrentReportAbacEvaluator to use the PermissionSet value object instead of manual array parsing.</li>
<li>Added a new feature test to verify that system roles with wildcard permissions correctly grant reporting access.</li>
</ul></div>