### PR TITLE
fix[reports]: восстановить доступ и контракт ошибок

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Access/LaravelCurrentReportAbacEvaluator.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Access/LaravelCurrentReportAbacEvaluator.php
@@ -101,12 +101,40 @@ final class LaravelCurrentReportAbacEvaluator implements CurrentReportAbacEvalua
             if (! is_array($decoded)) {
                 continue;
             }
-            if (PermissionSet::fromJsonRole($decoded)->hasPermission($permission)) {
+            if ($this->systemRoleGrants($decoded, $permission)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function systemRoleGrants(array $role, string $permission): bool
+    {
+        $permissions = [];
+        foreach ($role['system_permissions'] ?? [] as $systemPermission) {
+            if (is_string($systemPermission)) {
+                $permissions[] = $systemPermission;
+            }
+        }
+
+        foreach ($role['module_permissions'] ?? [] as $module => $modulePermissions) {
+            if (! is_string($module) || ! is_array($modulePermissions)) {
+                continue;
+            }
+
+            foreach ($modulePermissions as $modulePermission) {
+                if (! is_string($modulePermission)) {
+                    continue;
+                }
+
+                $permissions[] = $modulePermission === '*' || str_starts_with($modulePermission, $module.'.')
+                    ? ($modulePermission === '*' ? $module.'.*' : $modulePermission)
+                    : $module.'.'.$modulePermission;
+            }
+        }
+
+        return (new PermissionSet($permissions))->hasSystemPermission($permission);
     }
 
     private function conditionsPass(array $conditions, int $actorId, DateTimeImmutable $occurredAt): bool

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use App\Http\Middleware\JwtMiddleware;
 use App\Http\Middleware\SetOrganizationContext;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorResponseFactory;
 use App\Services\Logging\SafeLogWriter;
+use App\Services\Logging\Context\RequestContext;
 use App\Services\Monitoring\GlitchTipReportPolicy;
 use App\Services\Monitoring\SentryScopeService;
 use Illuminate\Foundation\Application;
@@ -175,6 +178,17 @@ $app = Application::configure(basePath: dirname(__DIR__))
             $responseClass = $responseClassForRequest($request);
 
             return $responseClass::error($message, $exception->status, $errors);
+        });
+
+        $exceptions->render(function (ReportContractException $exception, Request $request) {
+            if (! str_starts_with($request->path(), 'api/v1/admin/reports/')) {
+                return null;
+            }
+
+            return app(ReportErrorResponseFactory::class)->make(
+                $exception,
+                app(RequestContext::class)->getCorrelationId(),
+            );
         });
 
         // Ошибки авторизации -> logs/auth/auth.log

--- a/tests/Feature/Reporting/Access/LaravelCurrentReportAbacEvaluatorTest.php
+++ b/tests/Feature/Reporting/Access/LaravelCurrentReportAbacEvaluatorTest.php
@@ -69,6 +69,22 @@ final class LaravelCurrentReportAbacEvaluatorTest extends TestCase
         ));
     }
 
+    public function test_system_role_wildcard_uses_fully_qualified_module_permission(): void
+    {
+        $assignment = new UserRoleAssignment([
+            'role_slug' => 'web_admin',
+            'role_type' => UserRoleAssignment::TYPE_SYSTEM,
+        ]);
+        $method = new ReflectionMethod(LaravelCurrentReportAbacEvaluator::class, 'roleGrants');
+
+        self::assertTrue($method->invoke(
+            new LaravelCurrentReportAbacEvaluator,
+            $assignment,
+            'reports.run',
+            1,
+        ));
+    }
+
     public static function malformedTimeConditions(): array
     {
         return [

--- a/tests/Unit/Reporting/Errors/ReportContractExceptionFallbackTest.php
+++ b/tests/Unit/Reporting/Errors/ReportContractExceptionFallbackTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Errors;
+
+use PHPUnit\Framework\TestCase;
+
+final class ReportContractExceptionFallbackTest extends TestCase
+{
+    public function test_reporting_contract_exception_has_global_admin_api_fallback(): void
+    {
+        $bootstrap = file_get_contents(dirname(__DIR__, 4).'/bootstrap/app.php');
+
+        self::assertIsString($bootstrap);
+        self::assertStringContainsString('function (ReportContractException $exception, Request $request)', $bootstrap);
+        self::assertStringContainsString("str_starts_with(\$request->path(), 'api/v1/admin/reports/')", $bootstrap);
+        self::assertStringContainsString('app(ReportErrorResponseFactory::class)->make(', $bootstrap);
+    }
+}


### PR DESCRIPTION
Исправляет разбор квалифицированных wildcard-прав в системных ролях для нового контура отчетов и добавляет центральный JSON fallback для ReportContractException на admin API отчетов. Добавлены регрессионные тесты.