### PR TITLE
fix[backend]: исправить триггер потока дефектов

### DIFF
--- a/app/BusinessModules/Features/QualityControl/migrations/2026_08_01_000020_create_quality_defect_flow_source.php
+++ b/app/BusinessModules/Features/QualityControl/migrations/2026_08_01_000020_create_quality_defect_flow_source.php
@@ -675,9 +675,12 @@ SQL);
         DB::unprepared(<<<'SQL'
 CREATE OR REPLACE FUNCTION quality_defect_flow_reject_lineage_retarget()
 RETURNS trigger AS $$
+DECLARE
+    new_row jsonb := to_jsonb(NEW);
+    old_row jsonb := to_jsonb(OLD);
 BEGIN
     IF TG_TABLE_NAME = 'quality_defects' THEN
-        IF NEW.organization_id <> OLD.organization_id
+        IF new_row->>'organization_id' <> old_row->>'organization_id'
            AND (
                 EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE quality_defect_id = OLD.id)
                 OR EXISTS (SELECT 1 FROM quality_defect_flow_gaps WHERE quality_defect_id = OLD.id)
@@ -685,29 +688,29 @@ BEGIN
             RAISE EXCEPTION 'quality defect flow defect organization cannot be retargeted' USING ERRCODE = '55000';
         END IF;
 
-        IF NEW.project_id <> OLD.project_id
+        IF new_row->>'project_id' <> old_row->>'project_id'
            AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE quality_defect_id = OLD.id) THEN
             RAISE EXCEPTION 'quality defect flow defect project cannot be retargeted' USING ERRCODE = '55000';
         END IF;
     ELSIF TG_TABLE_NAME = 'projects'
-       AND NEW.organization_id <> OLD.organization_id
+       AND new_row->>'organization_id' <> old_row->>'organization_id'
        AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE project_id = OLD.id) THEN
         RAISE EXCEPTION 'quality defect flow project organization cannot be retargeted' USING ERRCODE = '55000';
     ELSIF TG_TABLE_NAME = 'contractors'
-       AND NEW.organization_id <> OLD.organization_id
+       AND new_row->>'organization_id' <> old_row->>'organization_id'
        AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE contractor_id = OLD.id) THEN
         RAISE EXCEPTION 'quality defect flow contractor organization cannot be retargeted' USING ERRCODE = '55000';
     ELSIF TG_TABLE_NAME = 'schedule_tasks'
        AND (
-            NEW.organization_id <> OLD.organization_id
-            OR NEW.schedule_id <> OLD.schedule_id
+            new_row->>'organization_id' <> old_row->>'organization_id'
+            OR new_row->>'schedule_id' <> old_row->>'schedule_id'
        )
        AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE schedule_task_id = OLD.id) THEN
         RAISE EXCEPTION 'quality defect flow schedule task cannot be retargeted' USING ERRCODE = '55000';
     ELSIF TG_TABLE_NAME = 'project_schedules'
        AND (
-            NEW.organization_id <> OLD.organization_id
-            OR NEW.project_id <> OLD.project_id
+            new_row->>'organization_id' <> old_row->>'organization_id'
+            OR new_row->>'project_id' <> old_row->>'project_id'
        )
        AND EXISTS (
             SELECT 1

--- a/app/BusinessModules/Features/QualityControl/migrations/2026_08_02_000021_fix_quality_defect_flow_lineage_trigger.php
+++ b/app/BusinessModules/Features/QualityControl/migrations/2026_08_02_000021_fix_quality_defect_flow_lineage_trigger.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::unprepared(<<<'SQL'
+CREATE OR REPLACE FUNCTION quality_defect_flow_reject_lineage_retarget()
+RETURNS trigger AS $$
+DECLARE
+    new_row jsonb := to_jsonb(NEW);
+    old_row jsonb := to_jsonb(OLD);
+BEGIN
+    IF TG_TABLE_NAME = 'quality_defects' THEN
+        IF new_row->>'organization_id' <> old_row->>'organization_id'
+           AND (
+                EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE quality_defect_id = OLD.id)
+                OR EXISTS (SELECT 1 FROM quality_defect_flow_gaps WHERE quality_defect_id = OLD.id)
+           ) THEN
+            RAISE EXCEPTION 'quality defect flow defect organization cannot be retargeted' USING ERRCODE = '55000';
+        END IF;
+
+        IF new_row->>'project_id' <> old_row->>'project_id'
+           AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE quality_defect_id = OLD.id) THEN
+            RAISE EXCEPTION 'quality defect flow defect project cannot be retargeted' USING ERRCODE = '55000';
+        END IF;
+    ELSIF TG_TABLE_NAME = 'projects'
+       AND new_row->>'organization_id' <> old_row->>'organization_id'
+       AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE project_id = OLD.id) THEN
+        RAISE EXCEPTION 'quality defect flow project organization cannot be retargeted' USING ERRCODE = '55000';
+    ELSIF TG_TABLE_NAME = 'contractors'
+       AND new_row->>'organization_id' <> old_row->>'organization_id'
+       AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE contractor_id = OLD.id) THEN
+        RAISE EXCEPTION 'quality defect flow contractor organization cannot be retargeted' USING ERRCODE = '55000';
+    ELSIF TG_TABLE_NAME = 'schedule_tasks'
+       AND (
+            new_row->>'organization_id' <> old_row->>'organization_id'
+            OR new_row->>'schedule_id' <> old_row->>'schedule_id'
+       )
+       AND EXISTS (SELECT 1 FROM quality_defect_flow_events WHERE schedule_task_id = OLD.id) THEN
+        RAISE EXCEPTION 'quality defect flow schedule task cannot be retargeted' USING ERRCODE = '55000';
+    ELSIF TG_TABLE_NAME = 'project_schedules'
+       AND (
+            new_row->>'organization_id' <> old_row->>'organization_id'
+            OR new_row->>'project_id' <> old_row->>'project_id'
+       )
+       AND EXISTS (
+            SELECT 1
+            FROM quality_defect_flow_events
+            INNER JOIN schedule_tasks ON schedule_tasks.id = quality_defect_flow_events.schedule_task_id
+            WHERE schedule_tasks.schedule_id = OLD.id
+       ) THEN
+        RAISE EXCEPTION 'quality defect flow project schedule cannot be retargeted' USING ERRCODE = '55000';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+SQL);
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/tests/Feature/QualityControl/Reporting/DefectFlow/QualityDefectFlowSourcePostgresTest.php
+++ b/tests/Feature/QualityControl/Reporting/DefectFlow/QualityDefectFlowSourcePostgresTest.php
@@ -766,6 +766,24 @@ final class QualityDefectFlowSourcePostgresTest extends TestCase
             ->value('status'));
     }
 
+    public function test_contractors_can_update_sync_timestamp_without_schedule_task_columns(): void
+    {
+        [$organization] = $this->identityFixture();
+        $contractorId = DB::table('contractors')->insertGetId([
+            'organization_id' => $organization->id,
+            'name' => 'Synchronization contractor',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('contractors')->where('id', $contractorId)->update([
+            'last_sync_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        self::assertNotNull(DB::table('contractors')->where('id', $contractorId)->value('last_sync_at'));
+    }
+
     public function test_append_only_source_supports_bounded_keyset_order_at_project_scale(): void
     {
         [$organization, $project, $actor] = $this->identityFixture();


### PR DESCRIPTION
## GlitchTip

- PROHELPER-BACKEND-FI / issue 529: http://5.129.220.32:8000/prohelper-backend/issues/529

## Причина

Одна PostgreSQL-функция триггера была назначена таблицам с разными наборами колонок. При обновлении `contractors` PostgreSQL обращался к отсутствующему у неё `NEW.schedule_id`, поэтому фоновая синхронизация приглашённых подрядчиков завершалась ошибкой.

## Изменения

- обращения к колонкам триггерной записи переведены на JSON-представление записи;
- добавлена миграция для исправления уже развёрнутых баз;
- добавлен PostgreSQL-регрессионный сценарий обновления `last_sync_at` у подрядчика.

## Проверки

- `php -l` для обеих миграций и теста — успешно;
- `git diff --check` — успешно;
- PHPStan и интеграционный PostgreSQL-тест не запускались: в изолированном worktree отсутствует `vendor`, а локальные подключения к БД запрещены правилами проекта.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored PostgreSQL trigger 'quality_defect_flow_reject_lineage_retarget' to use JSONB conversion for row comparisons, preventing false positive retargeting exceptions.</li>
<li>Added a new migration to apply the updated trigger logic.</li>
<li>Added a feature test to verify that contractor records can be updated (e.g., 'last_sync_at') without triggering lineage retargeting exceptions.</li>
</ul></div>