### PR TITLE
fix: защищён проектный запуск план-факт отчёта

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/BudgetPlanFactReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/BudgetPlanFactReportOptionsController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Features\Budgeting\Services\BudgetPlanFactReportOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final readonly class BudgetPlanFactReportOptionsController
+{
+    public function __construct(private BudgetPlanFactReportOptionsService $options) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $organization = $request->attributes->get('current_organization');
+
+        return AdminResponse::success([
+            'closures' => $this->options->availableClosures((int) $organization->id),
+        ]);
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/BindProjectReportScope.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/BindProjectReportScope.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Middleware;
+
+use App\Http\Responses\AdminResponse;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class BindProjectReportScope
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $filters = $request->input('filters');
+        if (! is_array($filters)) {
+            return $next($request);
+        }
+
+        if (array_key_exists('organization_id', $filters) || array_key_exists('project_id', $filters)) {
+            return AdminResponse::error(
+                trans_message('reports.errors.report_request_invalid'),
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
+        }
+
+        $project = $request->attributes->get('project');
+        $organization = $request->attributes->get('current_organization');
+        if ($project === null || $organization === null) {
+            return AdminResponse::error(
+                trans_message('reports.errors.report_request_invalid'),
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
+        }
+
+        $request->merge([
+            'filters' => [
+                ...$filters,
+                'organization_id' => (string) $organization->id,
+                'project_id' => (string) $project->id,
+            ],
+        ]);
+
+        return $next($request);
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMatrix;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportCatalogController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportDrillDownController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportExportController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportRowsController;
@@ -78,6 +79,14 @@ Route::prefix('api/v1/admin/reports')
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');
+        Route::post('/projects/{project}/budget-plan-fact/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'budget_plan_fact')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('project-budget-plan-fact.runs.store');
+        Route::get('/projects/{project}/budget-plan-fact/options', BudgetPlanFactReportOptionsController::class)
+            ->defaults('reportCode', 'budget_plan_fact')
+            ->middleware(['project.context', $resourceAccess])
+            ->name('project-budget-plan-fact.options');
         Route::get('/runs/{runId}', [ReportRunController::class, 'show'])
             ->middleware($resourceAccess)
             ->name('runs.show');

--- a/app/BusinessModules/Features/Budgeting/Services/BudgetPlanFactReportOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Services/BudgetPlanFactReportOptionsService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Services;
+
+use App\BusinessModules\Features\Budgeting\Enums\BudgetingReportSourceCloseStatus;
+use App\BusinessModules\Features\Budgeting\Models\BudgetingReportSourceCloseRecord;
+
+final class BudgetPlanFactReportOptionsService
+{
+    /** @return list<array{value:string,label:string,period_start:string,period_end:string,scenario_uuid:string,budget_version_uuid:string}> */
+    public function availableClosures(int $organizationId): array
+    {
+        return BudgetingReportSourceCloseRecord::query()
+            ->where('organization_id', $organizationId)
+            ->where('status', BudgetingReportSourceCloseStatus::APPROVED->value)
+            ->where('retained_until', '>', now())
+            ->orderByDesc('period_end')
+            ->orderByDesc('approved_at')
+            ->get(['close_id', 'period_start', 'period_end', 'scenario_identity', 'plan_identity'])
+            ->map(static fn (BudgetingReportSourceCloseRecord $close): array => [
+                'value' => (string) $close->close_id,
+                'label' => sprintf('Период %s — %s', $close->period_start->format('d.m.Y'), $close->period_end->format('d.m.Y')),
+                'period_start' => $close->period_start->format('Y-m-d'),
+                'period_end' => $close->period_end->format('Y-m-d'),
+                'scenario_uuid' => (string) $close->scenario_identity,
+                'budget_version_uuid' => (string) $close->plan_identity,
+            ])
+            ->all();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -54,6 +54,7 @@ $app = Application::configure(basePath: dirname(__DIR__))
             'organization.context' => SetOrganizationContext::class,
             'organization_context' => SetOrganizationContext::class,
             'project.context' => \App\Http\Middleware\ProjectContextMiddleware::class,
+            'report.project-scope' => \App\BusinessModules\Core\Reporting\Http\Admin\Middleware\BindProjectReportScope::class,
 
             // Дополнительные middleware
             'request.dedup' => \App\Http\Middleware\RequestDedupMiddleware::class,

--- a/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
+++ b/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
@@ -9,8 +9,11 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\CreateReportRunRequest;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\GetReportCatalogRequest;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ReportFormRequest;
+use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\BindProjectReportScope;
 use App\Domain\Authorization\Http\Middleware\InterfaceMiddleware;
 use App\Domain\Authorization\Services\AuthorizationService;
+use App\Models\Organization;
+use App\Models\Project;
 use App\Models\User;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
@@ -84,6 +87,43 @@ final class ReportInterfaceMiddlewareContractTest extends TestCase
 
         self::assertSame(ReportErrorCode::REPORT_REQUEST_INVALID, $exception->errorCode);
         self::assertSame([], $exception->safeFields);
+    }
+
+    public function test_project_report_scope_rejects_client_supplied_organization_or_project(): void
+    {
+        $request = $this->reportRequest(
+            CreateReportRunRequest::class,
+            'POST',
+            [],
+            [...self::validRunBody(), 'filters' => ['organization_id' => '99']],
+        );
+
+        $response = (new BindProjectReportScope)->handle($request, static fn (): Response => new Response(status: 204));
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_project_report_scope_binds_ids_only_from_verified_request_context(): void
+    {
+        $request = $this->reportRequest(CreateReportRunRequest::class, 'POST', [], self::validRunBody());
+        $project = new Project;
+        $project->id = 17;
+        $organization = new Organization;
+        $organization->id = 23;
+        $request->attributes->set('project', $project);
+        $request->attributes->set('current_organization', $organization);
+
+        $response = (new BindProjectReportScope)->handle(
+            $request,
+            static function (CreateReportRunRequest $request): Response {
+                self::assertSame('17', $request->input('filters.project_id'));
+                self::assertSame('23', $request->input('filters.organization_id'));
+
+                return new Response(status: 204);
+            },
+        );
+
+        self::assertSame(204, $response->getStatusCode());
     }
 
     public function test_client_query_interface_is_rejected_after_middleware_overwrites_legacy_input(): void


### PR DESCRIPTION
## Изменения\n- отдельный маршрут отчёта в контексте проекта\n- отклонение client-side organization_id и project_id\n- серверное связывание области отчёта\n- список закрытых периодов без отображения внутренних идентификаторов\n\n## Проверки\n- php -l изменённых файлов\n- git diff --check\n- целевой тест не запущен: в worktree отсутствует vendor/autoload.php

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented a new middleware 'BindProjectReportScope' to enforce project and organization context in report requests.</li>
<li>Added 'BudgetPlanFactReportOptionsController' and 'BudgetPlanFactReportOptionsService' to fetch available report closures.</li>
<li>Registered new routes for budget plan fact report runs and options, applying the new middleware.</li>
<li>Added unit tests to verify the middleware correctly rejects invalid client-supplied IDs and binds correct context.</li>
</ul></div>