### PR TITLE
fix[backend]: восстановлена provenance единиц обработки

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_03_000100_backfill_document_unit_provenance.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_03_000100_backfill_document_unit_provenance.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::unprepared(<<<'SQL'
+ALTER TABLE estimate_generation_processing_units
+    DROP CONSTRAINT IF EXISTS eg_units_locator_provenance_ck;
+
+UPDATE estimate_generation_processing_units
+SET locator = locator || jsonb_build_object(
+    'source_kind', CASE unit_type
+        WHEN 'pdf_page' THEN 'pdf'
+        WHEN 'spreadsheet_sheet' THEN 'spreadsheet'
+        WHEN 'raster_image' THEN 'image'
+        WHEN 'sketch' THEN 'image'
+        WHEN 'cad_drawing' THEN 'cad'
+        WHEN 'text_page' THEN 'text'
+    END,
+    'source_version', source_version,
+    'coordinate_space', CASE unit_type
+        WHEN 'pdf_page' THEN 'pdf_page_pixels'
+        WHEN 'spreadsheet_sheet' THEN 'spreadsheet_cells'
+        WHEN 'raster_image' THEN 'image_pixels'
+        WHEN 'sketch' THEN 'image_pixels'
+        WHEN 'cad_drawing' THEN 'cad_model'
+        WHEN 'text_page' THEN 'text_offsets'
+    END
+)
+WHERE NOT (locator ?& ARRAY['source_kind', 'source_version', 'coordinate_space']);
+
+ALTER TABLE estimate_generation_processing_units
+    ADD CONSTRAINT eg_units_locator_provenance_ck
+    CHECK (
+        locator ?& ARRAY['source_kind', 'source_version', 'coordinate_space', 'artifact_path', 'artifact_sha256', 'artifact_version_id']
+        AND jsonb_typeof(locator->'source_kind') = 'string'
+        AND jsonb_typeof(locator->'source_version') = 'string'
+        AND jsonb_typeof(locator->'coordinate_space') = 'string'
+        AND jsonb_typeof(locator->'artifact_path') = 'string'
+        AND jsonb_typeof(locator->'artifact_sha256') = 'string'
+        AND jsonb_typeof(locator->'artifact_version_id') = 'string'
+        AND (
+            (unit_type = 'pdf_page' AND locator->>'source_kind' = 'pdf' AND locator->>'coordinate_space' = 'pdf_page_pixels')
+            OR (unit_type = 'spreadsheet_sheet' AND locator->>'source_kind' = 'spreadsheet' AND locator->>'coordinate_space' = 'spreadsheet_cells')
+            OR (unit_type IN ('raster_image', 'sketch') AND locator->>'source_kind' = 'image' AND locator->>'coordinate_space' = 'image_pixels')
+            OR (unit_type = 'cad_drawing' AND locator->>'source_kind' = 'cad' AND locator->>'coordinate_space' = 'cad_model')
+            OR (unit_type = 'text_page' AND locator->>'source_kind' = 'text' AND locator->>'coordinate_space' = 'text_offsets')
+        )
+        AND locator->>'source_version' = source_version
+        AND char_length(locator->>'artifact_path') BETWEEN 1 AND 2048
+        AND locator->>'artifact_sha256' ~ '^sha256:[a-f0-9]{64}$'
+        AND locator->>'artifact_version_id' ~ '^[!-~]{1,1024}$'
+    ) NOT VALID;
+SQL);
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
## GlitchTip

- PROHELPER-BACKEND-FO / issue 535: http://5.129.220.32:8000/prohelper-backend/issues/535

## Причина

Ограничение provenance было добавлено в режиме `NOT VALID` к историческим единицам обработки. PostgreSQL всё равно проверяет ограничение при любом последующем `UPDATE`, поэтому повторное планирование старой записи с неполным locator завершалось ошибкой.

## Изменения

- Добавлена forward-миграция: временно снимает ограничение, восстанавливает в исторических locator значения `source_kind`, `source_version` и `coordinate_space` из существующих данных, затем возвращает то же ограничение в режиме `NOT VALID`.

## Проверки

- `php -l app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_03_000100_backfill_document_unit_provenance.php`
- `git diff --check`
- PHPStan не запускался: в изолированном worktree отсутствует `vendor/`; миграции и DB-тесты локально запрещены правилами проекта.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a database migration to backfill provenance data into the 'locator' JSONB column of the 'estimate_generation_processing_units' table.</li>
<li>The migration updates existing records by mapping 'unit_type' to specific 'source_kind' and 'coordinate_space' values.</li>
<li>Replaced the existing check constraint 'eg_units_locator_provenance_ck' with a more comprehensive version that enforces strict schema validation for the 'locator' JSONB field.</li>
</ul></div>