### PR TITLE
fix[backend]: исправлена граница regex provenance

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_04_000100_fix_document_unit_provenance_regex_bound.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_04_000100_fix_document_unit_provenance_regex_bound.php
@@ -15,6 +15,9 @@ return new class extends Migration
 
         DB::unprepared(<<<'SQL'
 ALTER TABLE estimate_generation_processing_units
+    DROP CONSTRAINT IF EXISTS eg_units_locator_provenance_ck;
+
+ALTER TABLE estimate_generation_processing_units
     ADD CONSTRAINT eg_units_locator_provenance_ck
     CHECK (
         locator ?& ARRAY['source_kind', 'source_version', 'coordinate_space', 'artifact_path', 'artifact_sha256', 'artifact_version_id']
@@ -41,8 +44,5 @@ SQL);
 
     public function down(): void
     {
-        if (DB::getDriverName() === 'pgsql') {
-            DB::statement('ALTER TABLE estimate_generation_processing_units DROP CONSTRAINT IF EXISTS eg_units_locator_provenance_ck');
-        }
     }
 };


### PR DESCRIPTION
## GlitchTip

- PROHELPER-BACKEND-FR / issue 538: [Invalid regular expression](http://5.129.220.32:8000/prohelper-backend/issues/538)
- Связанная ошибка PROHELPER-BACKEND-FS / issue 539 вызвана тем же запросом.

## Причина

В PostgreSQL верхняя граница в regex-квантификаторе ограничена 255. Ограничение provenance использовало `{1,1024}`, поэтому любое обновление затронутой записи завершалось ошибкой разбора регулярного выражения.

## Изменения

- Для новых установок граница `artifact_version_id` изменена на `{1,255}`.
- Добавлена корректирующая миграция, которая пересоздаёт уже развернутое ограничение с допустимой границей.

## Проверки

- `php -l` для обеих миграций
- `vendor/bin/phpstan.bat analyse` для обеих миграций
- `git diff --check`

Миграции и проверки БД локально не запускались согласно правилам окружения.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Reduced the maximum length constraint for the 'artifact_version_id' field in the database check constraint from 1024 to 255 characters.</li>
<li>Added a new migration to explicitly drop and recreate the 'eg_units_locator_provenance_ck' constraint on the 'estimate_generation_processing_units' table to ensure consistency.</li>
</ul></div>