### PR TITLE
feat[backend]: опубликована маржинальность проекта

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ProjectMarginReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ProjectMarginReportOptionsController.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
 
-use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\Budgeting\Services\BudgetingReportOptionsService;
 use App\Http\Responses\AdminResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-final readonly class BudgetPlanFactReportOptionsController
+final readonly class ProjectMarginReportOptionsController
 {
     public function __construct(private BudgetingReportOptionsService $options) {}
 
@@ -21,8 +21,8 @@ final readonly class BudgetPlanFactReportOptionsController
         return AdminResponse::success([
             'closures' => $this->options->availableClosures(
                 (int) $organization->id,
-                BudgetPlanFactCandidateContract::CODE,
-                BudgetPlanFactCandidateContract::FORMULA_VERSION,
+                ProjectMarginCandidateContract::CODE,
+                ProjectMarginCandidateContract::FORMULA_VERSION,
             ),
         ]);
     }

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -10,6 +10,8 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractExceptio
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthorizationTarget;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
+use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
@@ -69,7 +71,11 @@ final readonly class AuthorizeReportDefinitionAccess
     private function target(Request $request, string $routeName): CurrentReportAuthorizationTarget
     {
         return match ($routeName) {
-            'admin.reports.runs.store', 'admin.reports.project-budget-plan-fact.runs.store', 'admin.reports.project-budget-plan-fact.options' => $this->targets->createRun(
+            'admin.reports.runs.store' => $this->genericCreateRun($request),
+            'admin.reports.project-budget-plan-fact.runs.store',
+            'admin.reports.project-budget-plan-fact.options',
+            'admin.reports.project-margin.runs.store',
+            'admin.reports.project-margin.options' => $this->targets->createRun(
                 $this->routeId($request, 'reportCode'),
             ),
             'admin.reports.runs.show', 'admin.reports.runs.rows' => $this->targets->run(
@@ -102,6 +108,19 @@ final readonly class AuthorizeReportDefinitionAccess
             ),
             default => $this->deny(),
         };
+    }
+
+    private function genericCreateRun(Request $request): CurrentReportAuthorizationTarget
+    {
+        $reportCode = $this->routeId($request, 'reportCode');
+        if (in_array($reportCode, [
+            BudgetPlanFactCandidateContract::CODE,
+            ProjectMarginCandidateContract::CODE,
+        ], true)) {
+            $this->deny();
+        }
+
+        return $this->targets->createRun($reportCode);
     }
 
     private function catalogHashes(int $organizationId): array

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/BindProjectReportScope.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/BindProjectReportScope.php
@@ -11,27 +11,31 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class BindProjectReportScope
 {
+    private const FORBIDDEN_CONTEXT_FIELDS = [
+        'organization_id',
+        'project_id',
+        'user_id',
+        'owner_id',
+        'role',
+        'permission',
+        'scope',
+    ];
+
     public function handle(Request $request, Closure $next): Response
     {
-        $filters = $request->input('filters');
-        if (! is_array($filters)) {
-            return $next($request);
+        if ($this->hasClientContextOverride($request)) {
+            return $this->invalidRequest();
         }
 
-        if (array_key_exists('organization_id', $filters) || array_key_exists('project_id', $filters)) {
-            return AdminResponse::error(
-                trans_message('reports.errors.report_request_invalid'),
-                Response::HTTP_UNPROCESSABLE_ENTITY,
-            );
+        $filters = $request->input('filters');
+        if ($request->isMethod('GET') || ! is_array($filters)) {
+            return $next($request);
         }
 
         $project = $request->attributes->get('project');
         $organization = $request->attributes->get('current_organization');
         if ($project === null || $organization === null) {
-            return AdminResponse::error(
-                trans_message('reports.errors.report_request_invalid'),
-                Response::HTTP_UNPROCESSABLE_ENTITY,
-            );
+            return $this->invalidRequest();
         }
 
         $request->merge([
@@ -43,5 +47,29 @@ final class BindProjectReportScope
         ]);
 
         return $next($request);
+    }
+
+    private function hasClientContextOverride(Request $request): bool
+    {
+        foreach (self::FORBIDDEN_CONTEXT_FIELDS as $field) {
+            if ($request->exists($field)) {
+                return true;
+            }
+        }
+
+        $filters = $request->input('filters');
+        if (! is_array($filters)) {
+            return false;
+        }
+
+        return array_intersect(self::FORBIDDEN_CONTEXT_FIELDS, array_keys($filters)) !== [];
+    }
+
+    private function invalidRequest(): Response
+    {
+        return AdminResponse::error(
+            trans_message('reports.errors.report_request_invalid'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
     }
 }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -11,32 +11,44 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
 {
-    private PublishedReportDefinition $budgetPlanFact;
+    /** @var array<string, PublishedReportDefinition> */
+    private array $definitions;
 
-    public function __construct(BudgetPlanFactBuiltinPublishedReport $budgetPlanFact)
-    {
-        $this->budgetPlanFact = $budgetPlanFact->definition();
+    public function __construct(
+        ProjectMarginBuiltinPublishedReport $projectMargin,
+        BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
+    ) {
+        $byCode = [];
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition()] as $definition) {
+            $byCode[$definition->code] = $definition;
+        }
+        ksort($byCode, SORT_STRING);
+        $this->definitions = $byCode;
     }
 
     public function published(string $code): PublishedReportDefinition
     {
-        return $code === $this->budgetPlanFact->code
-            ? $this->budgetPlanFact
-            : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+        return $this->definitions[$code]
+            ?? throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
     }
 
     public function publishedCodes(): array
     {
-        return [$this->budgetPlanFact->code];
+        return array_keys($this->definitions);
     }
 
     public function manifestSha256(): Sha256Hash
     {
-        return new Sha256Hash(hash('sha256', CanonicalJson::encode([
-            ['code' => $this->budgetPlanFact->code, 'definition_sha256' => $this->budgetPlanFact->definitionHash->value],
-        ])));
+        return new Sha256Hash(hash('sha256', CanonicalJson::encode(array_map(
+            static fn (PublishedReportDefinition $definition): array => [
+                'code' => $definition->code,
+                'definition_sha256' => $definition->definitionHash->value,
+            ],
+            array_values($this->definitions),
+        ))));
     }
 }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -9,15 +9,21 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportCatalogMetadataRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
 {
-    public function __construct(private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact) {}
+    public function __construct(
+        private ProjectMarginBuiltinPublishedReport $projectMargin,
+        private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
+    ) {}
 
     public function published(string $code): ReportCatalogMetadata
     {
-        return $code === $this->budgetPlanFact->metadata()->code
-            ? $this->budgetPlanFact->metadata()
-            : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+        return match ($code) {
+            $this->projectMargin->metadata()->code => $this->projectMargin->metadata(),
+            $this->budgetPlanFact->metadata()->code => $this->budgetPlanFact->metadata(),
+            default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
+        };
     }
 }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -9,15 +9,21 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSchedulingCapabilityRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
 {
-    public function __construct(private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact) {}
+    public function __construct(
+        private ProjectMarginBuiltinPublishedReport $projectMargin,
+        private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
+    ) {}
 
     public function published(string $code): ReportSchedulingCapability
     {
-        return $code === $this->budgetPlanFact->scheduling()->code
-            ? $this->budgetPlanFact->scheduling()
-            : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+        return match ($code) {
+            $this->projectMargin->scheduling()->code => $this->projectMargin->scheduling(),
+            $this->budgetPlanFact->scheduling()->code => $this->budgetPlanFact->scheduling(),
+            default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
+        };
     }
 }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -58,6 +58,7 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Publication\EloquentReport
 use App\BusinessModules\Core\Reporting\Infrastructure\Publication\EloquentReportPublicationRegistry;
 use App\BusinessModules\Core\Reporting\Infrastructure\Queue\LaravelReportSubscriptionDeliveryDispatcher;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -84,9 +85,13 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(BudgetPlanFactBuiltinPublishedReport::class, fn (Application $app): BudgetPlanFactBuiltinPublishedReport => new BudgetPlanFactBuiltinPublishedReport(
             $app->make(\App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract::class),
         ));
+        $this->app->singleton(ProjectMarginBuiltinPublishedReport::class, fn (Application $app): ProjectMarginBuiltinPublishedReport => new ProjectMarginBuiltinPublishedReport(
+            $app->make(\App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract::class),
+        ));
         $this->app->singleton(
             BuiltinPublishedReportDefinitionRegistry::class,
             fn (Application $app): BuiltinPublishedReportDefinitionRegistry => new BuiltinPublishedReportDefinitionRegistry(
+                $app->make(ProjectMarginBuiltinPublishedReport::class),
                 $app->make(BudgetPlanFactBuiltinPublishedReport::class),
             ),
         );
@@ -97,9 +102,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(BudgetPlanFactBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(BudgetPlanFactBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMatrix;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
-use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportCatalogController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectMarginReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportCatalogController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportDrillDownController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportExportController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportRowsController;
@@ -85,8 +86,16 @@ Route::prefix('api/v1/admin/reports')
             ->name('project-budget-plan-fact.runs.store');
         Route::get('/projects/{project}/budget-plan-fact/options', BudgetPlanFactReportOptionsController::class)
             ->defaults('reportCode', 'budget_plan_fact')
-            ->middleware(['project.context', $resourceAccess])
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
             ->name('project-budget-plan-fact.options');
+        Route::post('/projects/{project}/project-margin/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'project_margin')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('project-margin.runs.store');
+        Route::get('/projects/{project}/project-margin/options', ProjectMarginReportOptionsController::class)
+            ->defaults('reportCode', 'project_margin')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('project-margin.options');
         Route::get('/runs/{runId}', [ReportRunController::class, 'show'])
             ->middleware($resourceAccess)
             ->name('runs.show');

--- a/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
+++ b/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
@@ -8,8 +8,10 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingA
 use App\BusinessModules\Features\Budgeting\Console\Commands\RecalculateEpmDataMartSnapshotsCommand;
 use App\BusinessModules\Features\Budgeting\Contracts\BudgetingReportSourceCloseStore;
 use App\BusinessModules\Features\Budgeting\Contracts\PlanFactSourceSnapshotReport;
+use App\BusinessModules\Features\Budgeting\Contracts\ProjectMarginSourceSnapshotReport;
 use App\BusinessModules\Features\Budgeting\Infrastructure\Persistence\EloquentBudgetingReportSourceCloseStore;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\Budgeting\Services\BudgetCatalogService;
 use App\BusinessModules\Features\Budgeting\Services\BudgetImportFileReader;
 use App\BusinessModules\Features\Budgeting\Services\BudgetImportService;
@@ -18,8 +20,8 @@ use App\BusinessModules\Features\Budgeting\Services\BudgetingReportSourceCloseSe
 use App\BusinessModules\Features\Budgeting\Services\BudgetLineService;
 use App\BusinessModules\Features\Budgeting\Services\BudgetPeriodClosureService;
 use App\BusinessModules\Features\Budgeting\Services\BudgetPeriodReopenService;
-use App\BusinessModules\Features\Budgeting\Services\BudgetPlanFactReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Services\BudgetPlanFactPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\Budgeting\Services\BudgetPlanFactReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Services\BudgetVersionService;
 use App\BusinessModules\Features\Budgeting\Services\BudgetWorkflowService;
 use App\BusinessModules\Features\Budgeting\Services\CashGapForecastReadService;
@@ -37,6 +39,12 @@ use App\BusinessModules\Features\Budgeting\Services\PlanFactReportService;
 use App\BusinessModules\Features\Budgeting\Services\PlanFactReportSourceSnapshotAdapter;
 use App\BusinessModules\Features\Budgeting\Services\PlanFactSourceSnapshotMaterializer;
 use App\BusinessModules\Features\Budgeting\Services\PlanFactSourceSnapshotWriter;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginReportBindingFactory;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginReportService;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginReportSourceSnapshotAdapter;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginSourceSnapshotMaterializer;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginSourceSnapshotWriter;
 use App\BusinessModules\Features\Budgeting\Services\ProjectPortfolioDashboardPayloadBuilder;
 use App\BusinessModules\Features\Budgeting\Services\ProjectPortfolioDashboardService;
 use Illuminate\Support\ServiceProvider;
@@ -48,12 +56,19 @@ final class BudgetingServiceProvider extends ServiceProvider
         $this->app->bind(BudgetingReportSourceCloseStore::class, EloquentBudgetingReportSourceCloseStore::class);
         $this->app->singleton(BudgetingReportSourceCloseService::class);
         $this->app->bind(PlanFactSourceSnapshotReport::class, PlanFactReportService::class);
+        $this->app->bind(ProjectMarginSourceSnapshotReport::class, ProjectMarginReportService::class);
         $this->app->singleton(PlanFactSourceSnapshotMaterializer::class);
         $this->app->singleton(PlanFactSourceSnapshotWriter::class);
         $this->app->singleton(PlanFactReportSourceSnapshotAdapter::class);
         $this->app->singleton(BudgetPlanFactCandidateContract::class);
         $this->app->singleton(BudgetPlanFactReportBindingFactory::class);
         $this->app->singleton(BudgetPlanFactPublishedRuntimeBindingRegistrar::class);
+        $this->app->singleton(ProjectMarginSourceSnapshotMaterializer::class);
+        $this->app->singleton(ProjectMarginSourceSnapshotWriter::class);
+        $this->app->singleton(ProjectMarginReportSourceSnapshotAdapter::class);
+        $this->app->singleton(ProjectMarginCandidateContract::class);
+        $this->app->singleton(ProjectMarginReportBindingFactory::class);
+        $this->app->singleton(ProjectMarginPublishedRuntimeBindingRegistrar::class);
         $this->app->singleton(BudgetCatalogService::class);
         $this->app->singleton(BudgetVersionService::class);
         $this->app->singleton(BudgetLineService::class);
@@ -85,6 +100,9 @@ final class BudgetingServiceProvider extends ServiceProvider
             function (ReportDefinitionBindingAssembler $assembler): void {
                 $this->app
                     ->make(BudgetPlanFactPublishedRuntimeBindingRegistrar::class)
+                    ->register($assembler);
+                $this->app
+                    ->make(ProjectMarginPublishedRuntimeBindingRegistrar::class)
                     ->register($assembler);
             },
         );

--- a/app/BusinessModules/Features/Budgeting/DTOs/BudgetingReportSourceClose.php
+++ b/app/BusinessModules/Features/Budgeting/DTOs/BudgetingReportSourceClose.php
@@ -12,6 +12,7 @@ final readonly class BudgetingReportSourceClose
     /** @param list<BudgetingReportSourceWatermark> $sourceWatermarks */
     public function __construct(
         public string $closeId,
+        public string $reportCode,
         public BudgetingReportSourceCloseIdentity $identity,
         public array $sourceWatermarks,
         public string $formulaVersion,
@@ -22,8 +23,7 @@ final readonly class BudgetingReportSourceClose
         public DateTimeImmutable $retainedUntil,
         public BudgetingReportSourceCloseStatus $status,
         public ?string $restatesCloseId,
-    ) {
-    }
+    ) {}
 
     public function isAvailableAt(DateTimeImmutable $at): bool
     {
@@ -39,6 +39,7 @@ final readonly class BudgetingReportSourceClose
 
         return [
             'close_id' => $this->closeId,
+            'report_code' => $this->reportCode,
             'approved_at' => $this->approvedAt->format(DATE_ATOM),
             'retained_until' => $this->retainedUntil->format(DATE_ATOM),
             'identity' => $this->identity->toArray(),

--- a/app/BusinessModules/Features/Budgeting/DTOs/CreateBudgetingReportSourceClose.php
+++ b/app/BusinessModules/Features/Budgeting/DTOs/CreateBudgetingReportSourceClose.php
@@ -10,11 +10,12 @@ use InvalidArgumentException;
 final readonly class CreateBudgetingReportSourceClose
 {
     /**
-     * @param list<BudgetingReportSourceWatermark> $sourceWatermarks
-     * @param array<string, mixed> $sourceManifest
+     * @param  list<BudgetingReportSourceWatermark>  $sourceWatermarks
+     * @param  array<string, mixed>  $sourceManifest
      */
     public function __construct(
         public string $closeId,
+        public string $reportCode,
         public BudgetingReportSourceCloseIdentity $identity,
         public array $sourceWatermarks,
         public string $formulaVersion,
@@ -25,9 +26,10 @@ final readonly class CreateBudgetingReportSourceClose
         public DateTimeImmutable $retainedUntil,
         public ?string $restatesCloseId = null,
     ) {
-        if (!preg_match('/^[0-9A-HJKMNP-TV-Z]{26}$/', $this->closeId)
+        if (! preg_match('/^[0-9A-HJKMNP-TV-Z]{26}$/', $this->closeId)
+            || preg_match('/^[a-z][a-z0-9_]{2,63}$/D', $this->reportCode) !== 1
             || trim($this->formulaVersion) === ''
-            || !preg_match('/^[a-f0-9]{64}$/', $this->contentHash)
+            || ! preg_match('/^[a-f0-9]{64}$/', $this->contentHash)
             || $this->approvedBy <= 0
             || $this->sourceManifest === []) {
             throw new InvalidArgumentException('budgeting_report_source_close_input_invalid');
@@ -37,13 +39,13 @@ final readonly class CreateBudgetingReportSourceClose
             throw new InvalidArgumentException('budgeting_report_source_close_retention_invalid');
         }
 
-        if ($this->restatesCloseId !== null && !preg_match('/^[0-9A-HJKMNP-TV-Z]{26}$/', $this->restatesCloseId)) {
+        if ($this->restatesCloseId !== null && ! preg_match('/^[0-9A-HJKMNP-TV-Z]{26}$/', $this->restatesCloseId)) {
             throw new InvalidArgumentException('budgeting_report_source_close_restatement_invalid');
         }
 
         $sources = [];
         foreach ($this->sourceWatermarks as $watermark) {
-            if (!$watermark instanceof BudgetingReportSourceWatermark || isset($sources[$watermark->source])) {
+            if (! $watermark instanceof BudgetingReportSourceWatermark || isset($sources[$watermark->source])) {
                 throw new InvalidArgumentException('budgeting_report_source_close_watermarks_invalid');
             }
             $sources[$watermark->source] = true;
@@ -53,21 +55,22 @@ final readonly class CreateBudgetingReportSourceClose
             throw new InvalidArgumentException('budgeting_report_source_close_watermarks_invalid');
         }
 
-        if (!hash_equals(self::contentHashFor($this->identity, $this->sourceWatermarks, $this->formulaVersion, $this->sourceManifest), $this->contentHash)) {
+        if (! hash_equals(self::contentHashFor($this->reportCode, $this->identity, $this->sourceWatermarks, $this->formulaVersion, $this->sourceManifest), $this->contentHash)) {
             throw new InvalidArgumentException('budgeting_report_source_close_hash_invalid');
         }
     }
 
     public function calculateContentHash(): string
     {
-        return self::contentHashFor($this->identity, $this->sourceWatermarks, $this->formulaVersion, $this->sourceManifest);
+        return self::contentHashFor($this->reportCode, $this->identity, $this->sourceWatermarks, $this->formulaVersion, $this->sourceManifest);
     }
 
     /**
-     * @param list<BudgetingReportSourceWatermark> $sourceWatermarks
-     * @param array<string, mixed> $sourceManifest
+     * @param  list<BudgetingReportSourceWatermark>  $sourceWatermarks
+     * @param  array<string, mixed>  $sourceManifest
      */
     public static function contentHashFor(
+        string $reportCode,
         BudgetingReportSourceCloseIdentity $identity,
         array $sourceWatermarks,
         string $formulaVersion,
@@ -77,6 +80,7 @@ final readonly class CreateBudgetingReportSourceClose
         usort($watermarks, static fn (array $left, array $right): int => $left['source'] <=> $right['source']);
 
         return hash('sha256', json_encode([
+            'report_code' => $reportCode,
             'identity' => $identity->toArray(),
             'formula_version' => $formulaVersion,
             'source_manifest' => self::canonicalize($sourceManifest),
@@ -91,6 +95,7 @@ final readonly class CreateBudgetingReportSourceClose
         usort($watermarks, static fn (array $left, array $right): int => $left['source'] <=> $right['source']);
 
         return [
+            'report_code' => $this->reportCode,
             'identity' => $this->identity->toArray(),
             'formula_version' => $this->formulaVersion,
             'source_manifest' => self::canonicalize($this->sourceManifest),

--- a/app/BusinessModules/Features/Budgeting/Infrastructure/Persistence/EloquentBudgetingReportSourceCloseStore.php
+++ b/app/BusinessModules/Features/Budgeting/Infrastructure/Persistence/EloquentBudgetingReportSourceCloseStore.php
@@ -21,14 +21,14 @@ final class EloquentBudgetingReportSourceCloseStore implements BudgetingReportSo
     public function createApproved(CreateBudgetingReportSourceClose $request): BudgetingReportSourceClose
     {
         return DB::transaction(function () use ($request): BudgetingReportSourceClose {
-            $active = $this->activeCloseFor($request->identity);
+            $active = $this->activeCloseFor($request->reportCode, $request->identity);
 
             if ($request->restatesCloseId === null && $active instanceof BudgetingReportSourceCloseRecord) {
                 throw new DomainException('budgeting_report_source_close_active_exists');
             }
 
             if ($request->restatesCloseId !== null) {
-                if (!$active instanceof BudgetingReportSourceCloseRecord || $active->close_id !== $request->restatesCloseId) {
+                if (! $active instanceof BudgetingReportSourceCloseRecord || $active->close_id !== $request->restatesCloseId) {
                     throw new DomainException('budgeting_report_source_close_restatement_target_invalid');
                 }
 
@@ -42,6 +42,7 @@ final class EloquentBudgetingReportSourceCloseStore implements BudgetingReportSo
 
             $record = BudgetingReportSourceCloseRecord::query()->create([
                 'close_id' => $request->closeId,
+                'report_code' => $request->reportCode,
                 ...$request->identity->toArray(),
                 'formula_version' => $request->formulaVersion,
                 'source_manifest' => $request->sourceManifest,
@@ -74,9 +75,12 @@ final class EloquentBudgetingReportSourceCloseStore implements BudgetingReportSo
         return $record instanceof BudgetingReportSourceCloseRecord ? $this->toDto($record) : null;
     }
 
-    private function activeCloseFor(BudgetingReportSourceCloseIdentity $identity): ?BudgetingReportSourceCloseRecord
-    {
+    private function activeCloseFor(
+        string $reportCode,
+        BudgetingReportSourceCloseIdentity $identity,
+    ): ?BudgetingReportSourceCloseRecord {
         return BudgetingReportSourceCloseRecord::query()
+            ->where('report_code', $reportCode)
             ->where($identity->toArray())
             ->where('status', BudgetingReportSourceCloseStatus::APPROVED->value)
             ->lockForUpdate()
@@ -98,6 +102,7 @@ final class EloquentBudgetingReportSourceCloseStore implements BudgetingReportSo
 
         return new BudgetingReportSourceClose(
             closeId: (string) $record->close_id,
+            reportCode: (string) $record->report_code,
             identity: new BudgetingReportSourceCloseIdentity(
                 organizationId: (int) $record->organization_id,
                 periodStart: $record->period_start->format('Y-m-d'),

--- a/app/BusinessModules/Features/Budgeting/Models/BudgetingReportSourceCloseRecord.php
+++ b/app/BusinessModules/Features/Budgeting/Models/BudgetingReportSourceCloseRecord.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\Budgeting\Models;
 
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 final class BudgetingReportSourceCloseRecord extends Model
 {
@@ -13,6 +13,7 @@ final class BudgetingReportSourceCloseRecord extends Model
 
     protected $fillable = [
         'close_id',
+        'report_code',
         'organization_id',
         'period_start',
         'period_end',

--- a/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactCandidateContract.php
@@ -169,7 +169,7 @@ final readonly class BudgetPlanFactCandidateContract
             }
         }
 
-        if ($close->formulaVersion !== $this->formulaVersion) {
+        if ($close->reportCode !== self::CODE || $close->formulaVersion !== $this->formulaVersion) {
             throw new InvalidArgumentException('budget_plan_fact_candidate_formula_version_invalid');
         }
 

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginBuiltinPublishedReport.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class ProjectMarginBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+
+    public const RENDERER_VERSION = '1.0.0';
+
+    public const MANIFEST_ORDINAL = 11;
+
+    public function __construct(private ProjectMarginCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            ProjectMarginCandidateContract::CODE,
+            'reports.catalog.project_margin',
+            ReportCatalogGroup::FINANCE,
+            'finance',
+            'project_article_currency_period',
+            1,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(ProjectMarginCandidateContract::CODE, false, false);
+    }
+
+    /** @return array<string, mixed> */
+    public function document(): array
+    {
+        return [
+            'code' => ProjectMarginCandidateContract::CODE,
+            'title_key' => 'reports.catalog.project_margin',
+            'catalog_group' => 'finance',
+            'category' => 'finance',
+            'grain' => 'project_article_currency_period',
+            'wave' => 1,
+            'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => [
+                'contract' => self::CONTRACT_VERSION,
+                'formula' => $this->contract->formulaVersion,
+                'source_schema' => $this->contract->sourceSchemaVersion,
+                'renderer' => self::RENDERER_VERSION,
+            ],
+            'semantic_fingerprints' => [
+                'formula' => $this->contract->formulaHash,
+                'source' => $this->contract->sourceHash,
+            ],
+            'permissions' => [
+                'view' => ['budgeting.project_margin.view'],
+                'export' => ['budgeting.project_margin.export'],
+                'sensitive' => [],
+                'audit' => [],
+            ],
+            'readiness' => [
+                'source' => 'ready',
+                'formula' => 'ready',
+                'delivery' => 'verified',
+                'publication' => 'published',
+            ],
+            'capabilities' => [
+                'supports_subscriptions' => false,
+                'reproducible_scheduled_snapshot' => false,
+            ],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginCandidateContract.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\Budgeting\DTOs\BudgetingReportSourceClose;
+use App\BusinessModules\Features\Budgeting\DTOs\ProjectMarginReportFilters;
+use App\BusinessModules\Features\Budgeting\DTOs\ProjectMarginSourceSnapshotRequest;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginCalculator;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginSourceSnapshotMaterializer;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class ProjectMarginCandidateContract
+{
+    public const CODE = 'project_margin';
+
+    public const FORMULA_VERSION = 'margin-v1';
+
+    public const FORMULA_HASH = '9daf19a225a89d3990becd0654b5965eebfb79306f0acf31c0aba1fcd849ccb4';
+
+    public const SOURCE_HASH = 'a887a07672f66a2d382091b1468f6efc339bbec4d62cda88fabfe9a1007fbc45';
+
+    public function __construct(
+        public string $formulaVersion = self::FORMULA_VERSION,
+        public string $formulaHash = self::FORMULA_HASH,
+        public string $sourceSchemaVersion = ProjectMarginSourceSnapshotMaterializer::SCHEMA_VERSION,
+        public string $sourceHash = self::SOURCE_HASH,
+    ) {}
+
+    /** @return list<array{id: string, required: bool}> */
+    public function filters(): array
+    {
+        return [
+            ['id' => 'close_id', 'required' => true],
+            ['id' => 'organization_id', 'required' => true],
+            ['id' => 'period_start', 'required' => true],
+            ['id' => 'period_end', 'required' => true],
+            ['id' => 'scenario_uuid', 'required' => true],
+            ['id' => 'budget_version_uuid', 'required' => true],
+            ['id' => 'project_id', 'required' => false],
+            ['id' => 'contract_id', 'required' => false],
+            ['id' => 'responsibility_center_id', 'required' => false],
+            ['id' => 'budget_article_id', 'required' => false],
+            ['id' => 'counterparty_id', 'required' => false],
+            ['id' => 'currency', 'required' => false],
+            ['id' => 'group_by', 'required' => true],
+        ];
+    }
+
+    /** @return list<array{id: string}> */
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'actual',
+            'currency',
+            'drill',
+            'forecast',
+            'group',
+            'plan',
+            'problem_flags',
+            'quality_status',
+            'risk_flags',
+            'row_key',
+            'source_rows_count',
+            'source_types',
+            'variance',
+        ]);
+    }
+
+    /** @return list<array{id: string, direction: string}> */
+    public function sorts(): array
+    {
+        return [['id' => 'row_key', 'direction' => ReportSortDirection::ASC->value]];
+    }
+
+    /** @return list<string> */
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function drillColumnId(): string
+    {
+        return ProjectMarginSourceSnapshotMaterializer::DRILL_COLUMN_ID;
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if ($this->formulaVersion !== self::FORMULA_VERSION
+            || $this->sourceSchemaVersion !== ProjectMarginSourceSnapshotMaterializer::SCHEMA_VERSION
+            || ! hash_equals($this->formulaHash, self::classHash(ProjectMarginCalculator::class))
+            || ! hash_equals($this->sourceHash, self::classHash(ProjectMarginSourceSnapshotMaterializer::class))) {
+            throw new InvalidArgumentException('project_margin_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->formulaVersion !== $this->formulaVersion
+            || $definition->sourceSchemaVersion !== $this->sourceSchemaVersion
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['budgeting.project_margin.view']
+            || $definition->permissionPolicy->exportPermissions !== ['budgeting.project_margin.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== []) {
+            throw new InvalidArgumentException('project_margin_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSnapshotRequest(ReportScope $scope, array $filters, BudgetingReportSourceClose $close): void
+    {
+        $allowed = array_column($this->filters(), 'id');
+        unset($allowed[array_search('close_id', $allowed, true)]);
+        if (array_diff(array_keys($filters), $allowed) !== []) {
+            throw new InvalidArgumentException('project_margin_candidate_filters_invalid');
+        }
+
+        foreach ($this->filters() as $filter) {
+            if ($filter['required'] && $filter['id'] !== 'close_id' && ! array_key_exists($filter['id'], $filters)) {
+                throw new InvalidArgumentException('project_margin_candidate_filters_invalid');
+            }
+        }
+
+        if ($close->reportCode !== self::CODE || $close->formulaVersion !== $this->formulaVersion) {
+            throw new InvalidArgumentException('project_margin_candidate_formula_version_invalid');
+        }
+
+        $groupBy = $filters['group_by'] ?? null;
+        if (! is_array($groupBy)
+            || ! array_is_list($groupBy)
+            || $groupBy === []
+            || count(array_filter($groupBy, 'is_string')) !== count($groupBy)
+            || $groupBy !== array_values(array_unique($groupBy))
+            || array_diff($groupBy, ProjectMarginReportFilters::ALLOWED_GROUP_BY) !== []
+            || ! in_array(ProjectMarginReportFilters::GROUP_CURRENCY, $groupBy, true)) {
+            throw new InvalidArgumentException('project_margin_candidate_grouping_invalid');
+        }
+
+        new ProjectMarginSourceSnapshotRequest(
+            $scope,
+            $filters,
+            $close->closeId,
+            $close->identity,
+            new DateTimeImmutable('2026-01-31T00:00:00+00:00'),
+            null,
+        );
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if ($sort->field !== 'row_key' || $sort->direction !== ReportSortDirection::ASC) {
+            throw new InvalidArgumentException('project_margin_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('project_margin_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR),
+            $items,
+        );
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Services/BudgetingReportOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Services/BudgetingReportOptionsService.php
@@ -7,13 +7,15 @@ namespace App\BusinessModules\Features\Budgeting\Services;
 use App\BusinessModules\Features\Budgeting\Enums\BudgetingReportSourceCloseStatus;
 use App\BusinessModules\Features\Budgeting\Models\BudgetingReportSourceCloseRecord;
 
-final class BudgetPlanFactReportOptionsService
+final class BudgetingReportOptionsService
 {
     /** @return list<array{value:string,label:string,period_start:string,period_end:string,scenario_uuid:string,budget_version_uuid:string}> */
-    public function availableClosures(int $organizationId): array
+    public function availableClosures(int $organizationId, string $reportCode, string $formulaVersion): array
     {
         return BudgetingReportSourceCloseRecord::query()
             ->where('organization_id', $organizationId)
+            ->where('report_code', $reportCode)
+            ->where('formula_version', $formulaVersion)
             ->where('status', BudgetingReportSourceCloseStatus::APPROVED->value)
             ->where('retained_until', '>', now())
             ->orderByDesc('period_end')

--- a/app/BusinessModules/Features/Budgeting/Services/BudgetingReportSourceCloseService.php
+++ b/app/BusinessModules/Features/Budgeting/Services/BudgetingReportSourceCloseService.php
@@ -13,9 +13,7 @@ use DomainException;
 
 final class BudgetingReportSourceCloseService
 {
-    public function __construct(private readonly BudgetingReportSourceCloseStore $store)
-    {
-    }
+    public function __construct(private readonly BudgetingReportSourceCloseStore $store) {}
 
     public function createApproved(CreateBudgetingReportSourceClose $request): BudgetingReportSourceClose
     {
@@ -24,16 +22,19 @@ final class BudgetingReportSourceCloseService
 
     public function validatedCloseForReporting(
         string $closeId,
+        string $reportCode,
         BudgetingReportSourceCloseIdentity $identity,
         DateTimeImmutable $at,
     ): BudgetingReportSourceClose {
         $close = $this->store->find($closeId);
 
-        if (!$close instanceof BudgetingReportSourceClose || $close->identity->toArray() !== $identity->toArray()) {
+        if (! $close instanceof BudgetingReportSourceClose
+            || $close->reportCode !== $reportCode
+            || $close->identity->toArray() !== $identity->toArray()) {
             throw new DomainException('budgeting_report_source_close_not_found');
         }
 
-        if (!$close->isAvailableAt($at)) {
+        if (! $close->isAvailableAt($at)) {
             throw new DomainException('budgeting_report_source_close_not_available');
         }
 

--- a/app/BusinessModules/Features/Budgeting/Services/PlanFactReportSourceSnapshotAdapter.php
+++ b/app/BusinessModules/Features/Budgeting/Services/PlanFactReportSourceSnapshotAdapter.php
@@ -40,6 +40,7 @@ final class PlanFactReportSourceSnapshotAdapter extends AbstractBudgetingReportS
     {
         return $this->closeService->validatedCloseForReporting(
             $this->closeId($query),
+            PlanFactSourceSnapshotMaterializer::REPORT_CODE,
             $this->closeIdentity($query),
             $query->asOf,
         )->formulaVersion;

--- a/app/BusinessModules/Features/Budgeting/Services/PlanFactSourceSnapshotWriter.php
+++ b/app/BusinessModules/Features/Budgeting/Services/PlanFactSourceSnapshotWriter.php
@@ -22,7 +22,12 @@ final class PlanFactSourceSnapshotWriter
 
     public function persist(PlanFactSourceSnapshotRequest $request): ReportSourceSnapshotHeader
     {
-        $close = $this->closeService->validatedCloseForReporting($request->closeId, $request->closeIdentity, $request->asOf);
+        $close = $this->closeService->validatedCloseForReporting(
+            $request->closeId,
+            PlanFactSourceSnapshotMaterializer::REPORT_CODE,
+            $request->closeIdentity,
+            $request->asOf,
+        );
         $filters = $this->normalizeFilters($request);
         $identity = $this->materializer->identity($request->scope, $filters, $close->closeId, $request->reportQueryIdentity);
         $ready = $this->store->findReady($identity);

--- a/app/BusinessModules/Features/Budgeting/Services/ProjectMarginPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/Budgeting/Services/ProjectMarginPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Services;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+
+final readonly class ProjectMarginPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private ProjectMarginReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(ProjectMarginCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+
+            throw $exception;
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Services/ProjectMarginReportBindingFactory.php
+++ b/app/BusinessModules/Features/Budgeting/Services/ProjectMarginReportBindingFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Services;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+
+final readonly class ProjectMarginReportBindingFactory
+{
+    public function __construct(
+        private ProjectMarginReportSourceSnapshotAdapter $adapter,
+        private ProjectMarginCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->adapter,
+            $this->adapter,
+            $this->adapter,
+            null,
+        );
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Services/ProjectMarginReportSourceSnapshotAdapter.php
+++ b/app/BusinessModules/Features/Budgeting/Services/ProjectMarginReportSourceSnapshotAdapter.php
@@ -40,6 +40,7 @@ final class ProjectMarginReportSourceSnapshotAdapter extends AbstractBudgetingRe
     {
         return $this->closeService->validatedCloseForReporting(
             $this->closeId($query),
+            ProjectMarginSourceSnapshotMaterializer::REPORT_CODE,
             $this->closeIdentity($query),
             $query->asOf,
         )->formulaVersion;

--- a/app/BusinessModules/Features/Budgeting/Services/ProjectMarginSourceSnapshotWriter.php
+++ b/app/BusinessModules/Features/Budgeting/Services/ProjectMarginSourceSnapshotWriter.php
@@ -22,7 +22,12 @@ final class ProjectMarginSourceSnapshotWriter
 
     public function persist(ProjectMarginSourceSnapshotRequest $request): ReportSourceSnapshotHeader
     {
-        $close = $this->closeService->validatedCloseForReporting($request->closeId, $request->closeIdentity, $request->asOf);
+        $close = $this->closeService->validatedCloseForReporting(
+            $request->closeId,
+            ProjectMarginSourceSnapshotMaterializer::REPORT_CODE,
+            $request->closeIdentity,
+            $request->asOf,
+        );
         $filters = $this->normalizeFilters($request);
         $identity = $this->materializer->identity($request->scope, $filters, $close->closeId, $request->reportQueryIdentity);
         $ready = $this->store->findReady($identity);

--- a/app/BusinessModules/Features/Budgeting/migrations/2026_08_05_120000_scope_budgeting_report_source_closes_by_report.php
+++ b/app/BusinessModules/Features/Budgeting/migrations/2026_08_05_120000_scope_budgeting_report_source_closes_by_report.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::unprepared(<<<'SQL'
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM budgeting_report_source_closes
+                    WHERE formula_version NOT IN ('margin-v1', '1.0.0')
+                ) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_report_backfill_unknown';
+                END IF;
+            END;
+            $$
+            SQL);
+        Schema::table('budgeting_report_source_closes', function (Blueprint $table): void {
+            $table->string('report_code', 64)->nullable()->after('close_id');
+        });
+        DB::statement('DROP TRIGGER budgeting_report_source_close_immutability_trigger ON budgeting_report_source_closes');
+        DB::statement(<<<'SQL'
+            UPDATE budgeting_report_source_closes
+            SET report_code = CASE
+                WHEN formula_version = 'margin-v1' THEN 'project_margin'
+                WHEN formula_version = '1.0.0' THEN 'budget_plan_fact'
+            END
+            WHERE report_code IS NULL
+            SQL);
+        DB::statement(<<<'SQL'
+            CREATE TRIGGER budgeting_report_source_close_immutability_trigger
+            BEFORE UPDATE OR DELETE ON budgeting_report_source_closes
+            FOR EACH ROW EXECUTE FUNCTION budgeting_report_source_close_immutability_guard()
+            SQL);
+        DB::statement('ALTER TABLE budgeting_report_source_closes ALTER COLUMN report_code SET NOT NULL');
+        DB::statement("ALTER TABLE budgeting_report_source_closes
+            ADD CONSTRAINT budgeting_report_source_close_report_code_check
+            CHECK (report_code ~ '^[a-z][a-z0-9_]{2,63}$')");
+        DB::statement('DROP INDEX IF EXISTS budgeting_report_close_active_identity_unique');
+        DB::statement("CREATE UNIQUE INDEX budgeting_report_close_active_identity_unique
+            ON budgeting_report_source_closes (report_code, organization_id, period_start, period_end, scenario_identity, plan_identity)
+            WHERE status = 'approved'");
+        Schema::table('budgeting_report_source_closes', function (Blueprint $table): void {
+            $table->index(
+                ['organization_id', 'report_code', 'formula_version', 'status'],
+                'budgeting_report_close_options_idx',
+            );
+        });
+
+        DB::unprepared(<<<'SQL'
+            CREATE OR REPLACE FUNCTION budgeting_report_source_close_immutability_guard()
+            RETURNS trigger AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_immutable';
+                END IF;
+
+                IF OLD.close_id IS DISTINCT FROM NEW.close_id
+                    OR OLD.report_code IS DISTINCT FROM NEW.report_code
+                    OR OLD.organization_id IS DISTINCT FROM NEW.organization_id
+                    OR OLD.period_start IS DISTINCT FROM NEW.period_start
+                    OR OLD.period_end IS DISTINCT FROM NEW.period_end
+                    OR OLD.scenario_identity IS DISTINCT FROM NEW.scenario_identity
+                    OR OLD.plan_identity IS DISTINCT FROM NEW.plan_identity
+                    OR OLD.formula_version IS DISTINCT FROM NEW.formula_version
+                    OR OLD.source_manifest IS DISTINCT FROM NEW.source_manifest
+                    OR OLD.content_hash IS DISTINCT FROM NEW.content_hash
+                    OR OLD.approved_by IS DISTINCT FROM NEW.approved_by
+                    OR OLD.approved_at IS DISTINCT FROM NEW.approved_at
+                    OR OLD.retained_until IS DISTINCT FROM NEW.retained_until
+                    OR OLD.restates_close_id IS DISTINCT FROM NEW.restates_close_id THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_immutable';
+                END IF;
+
+                IF OLD.status <> 'approved'
+                    OR NEW.status NOT IN ('restated', 'expired')
+                    OR (NEW.status = 'restated' AND (NEW.restated_by IS NULL OR NEW.restated_at IS NULL OR NEW.restated_by_close_id IS NULL))
+                    OR (NEW.status = 'expired' AND (NEW.restated_by IS NOT NULL OR NEW.restated_at IS NOT NULL OR NEW.restated_by_close_id IS NOT NULL)) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_invalid_transition';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE OR REPLACE FUNCTION budgeting_report_source_close_restatement_guard()
+            RETURNS trigger AS $$
+            BEGIN
+                IF NEW.status = 'restated' AND NOT EXISTS (
+                    SELECT 1
+                    FROM budgeting_report_source_closes replacement
+                    WHERE replacement.close_id = NEW.restated_by_close_id
+                        AND replacement.status = 'approved'
+                        AND replacement.restates_close_id = NEW.close_id
+                        AND replacement.report_code = NEW.report_code
+                        AND replacement.organization_id = NEW.organization_id
+                        AND replacement.period_start = NEW.period_start
+                        AND replacement.period_end = NEW.period_end
+                        AND replacement.scenario_identity = NEW.scenario_identity
+                        AND replacement.plan_identity = NEW.plan_identity
+                ) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_restatement_link_invalid';
+                END IF;
+
+                IF NEW.restates_close_id IS NOT NULL AND NOT EXISTS (
+                    SELECT 1
+                    FROM budgeting_report_source_closes prior_close
+                    WHERE prior_close.close_id = NEW.restates_close_id
+                        AND prior_close.status = 'restated'
+                        AND prior_close.restated_by_close_id = NEW.close_id
+                        AND prior_close.report_code = NEW.report_code
+                        AND prior_close.organization_id = NEW.organization_id
+                        AND prior_close.period_start = NEW.period_start
+                        AND prior_close.period_end = NEW.period_end
+                        AND prior_close.scenario_identity = NEW.scenario_identity
+                        AND prior_close.plan_identity = NEW.plan_identity
+                ) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_restatement_link_invalid';
+                END IF;
+
+                RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql;
+            SQL);
+    }
+
+    public function down(): void
+    {
+        DB::unprepared(<<<'SQL'
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM budgeting_report_source_closes
+                    WHERE status = 'approved'
+                    GROUP BY organization_id, period_start, period_end, scenario_identity, plan_identity
+                    HAVING COUNT(*) > 1
+                ) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_report_rollback_conflict';
+                END IF;
+            END;
+            $$
+            SQL);
+        DB::statement('DROP TRIGGER budgeting_report_source_close_immutability_trigger ON budgeting_report_source_closes');
+        DB::statement('DROP TRIGGER budgeting_report_source_close_restatement_trigger ON budgeting_report_source_closes');
+        DB::statement('DROP FUNCTION budgeting_report_source_close_immutability_guard()');
+        DB::statement('DROP FUNCTION budgeting_report_source_close_restatement_guard()');
+        DB::statement('DROP INDEX IF EXISTS budgeting_report_close_active_identity_unique');
+        Schema::table('budgeting_report_source_closes', function (Blueprint $table): void {
+            $table->dropIndex('budgeting_report_close_options_idx');
+        });
+        Schema::table('budgeting_report_source_closes', function (Blueprint $table): void {
+            $table->dropColumn('report_code');
+        });
+        DB::statement("CREATE UNIQUE INDEX budgeting_report_close_active_identity_unique
+            ON budgeting_report_source_closes (organization_id, period_start, period_end, scenario_identity, plan_identity)
+            WHERE status = 'approved'");
+        DB::unprepared(<<<'SQL'
+            CREATE FUNCTION budgeting_report_source_close_immutability_guard()
+            RETURNS trigger AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_immutable';
+                END IF;
+
+                IF OLD.close_id IS DISTINCT FROM NEW.close_id
+                    OR OLD.organization_id IS DISTINCT FROM NEW.organization_id
+                    OR OLD.period_start IS DISTINCT FROM NEW.period_start
+                    OR OLD.period_end IS DISTINCT FROM NEW.period_end
+                    OR OLD.scenario_identity IS DISTINCT FROM NEW.scenario_identity
+                    OR OLD.plan_identity IS DISTINCT FROM NEW.plan_identity
+                    OR OLD.formula_version IS DISTINCT FROM NEW.formula_version
+                    OR OLD.source_manifest IS DISTINCT FROM NEW.source_manifest
+                    OR OLD.content_hash IS DISTINCT FROM NEW.content_hash
+                    OR OLD.approved_by IS DISTINCT FROM NEW.approved_by
+                    OR OLD.approved_at IS DISTINCT FROM NEW.approved_at
+                    OR OLD.retained_until IS DISTINCT FROM NEW.retained_until
+                    OR OLD.restates_close_id IS DISTINCT FROM NEW.restates_close_id THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_immutable';
+                END IF;
+
+                IF OLD.status <> 'approved'
+                    OR NEW.status NOT IN ('restated', 'expired')
+                    OR (NEW.status = 'restated' AND (NEW.restated_by IS NULL OR NEW.restated_at IS NULL OR NEW.restated_by_close_id IS NULL))
+                    OR (NEW.status = 'expired' AND (NEW.restated_by IS NOT NULL OR NEW.restated_at IS NOT NULL OR NEW.restated_by_close_id IS NOT NULL)) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_invalid_transition';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE TRIGGER budgeting_report_source_close_immutability_trigger
+            BEFORE UPDATE OR DELETE ON budgeting_report_source_closes
+            FOR EACH ROW EXECUTE FUNCTION budgeting_report_source_close_immutability_guard();
+
+            CREATE FUNCTION budgeting_report_source_close_restatement_guard()
+            RETURNS trigger AS $$
+            BEGIN
+                IF NEW.status = 'restated' AND NOT EXISTS (
+                    SELECT 1
+                    FROM budgeting_report_source_closes replacement
+                    WHERE replacement.close_id = NEW.restated_by_close_id
+                        AND replacement.status = 'approved'
+                        AND replacement.restates_close_id = NEW.close_id
+                        AND replacement.organization_id = NEW.organization_id
+                        AND replacement.period_start = NEW.period_start
+                        AND replacement.period_end = NEW.period_end
+                        AND replacement.scenario_identity = NEW.scenario_identity
+                        AND replacement.plan_identity = NEW.plan_identity
+                ) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_restatement_link_invalid';
+                END IF;
+
+                IF NEW.restates_close_id IS NOT NULL AND NOT EXISTS (
+                    SELECT 1
+                    FROM budgeting_report_source_closes prior_close
+                    WHERE prior_close.close_id = NEW.restates_close_id
+                        AND prior_close.status = 'restated'
+                        AND prior_close.restated_by_close_id = NEW.close_id
+                        AND prior_close.organization_id = NEW.organization_id
+                        AND prior_close.period_start = NEW.period_start
+                        AND prior_close.period_end = NEW.period_end
+                        AND prior_close.scenario_identity = NEW.scenario_identity
+                        AND prior_close.plan_identity = NEW.plan_identity
+                ) THEN
+                    RAISE EXCEPTION 'budgeting_report_source_close_restatement_link_invalid';
+                END IF;
+
+                RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE CONSTRAINT TRIGGER budgeting_report_source_close_restatement_trigger
+            AFTER INSERT OR UPDATE ON budgeting_report_source_closes
+            DEFERRABLE INITIALLY DEFERRED
+            FOR EACH ROW EXECUTE FUNCTION budgeting_report_source_close_restatement_guard();
+            SQL);
+    }
+};

--- a/docs/reports/wave-1-source-contracts.md
+++ b/docs/reports/wave-1-source-contracts.md
@@ -4,11 +4,11 @@
 
 G10 `budget_plan_fact` admitted and published after the owner-approved close, immutable source snapshot, replay, scoped runtime binding, rows, drill-down and export contracts were implemented. Its current runtime uses `PlanFactReportSourceSnapshotAdapter`; organization and project scope are derived server-side. The reconciliation status and verification boundary are recorded in `budget-plan-fact-reconciliation.md`.
 
-G01, G04 and G09 remain blocked by source readiness. G09 has an owner-approved close contract and pre-admission writer, but still has no published runtime binding.
+G01 and G04 remain blocked by source readiness. G09 is admitted through the canonical runtime after its approved-close, immutable snapshot, replay and scoped provider contracts were completed.
 
 G06, G11, G12, G13 and G21-G24 remain blocked by an explicit source contract. Their binding status is `blocked_by_source_contract`, their provider is `null`, and they are not executable reports.
 
-Other candidates retain their status below; this document must not use the historical pre-admission state to describe published G10.
+Other candidates retain their status below. The closed candidate-inventory manifest remains historical admission input and must not be used as runtime status for published G09 or G10.
 
 ## Source-readiness contracts
 
@@ -16,12 +16,12 @@ Other candidates retain their status below; this document must not use the histo
 | --- | --- | --- | --- |
 | G01 project_portfolio_health | Portfolio aggregation | Immutable as-of snapshot, replay cursor, and source-version retention | A persisted source snapshot can be replayed by `(organization_id, as_of, source_version)` with identical scoped and redacted rows. |
 | G04 portfolio_liquidity | Liquidity forecast aggregation | Immutable forecast snapshot, scenario version, and replay cursor | A persisted snapshot can be replayed by `(organization_id, as_of, scenario_id, source_version)` without reading mutable current state. |
-| G09 project_margin | Project-margin calculation | Approved close identity, immutable inputs, per-source watermark, formula/source version and replay cursor | An approved close snapshot reproduces rows from `(organization_id, reporting_period, close_version)` after later source changes. |
+| G09 project_margin | Project-margin calculation | Admitted: approved close identity, immutable inputs, per-source watermarks, formula/source version, scoped cursor and replay are implemented | An approved close snapshot reproduces rows, totals and attribution drill entries from `(organization_id, reporting_period, close_version)` after later source changes. |
 | G10 budget_plan_fact | Budget plan/fact calculation | Admitted: approved close, immutable source snapshot, watermarks, formula/source version, scoped cursor and replay are implemented | A persisted `(organization_id, reporting_period, scenario_id, source_version)` snapshot reproduces plan, fact, variance, drill rows and totals without client-controlled tenant scope. |
 
 ### G09 `project_margin` source snapshot contract (schema `1.0.0`)
 
-`ProjectMarginSourceSnapshotWriter` is a pre-admission infrastructure writer. It calls the real `ProjectMarginReportService` and persists only through `ReportSourceSnapshotStore`; it is not a `ReportDataProvider`, `ReportRowQuery`, `ReportDrillDownProvider`, runtime binding, route or catalog registration.
+`ProjectMarginSourceSnapshotWriter` calls the real scoped `ProjectMarginReportService` and persists only through `ReportSourceSnapshotStore`. `ProjectMarginReportSourceSnapshotAdapter` supplies the published `ReportDataProvider`, `ReportRowQuery` and `ReportDrillDownProvider` binding.
 
 | Contract element | G09 rule |
 | --- | --- |
@@ -35,7 +35,7 @@ Other candidates retain their status below; this document must not use the histo
 | Redaction | Rows exclude project, contract, counterparty, article and responsibility-center display names. Drill entries exclude raw line/source IDs, document numbers, titles, source URLs, route hints, permissions and nested labels; only `sha256(line_id)` is retained as the opaque attribution reference. |
 | Freshness and close limitation | The current source service reads live budget, act, work, payment, warehouse and time-entry tables. `BudgetPeriodClosure` locks the budgeting period but retains only a management summary (counts and totals), not the selected versions, fact inputs, per-source update watermarks or a content hash. Its period may be reopened. `BudgetVersion` has an approval/activation workflow but no immutable materialization of lines and amounts, and it covers neither facts nor the other G09 sources. `EpmDataMartSnapshot` is a recalculation artifact, not an owner-approved close; newer recalculations supersede it and no retention policy is attached. A writer may set `as_of`/`stale_at`, but this does not establish a close policy or admission. |
 
-G09 therefore remains `blocked_by_source_readiness` with a `null` provider. Close validation is wired into the pre-admission writer, but admission still requires PostgreSQL CI constraint evidence, a replay acceptance test showing a closed-period snapshot remains identical after upstream mutation, and runtime-provider conformance. No runtime provider is created by this wiring.
+G09 is published through the canonical runtime with formula version `margin-v1`. The project route injects organization/project filters from verified request context and rejects client-supplied scope. Options expose only retained approved closes for the current organization and the exact G09 formula version. Rows, server-provided totals, attribution drill-down and CSV/XLSX export read one sealed snapshot. The PostgreSQL constraint test remains deployment/CI evidence and is not executed through a local database command.
 
 ### G10 `budget_plan_fact` source snapshot contract (schema `1.0.0`)
 
@@ -54,7 +54,7 @@ G09 therefore remains `blocked_by_source_readiness` with a `null` provider. Clos
 | Redaction | Rows exclude article, responsibility-center, project, counterparty and scenario display payloads. Drill entries exclude raw IDs, numbers, titles, route hints and source URLs; `sha256(source_type|source_id)` is the only retained source reference. |
 | Freshness and close limitation | `PlanFactReportService` currently reads mutable budget, payment transaction, reservation, payment document and schedule tables. `BudgetPeriodClosure` locks budget edits but does not capture the active version identifiers, plan rows, factual inputs, per-source update watermarks or a content hash; the period may be reopened. A `BudgetVersion` approval/activation records lifecycle timestamps but is not a retained immutable plan snapshot and does not version facts, reservations or documents. `EpmDataMartSnapshot` is recalculated from live services, superseded on the next run and has no owner approval or retention policy. A writer may set `as_of`/`stale_at`, but this is only a captured live result and does not establish a close policy or admission. |
 
-G10 is published through the canonical runtime. The project route injects organization/project filters from verified request context and rejects client-supplied scope. Options expose only retained approved closes of the current organization. Rows, server-provided totals, drill-down and CSV/XLSX share one sealed snapshot. PostgreSQL migration/constraint execution remains a deployment responsibility and is not emulated by local DB commands.
+G10 is published through the canonical runtime. The project route injects organization/project filters from verified request context and rejects client-supplied scope. Options expose only retained approved closes of the current organization with the exact G10 formula version. Rows, server-provided totals, drill-down and CSV/XLSX share one sealed snapshot. PostgreSQL migration/constraint execution remains a deployment responsibility and is not emulated by local DB commands.
 
 ### G09/G10 close and source-version decision (verified 2026-07-31)
 
@@ -66,15 +66,17 @@ No existing Budgeting model is an authoritative approved-close source for either
 | `BudgetPeriodClosure` | Budget changes were blocked at one moment and a management summary was recorded. | Its metadata stores counts and totals, not the complete selected version set, source rows, source update cutoffs, content hash, retention horizon or factual source state. A later reopen creates a new lifecycle event rather than a protected source version. |
 | `EpmDataMartSnapshot` | A live-service payload was generated with a derived `source_hash` and freshness data. | It is a recalculation artifact, not owner-approved close evidence. It is superseded on the next recalculation and has neither a close identity nor a documented retention policy or per-source update watermarks. |
 
-The approved-close contract now stores an explicit record outside the Reporting runtime with immutable `close_id`; organization and inclusive reporting period; selected plan/scenario version identities; a source watermark and cutoff for every factual source used by the candidate; formula/source-schema version; canonical content hash; approver and approval time; lifecycle/restatement relation; and a retention deadline. The G09/G10 pre-admission writers require that record before reading their live scoped services, and carry its identity into the snapshot source hash and watermarks. Until the remaining gates pass, capture metadata, `as_of`, `stale_at`, `source_hash`, `BudgetVersion`, `BudgetPeriodClosure` and `EpmDataMartSnapshot` remain non-admission evidence.
+The approved-close contract stores an explicit record outside the Reporting runtime with immutable `close_id`; organization and inclusive reporting period; selected plan/scenario version identities; a source watermark and cutoff for every factual source used by the report; formula/source-schema version; canonical content hash; approver and approval time; lifecycle/restatement relation; and a retention deadline. G09 and G10 require that record before reading their live scoped services and carry its identity into the snapshot source hash and watermarks. Formula versions are report-specific (`margin-v1` and `1.0.0` respectively), so a close from one report cannot be selected or executed as the other. Capture metadata, `as_of`, `stale_at`, `source_hash`, `BudgetVersion`, `BudgetPeriodClosure` and `EpmDataMartSnapshot` alone remain non-admission evidence.
 
 ### G09/G10 approved close contract and storage
 
-`budgeting_report_source_closes` and `budgeting_report_source_watermarks` provide the separate owner-owned close boundary outside Reporting runtime. A close has an ULID `close_id`, organization, inclusive period, scenario and plan identities, formula version, canonical source manifest/content hash, owner/approval time, mandatory retention deadline and restatement lifecycle. Every source has its own cutoff, watermark and source-schema version.
+`budgeting_report_source_closes` and `budgeting_report_source_watermarks` provide the separate owner-owned close boundary outside Reporting runtime. A close has an ULID `close_id`, immutable `report_code`, organization, inclusive period, scenario and plan identities, report-specific formula version, canonical source manifest/content hash, owner/approval time, mandatory retention deadline and restatement lifecycle. Every source has its own cutoff, watermark and source-schema version.
 
-PostgreSQL admits only one active `approved` close for an organization/period/scenario/plan identity. A second close must name that exact prior close as a restatement; deferred foreign keys and a deferred reverse-link check require the prior close to be `restated`, the replacement to remain `approved`, and both identities to match. Header content and watermarks cannot be changed or deleted after creation; only the one-way approved-to-restated/expired lifecycle transition is permitted. `BudgetingReportSourceCloseService` can create explicit approved input and validate a retained approved close for a future G09/G10 writer, but it does not call live reporting services or recompute source data.
+PostgreSQL admits only one active `approved` close for a `(report_code, organization, period, scenario, plan)` identity, so G09 and G10 can close the same business period independently. A second close of the same report must name that exact prior close as a restatement; deferred foreign keys and a deferred reverse-link check require the prior close to be `restated`, the replacement to remain `approved`, and the report code plus business identity to match. Header content and watermarks cannot be changed or deleted after creation; only the one-way approved-to-restated/expired lifecycle transition is permitted. `BudgetingReportSourceCloseService` creates explicit approved input and validates the report code, identity, status and retention before a runtime writer can read source data.
 
-This contract remains pre-admission infrastructure for G09. For G10 it is consumed by the published runtime binding and is part of the immutable source identity.
+The forward migration maps only the two previously valid formula versions (`margin-v1` → `project_margin`, `1.0.0` → `budget_plan_fact`) and aborts before mutation if an unknown legacy formula is present. It is applied by the normal deployment migration process; no local database execution is part of this delivery.
+
+This contract is consumed by both published G09 and G10 runtime bindings and is part of each immutable source identity.
 
 ## Source contracts
 
@@ -106,4 +108,4 @@ Only a `ready` snapshot may be read. Reads must match organization, complete can
 
 Persistence seals the header after row insertion. PostgreSQL constraints and triggers prevent a ready or expired header, its rows or its drill rows from being changed or appended. Replay ordering is the persisted ordinal with row-key uniqueness; drill ordering is persisted per `(snapshot_id, row_key, column_id, ordinal)`.
 
-This foundation alone is not candidate admission evidence. G01, G04 and G09 remain `blocked_by_source_readiness` with `provider: null` until each owner supplies the remaining source-specific evidence. G10 additionally supplies its source writer, close validation, runtime adapter, route, catalog registration, UI and focused replay/context tests.
+This foundation alone is not candidate admission evidence. G01 and G04 remain `blocked_by_source_readiness` with `provider: null` until each owner supplies the remaining source-specific evidence. G09 and G10 additionally supply their source writer, close validation, runtime adapter, route, catalog registration and focused replay/context tests; UI completion is tracked by each report's Definition of Done.

--- a/docs/superpowers/plans/2026-08-04-reports-architecture-simplification.md
+++ b/docs/superpowers/plans/2026-08-04-reports-architecture-simplification.md
@@ -128,7 +128,7 @@ UI различает initial, options loading, ready to run, validation error, 
 
 1. Reconciliation G10 «План-факт бюджета»: сверить фактический `main` с полным Definition of Done и исправить устаревшие source/handoff документы.
 2. Cleanup отменённой publication/CI-инфраструктуры отдельным блоком.
-3. G09 «Маржинальность проекта» после доказательства approved close/replay.
+3. G09 «Маржинальность проекта»: approved close/replay доказаны; выполняется последовательная поставка canonical backend, затем admin UI.
 4. Остальные отчёты — по одному, в порядке реальной готовности источников.
 
 Для каждого блока создаются отдельные backend/admin feature-ветки от актуальных `main`; выполняются минимальные релевантные проверки и одно независимое review.

--- a/tests/Integration/Budgeting/BudgetingReportSourceClosePostgresTest.php
+++ b/tests/Integration/Budgeting/BudgetingReportSourceClosePostgresTest.php
@@ -14,7 +14,8 @@ use PHPUnit\Framework\TestCase;
 
 final class BudgetingReportSourceClosePostgresTest extends TestCase
 {
-    private ?Migration $migration = null;
+    /** @var list<Migration> */
+    private array $migrations = [];
 
     protected function setUp(): void
     {
@@ -24,7 +25,7 @@ final class BudgetingReportSourceClosePostgresTest extends TestCase
             $this->markTestSkipped('RUN_PGSQL_CLOSE_CONTRACT_TESTS=1 is required.');
         }
 
-        $app = require dirname(__DIR__, 3) . '/bootstrap/app.php';
+        $app = require dirname(__DIR__, 3).'/bootstrap/app.php';
         $app->make(Kernel::class)->bootstrap();
 
         $connection = DB::connection();
@@ -33,14 +34,14 @@ final class BudgetingReportSourceClosePostgresTest extends TestCase
         }
 
         $database = (string) $connection->getDatabaseName();
-        if (!str_ends_with($database, '_test')) {
+        if (! str_ends_with($database, '_test')) {
             throw new LogicException('pgsql_close_contract_test_database_required');
         }
 
         Schema::dropIfExists('budgeting_report_source_watermarks');
         Schema::dropIfExists('budgeting_report_source_closes');
 
-        if (!Schema::hasTable('users')) {
+        if (! Schema::hasTable('users')) {
             Schema::create('users', function ($table): void {
                 $table->id();
                 $table->string('name');
@@ -55,18 +56,25 @@ final class BudgetingReportSourceClosePostgresTest extends TestCase
             ['name' => 'Close contract test', 'email' => 'close-contract-test@example.test', 'password' => 'not-used']
         );
 
-        $migration = require dirname(__DIR__, 3) . '/app/BusinessModules/Features/Budgeting/migrations/2026_07_31_120000_create_budgeting_report_source_close_tables.php';
-        if (!$migration instanceof Migration) {
-            throw new LogicException('pgsql_close_contract_migration_invalid');
-        }
+        foreach ([
+            '2026_07_31_120000_create_budgeting_report_source_close_tables.php',
+            '2026_08_05_120000_scope_budgeting_report_source_closes_by_report.php',
+        ] as $migrationFile) {
+            $migration = require dirname(__DIR__, 3).'/app/BusinessModules/Features/Budgeting/migrations/'.$migrationFile;
+            if (! $migration instanceof Migration) {
+                throw new LogicException('pgsql_close_contract_migration_invalid');
+            }
 
-        $this->migration = $migration;
-        $this->migration->up();
+            $migration->up();
+            $this->migrations[] = $migration;
+        }
     }
 
     protected function tearDown(): void
     {
-        $this->migration?->down();
+        foreach (array_reverse($this->migrations) as $migration) {
+            $migration->down();
+        }
 
         parent::tearDown();
     }
@@ -77,6 +85,21 @@ final class BudgetingReportSourceClosePostgresTest extends TestCase
 
         $this->expectException(QueryException::class);
         DB::table('budgeting_report_source_closes')->insert($this->close('01K00000000000000000000000'));
+    }
+
+    public function test_different_reports_can_close_the_same_period_identity_independently(): void
+    {
+        DB::table('budgeting_report_source_closes')->insert($this->close('01JZZZZZZZZZZZZZZZZZZZZZZZ'));
+        DB::table('budgeting_report_source_closes')->insert($this->close(
+            '01K00000000000000000000000',
+            reportCode: 'budget_plan_fact',
+        ));
+
+        self::assertSame(2, DB::table('budgeting_report_source_closes')->count());
+
+        DB::table('budgeting_report_source_closes')
+            ->where('report_code', 'budget_plan_fact')
+            ->update(['status' => 'expired']);
     }
 
     public function test_header_and_watermark_are_immutable(): void
@@ -162,10 +185,37 @@ final class BudgetingReportSourceClosePostgresTest extends TestCase
         });
     }
 
-    private function close(string $closeId, ?string $restatesCloseId = null, string $planIdentity = 'budget-v2'): array
+    public function test_restatement_with_replacement_from_another_report_is_rejected_at_commit(): void
     {
+        $priorCloseId = '01JZZZZZZZZZZZZZZZZZZZZZZZ';
+        $replacementCloseId = '01K00000000000000000000000';
+        DB::table('budgeting_report_source_closes')->insert($this->close($priorCloseId));
+
+        $this->expectException(QueryException::class);
+        DB::transaction(function () use ($priorCloseId, $replacementCloseId): void {
+            DB::table('budgeting_report_source_closes')->where('close_id', $priorCloseId)->update([
+                'status' => 'restated',
+                'restated_by' => 900000001,
+                'restated_at' => '2026-02-01 00:00:00+00',
+                'restated_by_close_id' => $replacementCloseId,
+            ]);
+            DB::table('budgeting_report_source_closes')->insert($this->close(
+                $replacementCloseId,
+                $priorCloseId,
+                reportCode: 'budget_plan_fact',
+            ));
+        });
+    }
+
+    private function close(
+        string $closeId,
+        ?string $restatesCloseId = null,
+        string $planIdentity = 'budget-v2',
+        string $reportCode = 'project_margin',
+    ): array {
         return [
             'close_id' => $closeId,
+            'report_code' => $reportCode,
             'organization_id' => 700001,
             'period_start' => '2026-01-01',
             'period_end' => '2026-01-31',

--- a/tests/Support/Budgeting/BudgetPlanFactCandidateFixture.php
+++ b/tests/Support/Budgeting/BudgetPlanFactCandidateFixture.php
@@ -81,9 +81,11 @@ final class BudgetPlanFactCandidateFixture
     public static function close(
         ?BudgetingReportSourceCloseIdentity $identity = null,
         ?string $formulaVersion = null,
+        string $reportCode = BudgetPlanFactCandidateContract::CODE,
     ): BudgetingReportSourceClose {
         return new BudgetingReportSourceClose(
             self::closeId(),
+            $reportCode,
             $identity ?? self::closeIdentity(),
             [new BudgetingReportSourceWatermark('budget', new DateTimeImmutable('2026-01-31T00:00:00+00:00'), 'budget:1', 'budget-v1')],
             $formulaVersion ?? BudgetPlanFactCandidateContract::FORMULA_VERSION,

--- a/tests/Unit/Budgeting/BudgetingReportOptionsFormulaIsolationTest.php
+++ b/tests/Unit/Budgeting/BudgetingReportOptionsFormulaIsolationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Budgeting;
+
+use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\Budgeting\Services\BudgetingReportOptionsService;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class BudgetingReportOptionsFormulaIsolationTest extends TestCase
+{
+    public function test_each_report_has_a_distinct_close_formula_and_options_filter_by_it(): void
+    {
+        self::assertNotSame(
+            BudgetPlanFactCandidateContract::FORMULA_VERSION,
+            ProjectMarginCandidateContract::FORMULA_VERSION,
+        );
+
+        $file = (new ReflectionClass(BudgetingReportOptionsService::class))->getFileName();
+        self::assertIsString($file);
+        $source = file_get_contents($file);
+        self::assertIsString($source);
+        self::assertStringContainsString("->where('report_code', \$reportCode)", $source);
+        self::assertStringContainsString("->where('formula_version', \$formulaVersion)", $source);
+    }
+}

--- a/tests/Unit/Budgeting/BudgetingReportSnapshotCompositionTest.php
+++ b/tests/Unit/Budgeting/BudgetingReportSnapshotCompositionTest.php
@@ -11,11 +11,15 @@ use App\BusinessModules\Core\Reporting\ReportingContractsServiceProvider;
 use App\BusinessModules\Features\Budgeting\BudgetingServiceProvider;
 use App\BusinessModules\Features\Budgeting\Contracts\BudgetingReportSourceCloseStore;
 use App\BusinessModules\Features\Budgeting\Contracts\PlanFactSourceSnapshotReport;
+use App\BusinessModules\Features\Budgeting\Contracts\ProjectMarginSourceSnapshotReport;
 use App\BusinessModules\Features\Budgeting\DTOs\BudgetingReportSourceClose;
 use App\BusinessModules\Features\Budgeting\DTOs\CreateBudgetingReportSourceClose;
 use App\BusinessModules\Features\Budgeting\Services\BudgetPlanFactReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Services\PlanFactReportSourceSnapshotAdapter;
 use App\BusinessModules\Features\Budgeting\Services\PlanFactSourceSnapshotWriter;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginReportBindingFactory;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginReportSourceSnapshotAdapter;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginSourceSnapshotWriter;
 use Illuminate\Container\Container;
 use PHPUnit\Framework\TestCase;
 
@@ -28,6 +32,18 @@ final class BudgetingReportSnapshotCompositionTest extends TestCase
         (new BudgetingServiceProvider($app))->register();
 
         $app->bind(PlanFactSourceSnapshotReport::class, static fn (): PlanFactSourceSnapshotReport => new class implements PlanFactSourceSnapshotReport
+        {
+            public function reportForProjectScope(array $input, array $projectIds): array
+            {
+                return [];
+            }
+
+            public function drillDownForProjectScope(array $input, array $projectIds): array
+            {
+                return [];
+            }
+        });
+        $app->bind(ProjectMarginSourceSnapshotReport::class, static fn (): ProjectMarginSourceSnapshotReport => new class implements ProjectMarginSourceSnapshotReport
         {
             public function reportForProjectScope(array $input, array $projectIds): array
             {
@@ -57,5 +73,8 @@ final class BudgetingReportSnapshotCompositionTest extends TestCase
         self::assertInstanceOf(PlanFactSourceSnapshotWriter::class, $app->make(PlanFactSourceSnapshotWriter::class));
         self::assertInstanceOf(PlanFactReportSourceSnapshotAdapter::class, $app->make(PlanFactReportSourceSnapshotAdapter::class));
         self::assertInstanceOf(BudgetPlanFactReportBindingFactory::class, $app->make(BudgetPlanFactReportBindingFactory::class));
+        self::assertInstanceOf(ProjectMarginSourceSnapshotWriter::class, $app->make(ProjectMarginSourceSnapshotWriter::class));
+        self::assertInstanceOf(ProjectMarginReportSourceSnapshotAdapter::class, $app->make(ProjectMarginReportSourceSnapshotAdapter::class));
+        self::assertInstanceOf(ProjectMarginReportBindingFactory::class, $app->make(ProjectMarginReportBindingFactory::class));
     }
 }

--- a/tests/Unit/Budgeting/BudgetingReportSourceCloseReportScopeMigrationTest.php
+++ b/tests/Unit/Budgeting/BudgetingReportSourceCloseReportScopeMigrationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Budgeting;
+
+use PHPUnit\Framework\TestCase;
+
+final class BudgetingReportSourceCloseReportScopeMigrationTest extends TestCase
+{
+    public function test_migration_scopes_uniqueness_immutability_and_restatement_by_report(): void
+    {
+        $migration = file_get_contents(
+            dirname(__DIR__, 3).'/app/BusinessModules/Features/Budgeting/migrations/'
+            .'2026_08_05_120000_scope_budgeting_report_source_closes_by_report.php',
+        );
+        self::assertIsString($migration);
+
+        self::assertStringContainsString(
+            '(report_code, organization_id, period_start, period_end, scenario_identity, plan_identity)',
+            $migration,
+        );
+        self::assertStringContainsString('OLD.report_code IS DISTINCT FROM NEW.report_code', $migration);
+        self::assertSame(2, substr_count($migration, 'replacement.report_code = NEW.report_code') + substr_count($migration, 'prior_close.report_code = NEW.report_code'));
+        self::assertStringContainsString('budgeting_report_source_close_report_backfill_unknown', $migration);
+        self::assertStringContainsString('budgeting_report_source_close_report_rollback_conflict', $migration);
+    }
+}

--- a/tests/Unit/Budgeting/BudgetingReportSourceCloseServiceTest.php
+++ b/tests/Unit/Budgeting/BudgetingReportSourceCloseServiceTest.php
@@ -17,16 +17,18 @@ use PHPUnit\Framework\TestCase;
 
 final class BudgetingReportSourceCloseServiceTest extends TestCase
 {
+    private const REPORT_CODE = 'project_margin';
+
     public function test_content_hash_is_canonical_across_manifest_and_watermark_order(): void
     {
         $identity = $this->identity();
         $first = $this->watermarks();
         $second = array_reverse($first);
 
-        $firstHash = CreateBudgetingReportSourceClose::contentHashFor($identity, $first, 'margin-v1', [
+        $firstHash = CreateBudgetingReportSourceClose::contentHashFor(self::REPORT_CODE, $identity, $first, 'margin-v1', [
             'sources' => ['budget' => ['version' => 'v2'], 'actual' => ['cutoff' => '2026-01-31']],
         ]);
-        $secondHash = CreateBudgetingReportSourceClose::contentHashFor($identity, $second, 'margin-v1', [
+        $secondHash = CreateBudgetingReportSourceClose::contentHashFor(self::REPORT_CODE, $identity, $second, 'margin-v1', [
             'sources' => ['actual' => ['cutoff' => '2026-01-31'], 'budget' => ['version' => 'v2']],
         ]);
 
@@ -39,6 +41,7 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
 
         new CreateBudgetingReportSourceClose(
             closeId: '01JZZZZZZZZZZZZZZZZZZZZZZZ',
+            reportCode: self::REPORT_CODE,
             identity: $this->identity(),
             sourceWatermarks: $this->watermarks(),
             formulaVersion: 'margin-v1',
@@ -52,7 +55,7 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
 
     public function test_only_one_active_close_is_created_for_an_identity_without_restatement(): void
     {
-        $store = new InMemoryBudgetingReportSourceCloseStore();
+        $store = new InMemoryBudgetingReportSourceCloseStore;
         $service = new BudgetingReportSourceCloseService($store);
         $first = $this->request('01JZZZZZZZZZZZZZZZZZZZZZZZ');
 
@@ -65,7 +68,7 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
 
     public function test_restatement_replaces_the_active_identity_only_when_it_names_the_prior_close(): void
     {
-        $store = new InMemoryBudgetingReportSourceCloseStore();
+        $store = new InMemoryBudgetingReportSourceCloseStore;
         $service = new BudgetingReportSourceCloseService($store);
         $original = $service->createApproved($this->request('01JZZZZZZZZZZZZZZZZZZZZZZZ'));
 
@@ -78,14 +81,29 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
         self::assertFalse(BudgetingReportSourceCloseStatus::RESTATED->canTransitionTo(BudgetingReportSourceCloseStatus::APPROVED));
     }
 
+    public function test_different_reports_have_independent_active_closes_for_the_same_period_identity(): void
+    {
+        $service = new BudgetingReportSourceCloseService(new InMemoryBudgetingReportSourceCloseStore);
+
+        $margin = $service->createApproved($this->request('01JZZZZZZZZZZZZZZZZZZZZZZZ'));
+        $planFact = $service->createApproved($this->request(
+            '01K00000000000000000000000',
+            reportCode: 'budget_plan_fact',
+        ));
+
+        self::assertSame(self::REPORT_CODE, $margin->reportCode);
+        self::assertSame('budget_plan_fact', $planFact->reportCode);
+    }
+
     public function test_validated_close_requires_matching_identity_and_retention(): void
     {
-        $store = new InMemoryBudgetingReportSourceCloseStore();
+        $store = new InMemoryBudgetingReportSourceCloseStore;
         $service = new BudgetingReportSourceCloseService($store);
         $close = $service->createApproved($this->request('01JZZZZZZZZZZZZZZZZZZZZZZZ'));
 
         self::assertSame($close, $service->validatedCloseForReporting(
             $close->closeId,
+            self::REPORT_CODE,
             $this->identity(),
             new DateTimeImmutable('2026-02-01T00:00:00+00:00'),
         ));
@@ -93,6 +111,7 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
         $this->expectException(DomainException::class);
         $service->validatedCloseForReporting(
             $close->closeId,
+            self::REPORT_CODE,
             new BudgetingReportSourceCloseIdentity(7, '2026-01-01', '2026-01-31', 'base', 'budget-v3'),
             new DateTimeImmutable('2026-02-01T00:00:00+00:00'),
         );
@@ -100,7 +119,7 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
 
     public function test_validated_close_rejects_an_expired_retention_deadline(): void
     {
-        $store = new InMemoryBudgetingReportSourceCloseStore();
+        $store = new InMemoryBudgetingReportSourceCloseStore;
         $service = new BudgetingReportSourceCloseService($store);
         $close = $service->createApproved($this->request(
             '01JZZZZZZZZZZZZZZZZZZZZZZZ',
@@ -111,6 +130,22 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
         $this->expectExceptionMessage('budgeting_report_source_close_not_available');
         $service->validatedCloseForReporting(
             $close->closeId,
+            self::REPORT_CODE,
+            $this->identity(),
+            new DateTimeImmutable('2026-02-01T00:00:00+00:00'),
+        );
+    }
+
+    public function test_validated_close_rejects_a_close_from_another_report(): void
+    {
+        $service = new BudgetingReportSourceCloseService(new InMemoryBudgetingReportSourceCloseStore);
+        $close = $service->createApproved($this->request('01JZZZZZZZZZZZZZZZZZZZZZZZ'));
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('budgeting_report_source_close_not_found');
+        $service->validatedCloseForReporting(
+            $close->closeId,
+            'budget_plan_fact',
             $this->identity(),
             new DateTimeImmutable('2026-02-01T00:00:00+00:00'),
         );
@@ -134,19 +169,20 @@ final class BudgetingReportSourceCloseServiceTest extends TestCase
         string $closeId,
         ?string $restatesCloseId = null,
         ?DateTimeImmutable $retainedUntil = null,
-    ): CreateBudgetingReportSourceClose
-    {
+        string $reportCode = self::REPORT_CODE,
+    ): CreateBudgetingReportSourceClose {
         $identity = $this->identity();
         $watermarks = $this->watermarks();
         $manifest = ['budget_version' => 'budget-v2', 'actuals_snapshot' => 'completed_work:771'];
 
         return new CreateBudgetingReportSourceClose(
             closeId: $closeId,
+            reportCode: $reportCode,
             identity: $identity,
             sourceWatermarks: $watermarks,
             formulaVersion: 'margin-v1',
             sourceManifest: $manifest,
-            contentHash: CreateBudgetingReportSourceClose::contentHashFor($identity, $watermarks, 'margin-v1', $manifest),
+            contentHash: CreateBudgetingReportSourceClose::contentHashFor($reportCode, $identity, $watermarks, 'margin-v1', $manifest),
             approvedBy: 11,
             approvedAt: new DateTimeImmutable('2026-01-31T18:00:00+00:00'),
             retainedUntil: $retainedUntil ?? new DateTimeImmutable('2033-01-31T00:00:00+00:00'),
@@ -165,7 +201,7 @@ final class InMemoryBudgetingReportSourceCloseStore implements BudgetingReportSo
 
     public function createApproved(CreateBudgetingReportSourceClose $request): BudgetingReportSourceClose
     {
-        $identity = json_encode($request->identity->toArray(), JSON_THROW_ON_ERROR);
+        $identity = $request->reportCode.':'.json_encode($request->identity->toArray(), JSON_THROW_ON_ERROR);
         $activeCloseId = $this->activeByIdentity[$identity] ?? null;
 
         if ($request->restatesCloseId === null && $activeCloseId !== null) {
@@ -180,6 +216,7 @@ final class InMemoryBudgetingReportSourceCloseStore implements BudgetingReportSo
             $prior = $this->byId[$request->restatesCloseId];
             $this->byId[$prior->closeId] = new BudgetingReportSourceClose(
                 closeId: $prior->closeId,
+                reportCode: $prior->reportCode,
                 identity: $prior->identity,
                 sourceWatermarks: $prior->sourceWatermarks,
                 formulaVersion: $prior->formulaVersion,
@@ -195,6 +232,7 @@ final class InMemoryBudgetingReportSourceCloseStore implements BudgetingReportSo
 
         $close = new BudgetingReportSourceClose(
             closeId: $request->closeId,
+            reportCode: $request->reportCode,
             identity: $request->identity,
             sourceWatermarks: $request->sourceWatermarks,
             formulaVersion: $request->formulaVersion,

--- a/tests/Unit/Budgeting/BudgetingReportSourceSnapshotAdapterTest.php
+++ b/tests/Unit/Budgeting/BudgetingReportSourceSnapshotAdapterTest.php
@@ -265,7 +265,10 @@ final class BudgetingReportSourceSnapshotAdapterTest extends TestCase
     {
         $store = new InMemoryReportSourceSnapshotStore;
         $source = new PlanFactSnapshotSource;
-        $closeService = self::closeService(BudgetPlanFactCandidateContract::FORMULA_VERSION);
+        $closeService = self::closeService(
+            BudgetPlanFactCandidateContract::CODE,
+            BudgetPlanFactCandidateContract::FORMULA_VERSION,
+        );
         $adapter = new PlanFactReportSourceSnapshotAdapter(
             new PlanFactSourceSnapshotWriter($source, new PlanFactSourceSnapshotMaterializer, $store, $closeService),
             $closeService,
@@ -345,7 +348,7 @@ final class BudgetingReportSourceSnapshotAdapterTest extends TestCase
             'G09 project margin' => (static function (): array {
                 $store = new InMemoryReportSourceSnapshotStore;
                 $source = new ProjectMarginSnapshotSource;
-                $closeService = self::closeService();
+                $closeService = self::closeService('project_margin');
                 $adapter = new ProjectMarginReportSourceSnapshotAdapter(
                     new ProjectMarginSourceSnapshotWriter(
                         $source,
@@ -362,7 +365,7 @@ final class BudgetingReportSourceSnapshotAdapterTest extends TestCase
             'G10 plan fact' => (static function (): array {
                 $store = new InMemoryReportSourceSnapshotStore;
                 $source = new PlanFactSnapshotSource;
-                $closeService = self::closeService();
+                $closeService = self::closeService('budget_plan_fact');
                 $adapter = new PlanFactReportSourceSnapshotAdapter(
                     new PlanFactSourceSnapshotWriter(
                         $source,
@@ -422,10 +425,11 @@ final class BudgetingReportSourceSnapshotAdapterTest extends TestCase
         );
     }
 
-    private static function closeService(string $formulaVersion = 'margin-v1'): BudgetingReportSourceCloseService
+    private static function closeService(string $reportCode, string $formulaVersion = 'margin-v1'): BudgetingReportSourceCloseService
     {
         $close = new BudgetingReportSourceClose(
             '01JZZZZZZZZZZZZZZZZZZZZZZZ',
+            $reportCode,
             new BudgetingReportSourceCloseIdentity(1, '2026-01-01', '2026-01-31', 'scenario-1', 'budget-1'),
             [new BudgetingReportSourceWatermark('actuals', new DateTimeImmutable('2026-01-31T17:00:00+00:00'), 'actuals:1', 'actuals-v1')],
             $formulaVersion,

--- a/tests/Unit/Budgeting/PlanFactSourceSnapshotTest.php
+++ b/tests/Unit/Budgeting/PlanFactSourceSnapshotTest.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Budgeting;
 
-use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStore;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStreamingStore;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotCursor;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotDrillPage;
+use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotDrillRow;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotHeader;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotIdentity;
+use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotIntegrity;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotPage;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotReadRequest;
-use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotWrite;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotStream;
-use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotDrillRow;
-use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotIntegrity;
+use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotWrite;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Features\Budgeting\Contracts\BudgetingReportSourceCloseStore;
 use App\BusinessModules\Features\Budgeting\Contracts\PlanFactSourceSnapshotReport;
@@ -321,6 +320,7 @@ final class PlanFactSourceSnapshotTest extends TestCase
         $first = $this->materialize($this->report());
         $other = new BudgetingReportSourceClose(
             closeId: '01K00000000000000000000000',
+            reportCode: 'budget_plan_fact',
             identity: $this->identity(),
             sourceWatermarks: $this->close()->sourceWatermarks,
             formulaVersion: 'margin-v1',
@@ -513,6 +513,7 @@ final class PlanFactSourceSnapshotTest extends TestCase
     {
         return new BudgetingReportSourceClose(
             closeId: '01JZZZZZZZZZZZZZZZZZZZZZZZ',
+            reportCode: 'budget_plan_fact',
             identity: $this->identity(),
             sourceWatermarks: [
                 new BudgetingReportSourceWatermark('actuals', new DateTimeImmutable('2026-01-31T17:00:00+00:00'), 'actuals:1', 'actuals-v1'),

--- a/tests/Unit/Budgeting/ProjectMarginPublishedRuntimeBindingRegistrarTest.php
+++ b/tests/Unit/Budgeting/ProjectMarginPublishedRuntimeBindingRegistrarTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Budgeting;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginReportBindingFactory;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginReportSourceSnapshotAdapter;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ProjectMarginPublishedRuntimeBindingRegistrarTest extends TestCase
+{
+    public function test_registers_the_sealed_snapshot_provider_for_the_published_definition(): void
+    {
+        $definition = (new ProjectMarginBuiltinPublishedReport(new ProjectMarginCandidateContract))->definition();
+        $adapter = (new ReflectionClass(ProjectMarginReportSourceSnapshotAdapter::class))->newInstanceWithoutConstructor();
+        $assembler = new ProjectMarginCapturingBindingAssembler;
+        $registrar = new ProjectMarginPublishedRuntimeBindingRegistrar(
+            new ProjectMarginPublishedRegistry($definition),
+            new ProjectMarginReportBindingFactory($adapter, new ProjectMarginCandidateContract),
+        );
+
+        $registrar->register($assembler);
+
+        $binding = $assembler->bindings[ProjectMarginCandidateContract::CODE];
+        self::assertSame($adapter, $binding->dataProvider);
+        self::assertSame($adapter, $binding->rowQuery);
+        self::assertSame($adapter, $binding->drillDownProvider);
+    }
+
+    public function test_skips_registration_when_definition_is_not_published(): void
+    {
+        $assembler = new ProjectMarginCapturingBindingAssembler;
+        $registrar = new ProjectMarginPublishedRuntimeBindingRegistrar(
+            new ProjectMarginUnpublishedRegistry,
+            new ProjectMarginReportBindingFactory(
+                (new ReflectionClass(ProjectMarginReportSourceSnapshotAdapter::class))->newInstanceWithoutConstructor(),
+                new ProjectMarginCandidateContract,
+            ),
+        );
+
+        $registrar->register($assembler);
+
+        self::assertSame([], $assembler->bindings);
+    }
+}
+
+final class ProjectMarginCapturingBindingAssembler implements ReportDefinitionBindingAssembler
+{
+    /** @var array<string, ReportDefinitionBinding> */
+    public array $bindings = [];
+
+    public function register(ReportDefinitionBinding $binding): void
+    {
+        $this->bindings[$binding->code] = $binding;
+    }
+
+    public function assemble(ReportDefinitionRegistry $registry): ReportDefinitionBindingMap
+    {
+        throw new LogicException('not_used');
+    }
+}
+
+final readonly class ProjectMarginPublishedRegistry implements ReportDefinitionRegistry
+{
+    public function __construct(private PublishedReportDefinition $definition) {}
+
+    public function published(string $code): PublishedReportDefinition
+    {
+        return $code === ProjectMarginCandidateContract::CODE
+            ? $this->definition
+            : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+    }
+
+    public function publishedCodes(): array
+    {
+        return [ProjectMarginCandidateContract::CODE];
+    }
+
+    public function manifestSha256(): Sha256Hash
+    {
+        return new Sha256Hash(str_repeat('a', 64));
+    }
+}
+
+final class ProjectMarginUnpublishedRegistry implements ReportDefinitionRegistry
+{
+    public function published(string $code): PublishedReportDefinition
+    {
+        throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+    }
+
+    public function publishedCodes(): array
+    {
+        return [];
+    }
+
+    public function manifestSha256(): Sha256Hash
+    {
+        return new Sha256Hash(str_repeat('a', 64));
+    }
+}

--- a/tests/Unit/Budgeting/ProjectMarginSourceSnapshotMaterializerTest.php
+++ b/tests/Unit/Budgeting/ProjectMarginSourceSnapshotMaterializerTest.php
@@ -57,7 +57,7 @@ final class ProjectMarginSourceSnapshotMaterializerTest extends TestCase
     public function test_source_hash_changes_when_the_validated_close_identity_changes(): void
     {
         $first = $this->materialize($this->report());
-        $second = (new ProjectMarginSourceSnapshotMaterializer())->materialize(
+        $second = (new ProjectMarginSourceSnapshotMaterializer)->materialize(
             '01ARZ3NDEKTSV4RRFFQ69G5FAV',
             new ReportScope(1, [1], [10, 20], [], new DateTimeZone('UTC')),
             [
@@ -88,7 +88,7 @@ final class ProjectMarginSourceSnapshotMaterializerTest extends TestCase
 
     private function materialize(array $report): \App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotWrite
     {
-        return (new ProjectMarginSourceSnapshotMaterializer())->materialize(
+        return (new ProjectMarginSourceSnapshotMaterializer)->materialize(
             '01ARZ3NDEKTSV4RRFFQ69G5FAV',
             new ReportScope(1, [1], [10, 20], [], new DateTimeZone('UTC')),
             [
@@ -114,6 +114,7 @@ final class ProjectMarginSourceSnapshotMaterializerTest extends TestCase
     {
         return new BudgetingReportSourceClose(
             closeId: $closeId,
+            reportCode: 'project_margin',
             identity: new BudgetingReportSourceCloseIdentity(1, '2026-01-01', '2026-01-31', 'scenario-1', 'budget-1'),
             sourceWatermarks: [
                 new BudgetingReportSourceWatermark('actuals', new DateTimeImmutable('2026-01-31T17:00:00+00:00'), 'actuals:1', 'actuals-v1'),

--- a/tests/Unit/Budgeting/ProjectMarginSourceSnapshotWriterCloseTest.php
+++ b/tests/Unit/Budgeting/ProjectMarginSourceSnapshotWriterCloseTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Budgeting;
 
-use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStore;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStreamingStore;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotCursor;
@@ -13,8 +12,8 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSn
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotIdentity;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotPage;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotReadRequest;
-use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotWrite;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotStream;
+use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotWrite;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Features\Budgeting\Contracts\BudgetingReportSourceCloseStore;
 use App\BusinessModules\Features\Budgeting\Contracts\ProjectMarginSourceSnapshotReport;
@@ -125,6 +124,7 @@ final class ProjectMarginSourceSnapshotWriterCloseTest extends TestCase
     ): BudgetingReportSourceClose {
         return new BudgetingReportSourceClose(
             closeId: '01JZZZZZZZZZZZZZZZZZZZZZZZ',
+            reportCode: 'project_margin',
             identity: $identity ?? $this->identity(),
             sourceWatermarks: [new BudgetingReportSourceWatermark('actuals', new DateTimeImmutable('2026-01-31T17:00:00+00:00'), 'actuals:1', 'actuals-v1')],
             formulaVersion: 'margin-v1',

--- a/tests/Unit/Budgeting/Reporting/BudgetPlanFactCandidateContractTest.php
+++ b/tests/Unit/Budgeting/Reporting/BudgetPlanFactCandidateContractTest.php
@@ -107,6 +107,16 @@ final class BudgetPlanFactCandidateContractTest extends TestCase
         );
     }
 
+    public function test_rejects_close_from_another_report(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BudgetPlanFactCandidateFixture::contract()->assertSnapshotRequest(
+            BudgetPlanFactCandidateFixture::scope(),
+            BudgetPlanFactCandidateFixture::filters(),
+            BudgetPlanFactCandidateFixture::close(reportCode: 'project_margin'),
+        );
+    }
+
     public function test_rejects_grouping_drift(): void
     {
         $filters = BudgetPlanFactCandidateFixture::filters();

--- a/tests/Unit/Budgeting/Reporting/ProjectMarginCandidateContractTest.php
+++ b/tests/Unit/Budgeting/Reporting/ProjectMarginCandidateContractTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Budgeting\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Features\Budgeting\DTOs\BudgetingReportSourceClose;
+use App\BusinessModules\Features\Budgeting\DTOs\BudgetingReportSourceCloseIdentity;
+use App\BusinessModules\Features\Budgeting\DTOs\BudgetingReportSourceWatermark;
+use App\BusinessModules\Features\Budgeting\DTOs\ProjectMarginReportFilters;
+use App\BusinessModules\Features\Budgeting\Enums\BudgetingReportSourceCloseStatus;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\Budgeting\Services\ProjectMarginSourceSnapshotMaterializer;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectMarginCandidateContractTest extends TestCase
+{
+    public function test_contract_locks_runtime_schema_columns_permissions_and_delivery(): void
+    {
+        $contract = new ProjectMarginCandidateContract;
+
+        $contract->assertRuntimeMatches();
+
+        self::assertSame(ProjectMarginCandidateContract::CODE, ProjectMarginSourceSnapshotMaterializer::REPORT_CODE);
+        self::assertSame('margin-v1', $contract->formulaVersion);
+        self::assertSame(ProjectMarginSourceSnapshotMaterializer::SCHEMA_VERSION, $contract->sourceSchemaVersion);
+        self::assertSame(['csv', 'xlsx'], $contract->formats());
+        self::assertSame([
+            'actual', 'currency', 'drill', 'forecast', 'group', 'plan', 'problem_flags', 'quality_status',
+            'risk_flags', 'row_key', 'source_rows_count', 'source_types', 'variance',
+        ], array_column($contract->columns(), 'id'));
+        self::assertSame([['id' => 'row_key', 'direction' => 'asc']], $contract->sorts());
+        self::assertSame('attributions', $contract->drillColumnId());
+    }
+
+    public function test_rejects_formula_schema_source_and_sort_drift(): void
+    {
+        foreach ([
+            new ProjectMarginCandidateContract(formulaHash: str_repeat('0', 64)),
+            new ProjectMarginCandidateContract(sourceSchemaVersion: '9.9.9'),
+            new ProjectMarginCandidateContract(sourceHash: str_repeat('0', 64)),
+        ] as $contract) {
+            try {
+                $contract->assertRuntimeMatches();
+                self::fail('Expected contract drift to be rejected.');
+            } catch (InvalidArgumentException $exception) {
+                self::assertSame('project_margin_candidate_contract_drift', $exception->getMessage());
+            }
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        (new ProjectMarginCandidateContract)->assertSort(new ReportWindowSort('currency', ReportSortDirection::ASC));
+    }
+
+    public function test_snapshot_request_requires_exact_server_scope_close_identity_formula_and_grouping(): void
+    {
+        $contract = new ProjectMarginCandidateContract;
+        $scope = new ReportScope(1, [1], [10], [], new \DateTimeZone('UTC'));
+        $filters = [
+            'organization_id' => 1,
+            'period_start' => '2026-01-01',
+            'period_end' => '2026-01-31',
+            'scenario_uuid' => 'scenario-1',
+            'budget_version_uuid' => 'budget-1',
+            'project_id' => 10,
+            'group_by' => ProjectMarginReportFilters::DEFAULT_GROUP_BY,
+        ];
+
+        $contract->assertSnapshotRequest($scope, $filters, $this->close());
+        self::addToAssertionCount(1);
+
+        $filters['group_by'] = [ProjectMarginReportFilters::GROUP_PROJECT, ProjectMarginReportFilters::GROUP_CURRENCY];
+        $contract->assertSnapshotRequest($scope, $filters, $this->close());
+        self::addToAssertionCount(1);
+
+        $filters['organization_id'] = 2;
+        $this->expectException(InvalidArgumentException::class);
+        $contract->assertSnapshotRequest($scope, $filters, $this->close());
+    }
+
+    public function test_snapshot_request_rejects_unknown_or_non_currency_grouping(): void
+    {
+        $contract = new ProjectMarginCandidateContract;
+        $scope = new ReportScope(1, [1], [10], [], new \DateTimeZone('UTC'));
+        $filters = [
+            'organization_id' => 1,
+            'period_start' => '2026-01-01',
+            'period_end' => '2026-01-31',
+            'scenario_uuid' => 'scenario-1',
+            'budget_version_uuid' => 'budget-1',
+            'project_id' => 10,
+            'group_by' => [ProjectMarginReportFilters::GROUP_PROJECT],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('project_margin_candidate_grouping_invalid');
+        $contract->assertSnapshotRequest($scope, $filters, $this->close());
+    }
+
+    public function test_snapshot_request_rejects_a_close_from_another_report(): void
+    {
+        $scope = new ReportScope(1, [1], [10], [], new \DateTimeZone('UTC'));
+        $filters = [
+            'organization_id' => 1,
+            'period_start' => '2026-01-01',
+            'period_end' => '2026-01-31',
+            'scenario_uuid' => 'scenario-1',
+            'budget_version_uuid' => 'budget-1',
+            'project_id' => 10,
+            'group_by' => ProjectMarginReportFilters::DEFAULT_GROUP_BY,
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        (new ProjectMarginCandidateContract)->assertSnapshotRequest(
+            $scope,
+            $filters,
+            $this->close(reportCode: 'budget_plan_fact'),
+        );
+    }
+
+    private function close(
+        string $formulaVersion = ProjectMarginCandidateContract::FORMULA_VERSION,
+        string $reportCode = ProjectMarginCandidateContract::CODE,
+    ): BudgetingReportSourceClose {
+        return new BudgetingReportSourceClose(
+            '01JZZZZZZZZZZZZZZZZZZZZZZZ',
+            $reportCode,
+            new BudgetingReportSourceCloseIdentity(1, '2026-01-01', '2026-01-31', 'scenario-1', 'budget-1'),
+            [new BudgetingReportSourceWatermark('actuals', new \DateTimeImmutable('2026-01-31T17:00:00Z'), 'actuals:1', 'actuals-v1')],
+            $formulaVersion,
+            ['actuals' => ['version' => 'actuals:1']],
+            str_repeat('a', 64),
+            1,
+            new \DateTimeImmutable('2026-02-01T00:00:00Z'),
+            new \DateTimeImmutable('2033-01-31T00:00:00Z'),
+            BudgetingReportSourceCloseStatus::APPROVED,
+            null,
+        );
+    }
+}

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -20,6 +20,8 @@ use App\BusinessModules\Core\Reporting\ReportingCatalogServiceProvider;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -48,19 +50,24 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
 
         $registry = $app->make(ReportDefinitionRegistry::class);
 
+        self::assertSame('project_margin', $registry->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $registry->published('budget_plan_fact')->code);
+        self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
+        self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
     {
         $builtins = new BuiltinPublishedReportDefinitionRegistry(
+            $this->projectMargin(),
             new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['budget_plan_fact'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'project_margin'], $registry->publishedCodes());
+        self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
 
@@ -78,11 +85,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry(new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract)),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract)),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['budget_plan_fact', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'project_margin', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -90,7 +97,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry(new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract)),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract)),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -127,5 +134,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
                 return new Sha256Hash(str_repeat('0', 64));
             }
         };
+    }
+
+    private function projectMargin(): ProjectMarginBuiltinPublishedReport
+    {
+        return new ProjectMarginBuiltinPublishedReport(new ProjectMarginCandidateContract);
     }
 }

--- a/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
+++ b/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Http;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportDefinitionModuleAuthorizer;
+use App\BusinessModules\Core\Reporting\Application\Contracts\Access\ReportHttpAuthorizationTargetResolver;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\AuthorizeReportDefinitionAccess;
+use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ProjectMarginCanonicalRouteContractTest extends TestCase
+{
+    public function test_project_margin_uses_only_project_context_routes_and_authorization_targets(): void
+    {
+        $routes = file_get_contents(dirname(__DIR__, 4).'/app/BusinessModules/Core/Reporting/routes.php');
+        self::assertIsString($routes);
+        self::assertStringContainsString("Route::post('/projects/{project}/project-margin/runs'", $routes);
+        self::assertStringContainsString("->defaults('reportCode', 'project_margin')", $routes);
+        self::assertStringContainsString("->middleware(['project.context', 'report.project-scope', \$resourceAccess])", $routes);
+        self::assertStringContainsString("Route::get('/projects/{project}/project-margin/options'", $routes);
+        self::assertSame(4, substr_count($routes, "'report.project-scope'"));
+
+        $middlewareFile = (new ReflectionClass(AuthorizeReportDefinitionAccess::class))->getFileName();
+        self::assertIsString($middlewareFile);
+        $middleware = file_get_contents($middlewareFile);
+        self::assertIsString($middleware);
+        self::assertStringContainsString("'admin.reports.project-margin.runs.store'", $middleware);
+        self::assertStringContainsString("'admin.reports.project-margin.options'", $middleware);
+        self::assertStringContainsString('private function genericCreateRun', $middleware);
+        self::assertStringContainsString('ProjectMarginCandidateContract::CODE', $middleware);
+        self::assertStringContainsString('BudgetPlanFactCandidateContract::CODE', $middleware);
+    }
+
+    #[DataProvider('projectScopedReportCodes')]
+    public function test_generic_run_route_rejects_project_scoped_reports(string $reportCode): void
+    {
+        $request = Request::create('/api/v1/admin/reports/'.$reportCode.'/runs', 'POST');
+        $request->setUserResolver(static fn (): User => new User);
+        $request->attributes->set('current_organization_id', 1);
+        $route = new Route(['POST'], '/api/v1/admin/reports/{reportCode}/runs', static fn (): null => null);
+        $route->name('admin.reports.runs.store');
+        $route->bind($request);
+        $route->setParameter('reportCode', $reportCode);
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $middleware = new AuthorizeReportDefinitionAccess(
+            $this->createMock(ReportHttpAuthorizationTargetResolver::class),
+            (new ReflectionClass(ReportDefinitionModuleAuthorizer::class))->newInstanceWithoutConstructor(),
+        );
+
+        try {
+            $middleware->handle($request, static fn (): Response => new Response(status: 204));
+            self::fail('Project-scoped report must reject the generic run route.');
+        } catch (ReportContractException $exception) {
+            self::assertSame(ReportErrorCode::REPORT_SCOPE_FORBIDDEN, $exception->errorCode);
+        }
+    }
+
+    public static function projectScopedReportCodes(): array
+    {
+        return [
+            'G09' => [ProjectMarginCandidateContract::CODE],
+            'G10' => [BudgetPlanFactCandidateContract::CODE],
+        ];
+    }
+}

--- a/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
+++ b/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
@@ -6,10 +6,10 @@ namespace Tests\Unit\Reporting\Http;
 
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\BindProjectReportScope;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\CreateReportRunRequest;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\GetReportCatalogRequest;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ReportFormRequest;
-use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\BindProjectReportScope;
 use App\Domain\Authorization\Http\Middleware\InterfaceMiddleware;
 use App\Domain\Authorization\Services\AuthorizationService;
 use App\Models\Organization;
@@ -17,6 +17,7 @@ use App\Models\Project;
 use App\Models\User;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -103,6 +104,19 @@ final class ReportInterfaceMiddlewareContractTest extends TestCase
         self::assertSame(422, $response->getStatusCode());
     }
 
+    #[DataProvider('projectOptionsContextOverrideProvider')]
+    public function test_project_options_reject_client_context_overrides(array $query): void
+    {
+        $request = Request::create('/api/v1/admin/reports/projects/17/project-margin/options', 'GET', $query);
+
+        $response = (new BindProjectReportScope)->handle(
+            $request,
+            static fn (): Response => new Response(status: 204),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
     public function test_project_report_scope_binds_ids_only_from_verified_request_context(): void
     {
         $request = $this->reportRequest(CreateReportRunRequest::class, 'POST', [], self::validRunBody());
@@ -124,6 +138,21 @@ final class ReportInterfaceMiddlewareContractTest extends TestCase
         );
 
         self::assertSame(204, $response->getStatusCode());
+    }
+
+    #[DataProvider('spoofedReportContextProvider')]
+    public function test_client_cannot_supply_actor_or_report_scope_fields(array $spoofed): void
+    {
+        $request = $this->reportRequest(
+            CreateReportRunRequest::class,
+            'POST',
+            [],
+            [...self::validRunBody(), ...$spoofed],
+        );
+
+        $exception = $this->middlewareValidationException($request);
+
+        self::assertSame(ReportErrorCode::REPORT_REQUEST_INVALID, $exception->errorCode);
     }
 
     public function test_client_query_interface_is_rejected_after_middleware_overwrites_legacy_input(): void
@@ -314,6 +343,27 @@ final class ReportInterfaceMiddlewareContractTest extends TestCase
         return [
             'catalog query' => [GetReportCatalogRequest::class, 'GET', [], []],
             'run JSON body' => [CreateReportRunRequest::class, 'POST', [], self::validRunBody()],
+        ];
+    }
+
+    public static function spoofedReportContextProvider(): array
+    {
+        return [
+            'actor' => [['user_id' => 99]],
+            'scope' => [['scope' => ['organization_id' => 99, 'project_ids' => [77]]]],
+            'organization' => [['organization_id' => 99]],
+            'project' => [['project_id' => 77]],
+        ];
+    }
+
+    public static function projectOptionsContextOverrideProvider(): array
+    {
+        return [
+            'organization' => [['organization_id' => 99]],
+            'project' => [['project_id' => 77]],
+            'actor' => [['user_id' => 88]],
+            'scope' => [['scope' => ['project_ids' => [77]]]],
+            'nested actor' => [['filters' => ['owner_id' => 88]]],
         ];
     }
 


### PR DESCRIPTION
## Что изменено

- опубликован встроенный canonical report G09 `project_margin`
- подключён sealed snapshot runtime для rows, totals и drill-down
- добавлены project-scoped run/options routes и запрет generic run для G09/G10
- организация, проект, actor и scope принимаются только из серверного контекста
- options фильтруются по организации, report_code, formula_version, status и retention
- close-контракт разделён по report_code, включая hash, uniqueness, restatement и immutability
- добавлена forward migration с безопасным backfill известных G09/G10 формул
- актуализированы source contracts и мастер-план

## Проверки

- 97 tests passed, 351 assertions
- PHP syntax: все изменённые PHP-файлы
- Larastan: no errors
- Laravel Pint: pass
- git diff --check: pass
- PostgreSQL contract test обновлён, локально не запускался согласно запрету DB-команд
- независимый review выполнен; найденный конфликт close identity между G09/G10 исправлен