### PR TITLE
fix: завершить итоги и детализацию G09

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/GetReportRowsHandler.php
+++ b/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/GetReportRowsHandler.php
@@ -14,6 +14,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthorization;
 use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthorizationTarget;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -71,6 +72,8 @@ final readonly class GetReportRowsHandler implements GetReportRowsAction
             || $page->sort->direction !== $window->sort->direction) {
             throw ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR);
         }
+
+        $page = $this->withDrillDownTokens($page, $binding, $run, $query, $snapshot);
 
         return $this->withSignedNextCursor($page, $run, $query, $snapshot);
     }
@@ -197,6 +200,60 @@ final readonly class GetReportRowsHandler implements GetReportRowsAction
             $token,
             $page->limit,
             true,
+            $page->sort,
+        );
+    }
+
+    private function withDrillDownTokens(
+        ReportPage $page,
+        ReportDefinitionBinding $binding,
+        ReportRun $run,
+        ReportQuery $query,
+        ReportSnapshotRef $snapshot,
+    ): ReportPage {
+        if (! $binding->drillDownProvider instanceof ReportDrillDownTokenColumns) {
+            return $page;
+        }
+
+        $columns = $binding->drillDownProvider->drillDownTokenColumns();
+        if ($columns === []) {
+            return $page;
+        }
+        $definitionColumns = array_fill_keys(array_column($query->definition->columns, 'id'), true);
+        foreach ($columns as $outputColumn => $providerColumn) {
+            if (! is_string($outputColumn)
+                || ! is_string($providerColumn)
+                || ! isset($definitionColumns[$outputColumn])
+                || preg_match('/^[a-z][a-z0-9_]{0,63}$/D', $providerColumn) !== 1) {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR);
+            }
+        }
+
+        $rows = array_map(function (array $row) use ($columns, $run, $query, $snapshot): array {
+            foreach ($columns as $outputColumn => $providerColumn) {
+                $row[$outputColumn] = $this->cursors->encodeDrillDownCell(
+                    $query->scope->organizationId,
+                    $run->reportCode,
+                    $run->id,
+                    $snapshot,
+                    $run->queryHash,
+                    $row['row_key'],
+                    $providerColumn,
+                    $run->expiresAt,
+                );
+            }
+
+            return $row;
+        }, $page->rows);
+
+        return new ReportPage(
+            $rows,
+            $page->totals,
+            $page->freshness,
+            $page->quality,
+            $page->nextCursor,
+            $page->limit,
+            $page->hasMore,
             $page->sort,
         );
     }

--- a/app/BusinessModules/Core/Reporting/Domain/Contracts/ReportDrillDownTokenColumns.php
+++ b/app/BusinessModules/Core/Reporting/Domain/Contracts/ReportDrillDownTokenColumns.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Domain\Contracts;
+
+interface ReportDrillDownTokenColumns
+{
+    /** @return array<string, string> output column => provider column */
+    public function drillDownTokenColumns(): array;
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginCandidateContract.php
@@ -26,7 +26,7 @@ final readonly class ProjectMarginCandidateContract
 
     public const FORMULA_HASH = '9daf19a225a89d3990becd0654b5965eebfb79306f0acf31c0aba1fcd849ccb4';
 
-    public const SOURCE_HASH = 'a887a07672f66a2d382091b1468f6efc339bbec4d62cda88fabfe9a1007fbc45';
+    public const SOURCE_HASH = '260d5232a220dca37f413648b1a4c33acf62ec186a5d7bcc01291b5f94664075';
 
     public function __construct(
         public string $formulaVersion = self::FORMULA_VERSION,

--- a/app/BusinessModules/Features/Budgeting/Services/AbstractBudgetingReportSourceSnapshotAdapter.php
+++ b/app/BusinessModules/Features/Budgeting/Services/AbstractBudgetingReportSourceSnapshotAdapter.php
@@ -9,6 +9,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStore;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCoverage;
@@ -36,7 +37,7 @@ use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 
-abstract class AbstractBudgetingReportSourceSnapshotAdapter implements ReportDataProvider, ReportDrillDownProvider, ReportRowQuery
+abstract class AbstractBudgetingReportSourceSnapshotAdapter implements ReportDataProvider, ReportDrillDownProvider, ReportDrillDownTokenColumns, ReportRowQuery
 {
     private const REPORT_QUERY_HASH = 'report_query_hash';
 
@@ -206,6 +207,11 @@ abstract class AbstractBudgetingReportSourceSnapshotAdapter implements ReportDat
             $sourcePage->nextCursor === null ? null : $this->cursorToken($sourcePage->nextCursor),
             [],
         );
+    }
+
+    final public function drillDownTokenColumns(): array
+    {
+        return ['drill' => $this->drillColumnId()];
     }
 
     abstract protected function persistSourceSnapshot(ReportQuery $query): ReportSourceSnapshotHeader;

--- a/app/BusinessModules/Features/Budgeting/Services/ProjectMarginReportSourceSnapshotAdapter.php
+++ b/app/BusinessModules/Features/Budgeting/Services/ProjectMarginReportSourceSnapshotAdapter.php
@@ -74,6 +74,16 @@ final class ProjectMarginReportSourceSnapshotAdapter extends AbstractBudgetingRe
         ]);
     }
 
+    protected function reportTotals(ReportSourceSnapshotHeader $header): array
+    {
+        $byCurrency = $header->watermarks['result_totals_by_currency'] ?? [];
+
+        return [
+            'row_count' => $header->rowCount,
+            'by_currency' => is_array($byCurrency) && array_is_list($byCurrency) ? $byCurrency : [],
+        ];
+    }
+
     private function closeId(ReportQuery $query): string
     {
         $value = $query->filters->values['close_id'] ?? null;

--- a/app/BusinessModules/Features/Budgeting/Services/ProjectMarginSourceSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/Budgeting/Services/ProjectMarginSourceSnapshotMaterializer.php
@@ -311,10 +311,53 @@ final class ProjectMarginSourceSnapshotMaterializer
             'scenario_uuid' => $filters['scenario_uuid'] ?? null,
             'source_rows_count' => $sourceRowsCount,
             'source_types' => array_keys($sourceTypes),
+            'result_totals_by_currency' => $this->resultTotals($report['totals_by_currency'] ?? []),
         ];
         sort($watermarks['source_types'], SORT_STRING);
 
         return [...$watermarks, ...$close->snapshotWatermarks()];
+    }
+
+    private function resultTotals(mixed $totals): array
+    {
+        if (! is_array($totals) || ! array_is_list($totals)) {
+            throw new InvalidArgumentException('project_margin_source_snapshot_totals_invalid');
+        }
+
+        $result = array_map(function (mixed $total): array {
+            if (! is_array($total)) {
+                throw new InvalidArgumentException('project_margin_source_snapshot_totals_invalid');
+            }
+
+            return [
+                'actual' => $this->canonicalMoneyBlock($total['actual'] ?? null),
+                'currency' => $this->string($total['currency'] ?? null),
+                'forecast' => $this->canonicalMoneyBlock($total['forecast'] ?? null),
+                'plan' => $this->canonicalMoneyBlock($total['plan'] ?? null),
+                'problem_flags' => $this->stringList($total['problem_flags'] ?? []),
+                'quality_status' => $this->string($total['quality_status'] ?? null),
+                'risk_flags' => $this->stringList($total['risk_flags'] ?? []),
+                'rows_count' => $this->integer($total['rows_count'] ?? null),
+                'variance' => $this->canonicalMoneyBlock($total['variance'] ?? null),
+            ];
+        }, $totals);
+
+        usort($result, static fn (array $left, array $right): int => $left['currency'] <=> $right['currency']);
+
+        return $result;
+    }
+
+    private function canonicalMoneyBlock(mixed $value): array
+    {
+        $block = $this->moneyBlock($value);
+        foreach ($block as $key => $amount) {
+            if (is_float($amount)) {
+                $normalized = rtrim(rtrim(sprintf('%.8F', $amount), '0'), '.');
+                $block[$key] = $normalized === '-0' ? '0' : $normalized;
+            }
+        }
+
+        return $block;
     }
 
     private function moneyBlock(mixed $value): array

--- a/tests/Support/Reporting/FakeReportDrillDownProvider.php
+++ b/tests/Support/Reporting/FakeReportDrillDownProvider.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Tests\Support\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 
-final class FakeReportDrillDownProvider implements ReportDrillDownProvider
+final class FakeReportDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
     private array $calls = [];
 
-    public function __construct(private readonly ReportDrillDownResult $result) {}
+    public function __construct(
+        private readonly ReportDrillDownResult $result,
+        private readonly array $tokenColumns = [],
+    ) {}
 
     public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownInput $input): ReportDrillDownResult
     {
@@ -26,5 +30,10 @@ final class FakeReportDrillDownProvider implements ReportDrillDownProvider
     public function calls(): array
     {
         return $this->calls;
+    }
+
+    public function drillDownTokenColumns(): array
+    {
+        return $this->tokenColumns;
     }
 }

--- a/tests/Unit/Budgeting/BudgetingReportSourceSnapshotAdapterTest.php
+++ b/tests/Unit/Budgeting/BudgetingReportSourceSnapshotAdapterTest.php
@@ -154,6 +154,10 @@ final class BudgetingReportSourceSnapshotAdapterTest extends TestCase
         self::assertSame($snapshot->id, $cursorRows[0]['snapshot_id']);
         self::assertSame($snapshot->sourceHash->value, $cursorRows[0]['source_hash']);
         self::assertCount(1, $drill->rows);
+        if ($code === 'project_margin') {
+            self::assertSame('RUB', $result->totals['by_currency'][0]['currency']);
+            self::assertSame('20', $result->totals['by_currency'][0]['actual']['revenue']);
+        }
         self::assertSame($liveCalls, $source->calls);
         self::assertStringNotContainsString('Sensitive', json_encode([$first, $drill, $cursorRows], JSON_THROW_ON_ERROR));
     }
@@ -612,9 +616,23 @@ final class ProjectMarginSnapshotSource implements ProjectMarginSourceSnapshotRe
     {
         $this->calls++;
 
-        return ['filters' => $input, 'period' => ['from' => '2026-01-01', 'to' => '2026-01-31'], 'rows' => [
-            $this->row('first', 'a'), $this->row('second', 'b'),
-        ]];
+        $money = [
+            'cost' => 4.0 * $this->revision,
+            'gross_margin' => 16.0 * $this->revision,
+            'margin_percent' => 80.0,
+            'revenue' => 20.0 * $this->revision,
+        ];
+
+        return [
+            'filters' => $input,
+            'period' => ['from' => '2026-01-01', 'to' => '2026-01-31'],
+            'totals_by_currency' => [[
+                'actual' => $money, 'currency' => 'RUB', 'forecast' => $money, 'plan' => $money,
+                'problem_flags' => [], 'quality_status' => 'complete', 'risk_flags' => [],
+                'rows_count' => 2, 'variance' => $money,
+            ]],
+            'rows' => [$this->row('first', 'a'), $this->row('second', 'b')],
+        ];
     }
 
     public function drillDownForProjectScope(array $input, array $projectIds): array

--- a/tests/Unit/Budgeting/ProjectMarginSourceSnapshotMaterializerTest.php
+++ b/tests/Unit/Budgeting/ProjectMarginSourceSnapshotMaterializerTest.php
@@ -34,6 +34,8 @@ final class ProjectMarginSourceSnapshotMaterializerTest extends TestCase
         self::assertSame('01JZZZZZZZZZZZZZZZZZZZZZZZ', $write->header->watermarks['close_id']);
         self::assertSame('margin-v1', $write->header->watermarks['formula_version']);
         self::assertSame('actuals:1', $write->header->watermarks['source_watermarks'][0]['watermark']);
+        self::assertSame('RUB', $write->header->watermarks['result_totals_by_currency'][0]['currency']);
+        self::assertSame('300', $write->header->watermarks['result_totals_by_currency'][0]['actual']['revenue']);
         self::assertArrayNotHasKey('source_document_number', $write->drillRows[0]->payload);
         self::assertArrayNotHasKey('source_id', $write->drillRows[0]->payload);
         self::assertArrayNotHasKey('drill_down', $write->drillRows[0]->payload);
@@ -136,6 +138,17 @@ final class ProjectMarginSourceSnapshotMaterializerTest extends TestCase
         return [
             'filters' => ['budget_version_uuid' => 'budget-1', 'scenario_uuid' => 'scenario-1'],
             'period' => ['from' => '2026-01-01', 'to' => '2026-01-31'],
+            'totals_by_currency' => [[
+                'currency' => 'RUB',
+                'plan' => ['revenue' => 300.0, 'cost' => 40.0, 'gross_margin' => 260.0, 'margin_percent' => 86.67],
+                'forecast' => ['revenue' => 300.0, 'cost' => 40.0, 'gross_margin' => 260.0, 'margin_percent' => 86.67],
+                'actual' => ['revenue' => 300.0, 'cost' => 40.0, 'gross_margin' => 260.0, 'margin_percent' => 86.67],
+                'variance' => ['revenue' => 0.0, 'cost' => 0.0, 'gross_margin' => 0.0, 'margin_percent' => 0.0],
+                'problem_flags' => [],
+                'risk_flags' => [],
+                'quality_status' => 'actual',
+                'rows_count' => 2,
+            ]],
             'rows' => [
                 $this->row('second-key', 20, 'Sensitive project B', 200.0),
                 $this->row('first-key', 10, 'Sensitive project A', 100.0),

--- a/tests/Unit/Reporting/Actions/ReportReadHandlersTest.php
+++ b/tests/Unit/Reporting/Actions/ReportReadHandlersTest.php
@@ -135,6 +135,34 @@ final class ReportReadHandlersTest extends TestCase
         self::assertSame($this->sort, $decoded->sort);
     }
 
+    public function test_rows_include_signed_drill_down_tokens_declared_by_the_provider(): void
+    {
+        $fixture = $this->fixture(
+            columns: [['id' => 'name'], ['id' => 'drill']],
+            drillTokenColumns: ['drill' => 'attributions'],
+        );
+        $operations = [];
+
+        $result = $this->rowsHandler($fixture, $this->authorizer($operations))->handle(
+            $this->context,
+            self::RUN_ID,
+            new ReportRowsWindow(null, 50, $this->sort),
+        );
+
+        $token = $result->rows[0]['drill'] ?? null;
+        self::assertIsString($token);
+        $cell = $this->codec()->decodeDrillDownCell(
+            $token,
+            $fixture['query']->scope->organizationId,
+            $fixture['run']->reportCode,
+            $fixture['run']->id,
+            $fixture['run']->resultMetadata->snapshot,
+            $fixture['run']->queryHash,
+        );
+        self::assertSame('row-1', $cell->rowKey);
+        self::assertSame('attributions', $cell->columnId);
+    }
+
     public function test_column_values_and_empty_permission_lists_do_not_drive_classification(): void
     {
         $fixture = $this->fixture(
@@ -383,6 +411,7 @@ final class ReportReadHandlersTest extends TestCase
         array $rows = [['row_key' => 'row-1', 'name' => 'Строка']],
         bool $hasMore = false,
         int $limit = 50,
+        array $drillTokenColumns = [],
     ): array {
         $definition = (new ReportDefinitionBuilder)
             ->columns($columns)
@@ -425,7 +454,7 @@ final class ReportReadHandlersTest extends TestCase
         );
         $rowQuery = new FakeReportRowQuery($page, []);
         $drillResult ??= new ReportDrillDownResult($rows, null, []);
-        $drillDown = new FakeReportDrillDownProvider($drillResult);
+        $drillDown = new FakeReportDrillDownProvider($drillResult, $drillTokenColumns);
         $binding = new ReportDefinitionBinding(
             $definition->code,
             $definition->definitionHash,


### PR DESCRIPTION
## Что исправлено
- серверные итоги маржинальности по валютам входят в утверждённый снимок
- строки канонического API получают подписанные токены детализации
- токены привязаны к организации, запуску, снимку и строке
- добавлены целевые unit/contract тесты

## Проверки
- 24 целевых backend-теста: 125 assertions
- отдельный тест токена детализации: 3 assertions
- PHPStan изменённых production-файлов: без ошибок
- Pint и PHP syntax: успешно

Миграции и DB-команды не запускались.