### PR TITLE
feat[reports]: готовность расчёта зарплаты

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/PayrollReadinessReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/PayrollReadinessReportOptionsController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\PayrollReadinessReportOptionsRequest;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class PayrollReadinessReportOptionsController
+{
+    public function __construct(private PayrollReadinessOptionsService $options) {}
+
+    public function __invoke(PayrollReadinessReportOptionsRequest $request): JsonResponse
+    {
+        $organization = $request->attributes->get('current_organization');
+        $project = $request->attributes->get('project');
+        $type = $request->type();
+        $payload = $type === null
+            ? $this->options->summary((int) $organization->id, (int) $project->id)
+            : $this->options->search((int) $organization->id, (int) $project->id, $type, $request->search(), $request->page());
+
+        return AdminResponse::success($payload);
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
@@ -78,7 +79,9 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.project-margin.runs.store',
             'admin.reports.project-margin.options',
             'admin.reports.project-labor-cost.runs.store',
-            'admin.reports.project-labor-cost.options' => $this->targets->createRun(
+            'admin.reports.payroll-readiness.runs.store',
+            'admin.reports.project-labor-cost.options',
+            'admin.reports.payroll-readiness.options' => $this->targets->createRun(
                 $this->routeId($request, 'reportCode'),
             ),
             'admin.reports.runs.show', 'admin.reports.runs.rows' => $this->targets->run(
@@ -120,6 +123,7 @@ final readonly class AuthorizeReportDefinitionAccess
             BudgetPlanFactCandidateContract::CODE,
             ProjectMarginCandidateContract::CODE,
             ProjectLaborCostCandidateContract::CODE,
+            PayrollReadinessCandidateContract::CODE,
         ], true)) {
             $this->deny();
         }

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/PayrollReadinessReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/PayrollReadinessReportOptionsRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessOptionsService;
+use Illuminate\Validation\Rule;
+
+final class PayrollReadinessReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'type' => ['sometimes', 'string', Rule::in(PayrollReadinessOptionsService::TYPES)],
+            'search' => ['sometimes', 'nullable', 'string', 'max:100', Rule::prohibitedIf(fn (): bool => $this->query('type') === null)],
+            'page' => ['sometimes', 'integer', 'min:1', 'max:10000', Rule::prohibitedIf(fn (): bool => $this->query('type') === null)],
+            ...$this->forbiddenClientFieldsRules(),
+        ];
+    }
+
+    protected function acceptedQueryFields(): array
+    {
+        return ['type', 'search', 'page'];
+    }
+
+    public function type(): ?string
+    {
+        $value = $this->validated('type');
+
+        return is_string($value) ? $value : null;
+    }
+
+    public function search(): ?string
+    {
+        $value = $this->validated('search');
+
+        return is_string($value) ? $value : null;
+    }
+
+    public function page(): int
+    {
+        return (int) $this->validated('page', 1);
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
 {
@@ -23,9 +24,10 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         ProjectMarginBuiltinPublishedReport $projectMargin,
         BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
         ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
+        PayrollReadinessBuiltinPublishedReport $payrollReadiness,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
 {
@@ -18,6 +19,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private ProjectMarginBuiltinPublishedReport $projectMargin,
         private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
         private ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
+        private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -26,6 +28,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->projectMargin->metadata()->code => $this->projectMargin->metadata(),
             $this->budgetPlanFact->metadata()->code => $this->budgetPlanFact->metadata(),
             $this->projectLaborCost->metadata()->code => $this->projectLaborCost->metadata(),
+            $this->payrollReadiness->metadata()->code => $this->payrollReadiness->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
 {
@@ -18,6 +19,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private ProjectMarginBuiltinPublishedReport $projectMargin,
         private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
         private ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
+        private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -26,6 +28,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->projectMargin->scheduling()->code => $this->projectMargin->scheduling(),
             $this->budgetPlanFact->scheduling()->code => $this->budgetPlanFact->scheduling(),
             $this->projectLaborCost->scheduling()->code => $this->projectLaborCost->scheduling(),
+            $this->payrollReadiness->scheduling()->code => $this->payrollReadiness->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -61,6 +61,8 @@ use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublis
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -93,12 +95,16 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(ProjectLaborCostBuiltinPublishedReport::class, fn (Application $app): ProjectLaborCostBuiltinPublishedReport => new ProjectLaborCostBuiltinPublishedReport(
             $app->make(ProjectLaborCostCandidateContract::class),
         ));
+        $this->app->singleton(PayrollReadinessBuiltinPublishedReport::class, fn (Application $app): PayrollReadinessBuiltinPublishedReport => new PayrollReadinessBuiltinPublishedReport(
+            $app->make(PayrollReadinessCandidateContract::class),
+        ));
         $this->app->singleton(
             BuiltinPublishedReportDefinitionRegistry::class,
             fn (Application $app): BuiltinPublishedReportDefinitionRegistry => new BuiltinPublishedReportDefinitionRegistry(
                 $app->make(ProjectMarginBuiltinPublishedReport::class),
                 $app->make(BudgetPlanFactBuiltinPublishedReport::class),
                 $app->make(ProjectLaborCostBuiltinPublishedReport::class),
+                $app->make(PayrollReadinessBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -108,9 +114,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMatrix;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectLaborCostReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectMarginReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportCatalogController;
@@ -105,6 +106,14 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'project_labor_cost')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])
             ->name('project-labor-cost.options');
+        Route::post('/projects/{project}/payroll-readiness/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'payroll_readiness')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('payroll-readiness.runs.store');
+        Route::get('/projects/{project}/payroll-readiness/options', PayrollReadinessReportOptionsController::class)
+            ->defaults('reportCode', 'payroll_readiness')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('payroll-readiness.options');
         Route::get('/runs/{runId}', [ReportRunController::class, 'show'])
             ->middleware($resourceAccess)
             ->name('runs.show');

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabasePayrollReadinessAdapter.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabasePayrollReadinessAdapter.php
@@ -49,11 +49,11 @@ use InvalidArgumentException;
 
 final readonly class DatabasePayrollReadinessAdapter implements PayrollReadinessDatabasePort
 {
-    private const FORMULA_VERSION = 'payroll-readiness.v1';
+    public const FORMULA_VERSION = 'payroll-readiness.v1';
 
-    private const SCHEMA_VERSION = 'workforce-payroll-calculation.v1';
+    public const SCHEMA_VERSION = 'workforce-payroll-calculation.v1';
 
-    private const SORTS = [
+    public const SORTS = [
         'period_start',
         'employee_name',
         'project_name',
@@ -1421,7 +1421,11 @@ final readonly class DatabasePayrollReadinessAdapter implements PayrollReadiness
 
     private function projectIds(ReportScope $scope, ReportQuery $query): array
     {
-        $requested = $this->ids($query, 'project_ids');
+        $projectId = $query->filters->values['project_id'] ?? null;
+        $requested = $projectId === null ? $this->ids($query, 'project_ids') : [(int) $projectId];
+        if ($projectId !== null && (! is_int($projectId) && ! (is_string($projectId) && ctype_digit($projectId)))) {
+            throw new InvalidArgumentException('payroll_readiness_filter_invalid');
+        }
         $resourceIds = array_values(array_unique(array_map(
             static fn (object $resource): int => $resource->id,
             array_filter(

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessBuiltinPublishedReport.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Infrastructure\DatabasePayrollReadinessAdapter;
+
+final readonly class PayrollReadinessBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+
+    public const RENDERER_VERSION = '1.0.0';
+
+    public const MANIFEST_ORDINAL = 22;
+
+    public function __construct(private PayrollReadinessCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(PayrollReadinessCandidateContract::CODE, 'reports.catalog.payroll_readiness', ReportCatalogGroup::TEAM, 'workforce', 'period_employee_issue', 1, self::MANIFEST_ORDINAL);
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(PayrollReadinessCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => PayrollReadinessCandidateContract::CODE,
+            'title_key' => 'reports.catalog.payroll_readiness',
+            'catalog_group' => 'team', 'category' => 'workforce', 'grain' => 'period_employee_issue', 'wave' => 1,
+            'filters' => $this->contract->filters(), 'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(), 'formats' => $this->contract->formats(),
+            'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => DatabasePayrollReadinessAdapter::FORMULA_VERSION, 'source_schema' => DatabasePayrollReadinessAdapter::SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION],
+            'semantic_fingerprints' => ['formula' => PayrollReadinessCandidateContract::FORMULA_HASH, 'source' => PayrollReadinessCandidateContract::SOURCE_HASH],
+            'permissions' => ['view' => ['workforce.view'], 'export' => ['workforce.reports.export'], 'sensitive' => [], 'audit' => ['workforce.audit.view']],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessCandidateContract.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessCandidateContract.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Formulas\PayrollReadinessFormula;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Infrastructure\DatabasePayrollReadinessAdapter;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class PayrollReadinessCandidateContract
+{
+    public const CODE = 'payroll_readiness';
+
+    public const FORMULA_HASH = '3ca061e58f58ee1e293c46909e2271f0d46178dccd6abff0eef43421973f988a';
+
+    public const SOURCE_HASH = 'f477fb89a2eb3700be9262046a99ec2f338a78f614a22eb6a43fd00447f02ea0';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'organization_id', 'required' => true],
+            ['id' => 'project_id', 'required' => true],
+            ['id' => 'payroll_period_ids', 'required' => true],
+            ['id' => 'employee_ids', 'required' => false],
+            ['id' => 'issue_codes', 'required' => false],
+            ['id' => 'severities', 'required' => false],
+            ['id' => 'statuses', 'required' => false],
+            ['id' => 'source_types', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'period_start', 'period_end', 'calculation_version', 'row_type',
+            'employee_name', 'project_name', 'source_type', 'hours', 'rate', 'rate_type',
+            'amount', 'currency', 'issue_code', 'severity', 'status', 'drill',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return array_map(static fn (string $id): array => [
+            'id' => $id,
+            'direction' => $id === 'period_start' ? ReportSortDirection::DESC->value : ReportSortDirection::ASC->value,
+        ], DatabasePayrollReadinessAdapter::SORTS);
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(PayrollReadinessFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(DatabasePayrollReadinessAdapter::class))) {
+            throw new InvalidArgumentException('payroll_readiness_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->formulaVersion !== DatabasePayrollReadinessAdapter::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== DatabasePayrollReadinessAdapter::SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['workforce.view']
+            || $definition->permissionPolicy->exportPermissions !== ['workforce.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== ['workforce.audit.view']) {
+            throw new InvalidArgumentException('payroll_readiness_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
+            throw new InvalidArgumentException('payroll_readiness_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('payroll_readiness_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR), $items);
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessOptionsService.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessOptionsService.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Builder;
+use InvalidArgumentException;
+
+final readonly class PayrollReadinessOptionsService
+{
+    public const TYPES = ['periods', 'employees', 'issue_codes', 'source_types'];
+
+    public const LIMIT = 50;
+
+    public function __construct(private ConnectionInterface $connection) {}
+
+    public function summary(int $organizationId, int $projectId): array
+    {
+        $periods = $this->connection->table('workforce_payroll_periods as period')
+            ->where('period.organization_id', $organizationId)
+            ->where('period.project_id', $projectId)
+            ->whereExists(function (Builder $query): void {
+                $query->selectRaw('1')->from('workforce_payroll_calculation_versions as version')
+                    ->whereColumn('version.organization_id', 'period.organization_id')
+                    ->whereColumn('version.payroll_period_id', 'period.id');
+            })
+            ->orderByDesc('period.period_start')->orderByDesc('period.id')
+            ->limit(100)
+            ->get(['period.id', 'period.period_start', 'period.period_end', 'period.status'])
+            ->map(static fn (object $period): array => [
+                'id' => (int) $period->id,
+                'label' => (string) $period->period_start.' — '.(string) $period->period_end,
+                'period_start' => (string) $period->period_start,
+                'period_end' => (string) $period->period_end,
+                'status' => (string) $period->status,
+            ])->all();
+
+        return [
+            'periods' => $periods,
+            'severities' => [['id' => 'blocking'], ['id' => 'warning']],
+            'statuses' => [['id' => 'built'], ['id' => 'validated'], ['id' => 'locked']],
+            'option_types' => self::TYPES,
+            'option_limit' => self::LIMIT,
+        ];
+    }
+
+    public function search(int $organizationId, int $projectId, string $type, ?string $search, int $page): array
+    {
+        if (! in_array($type, self::TYPES, true) || $page < 1) {
+            throw new InvalidArgumentException('payroll_readiness_option_type_invalid');
+        }
+        $needle = trim((string) $search);
+        $query = match ($type) {
+            'periods' => $this->periods($organizationId, $projectId, $needle),
+            'employees' => $this->employees($organizationId, $projectId, $needle),
+            'issue_codes' => $this->issueCodes($organizationId, $projectId, $needle),
+            'source_types' => $this->sourceTypes($organizationId, $projectId, $needle),
+        };
+        $rows = $query->offset(($page - 1) * self::LIMIT)->limit(self::LIMIT + 1)->get();
+        $hasMore = $rows->count() > self::LIMIT;
+
+        return [
+            'type' => $type,
+            'items' => $rows->take(self::LIMIT)->map(static fn (object $item): array => [
+                'id' => is_numeric($item->id) ? (int) $item->id : (string) $item->id,
+                'name' => (string) $item->name,
+            ])->values()->all(),
+            'has_more' => $hasMore,
+            'page' => $page,
+            'next_page' => $hasMore ? $page + 1 : null,
+        ];
+    }
+
+    private function scopedSourceRows(int $organizationId, int $projectId): Builder
+    {
+        return $this->connection->table('workforce_payroll_calculation_source_rows as source')
+            ->join('workforce_payroll_calculation_versions as version', function ($join): void {
+                $join->on('version.id', '=', 'source.calculation_version_id')
+                    ->on('version.organization_id', '=', 'source.organization_id');
+            })
+            ->join('workforce_payroll_periods as period', function ($join): void {
+                $join->on('period.id', '=', 'version.payroll_period_id')
+                    ->on('period.organization_id', '=', 'version.organization_id');
+            })
+            ->where('source.organization_id', $organizationId)
+            ->where('period.project_id', $projectId);
+    }
+
+    private function periods(int $organizationId, int $projectId, string $search): Builder
+    {
+        $query = $this->connection->table('workforce_payroll_periods as period')
+            ->where('period.organization_id', $organizationId)
+            ->where('period.project_id', $projectId)
+            ->whereExists(function (Builder $exists): void {
+                $exists->selectRaw('1')->from('workforce_payroll_calculation_versions as version')
+                    ->whereColumn('version.organization_id', 'period.organization_id')
+                    ->whereColumn('version.payroll_period_id', 'period.id');
+            })
+            ->selectRaw("period.id AS id, period.period_start || ' — ' || period.period_end AS name");
+        if ($search !== '') {
+            $query->where(function (Builder $nested) use ($search): void {
+                $nested->where('period.period_start', 'like', '%'.$search.'%')
+                    ->orWhere('period.period_end', 'like', '%'.$search.'%');
+            });
+        }
+
+        return $query->orderByDesc('period.period_start')->orderByDesc('period.id');
+    }
+
+    private function employees(int $organizationId, int $projectId, string $search): Builder
+    {
+        $query = $this->scopedSourceRows($organizationId, $projectId)
+            ->selectRaw('source.employee_id AS id, source.employee_name AS name')->distinct();
+        $this->applySearch($query, 'source.employee_name', $search);
+
+        return $query->orderBy('name')->orderBy('source.employee_id');
+    }
+
+    private function sourceTypes(int $organizationId, int $projectId, string $search): Builder
+    {
+        $query = $this->scopedSourceRows($organizationId, $projectId)
+            ->selectRaw('source.source_type AS id, source.source_type AS name')->distinct();
+        $this->applySearch($query, 'source.source_type', $search);
+
+        return $query->orderBy('source.source_type');
+    }
+
+    private function issueCodes(int $organizationId, int $projectId, string $search): Builder
+    {
+        $query = $this->connection->table('workforce_payroll_calculation_issues as issue')
+            ->join('workforce_payroll_calculation_versions as version', function ($join): void {
+                $join->on('version.id', '=', 'issue.calculation_version_id')
+                    ->on('version.organization_id', '=', 'issue.organization_id');
+            })
+            ->join('workforce_payroll_periods as period', function ($join): void {
+                $join->on('period.id', '=', 'version.payroll_period_id')
+                    ->on('period.organization_id', '=', 'version.organization_id');
+            })
+            ->where('issue.organization_id', $organizationId)->where('period.project_id', $projectId)
+            ->selectRaw('issue.issue_code AS id, issue.issue_code AS name')->distinct();
+        $this->applySearch($query, 'issue.issue_code', $search);
+
+        return $query->orderBy('issue.issue_code');
+    }
+
+    private function applySearch(Builder $query, string $column, string $search): void
+    {
+        if ($search !== '') {
+            $query->whereRaw("LOWER({$column}) LIKE ?", ['%'.mb_strtolower($search).'%']);
+        }
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class PayrollReadinessPublishedRuntimeBindingRegistrar
+{
+    public function __construct(private ReportDefinitionRegistry $definitions, private PayrollReadinessReportBindingFactory $bindings) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(PayrollReadinessCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+            throw $exception;
+        }
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessQueryService.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessQueryService.php
@@ -16,11 +16,9 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\Contracts\PayrollReadinessDatabasePort;
 
-final readonly class PayrollReadinessQueryService implements ReportRowQuery, ReportDrillDownProvider
+final readonly class PayrollReadinessQueryService implements ReportDrillDownProvider, ReportRowQuery
 {
-    public function __construct(private PayrollReadinessDatabasePort $database)
-    {
-    }
+    public function __construct(private PayrollReadinessDatabasePort $database) {}
 
     public function result(ReportExecutionContext $context, ReportSnapshotRef $snapshot): ReportResult
     {
@@ -52,5 +50,10 @@ final readonly class PayrollReadinessQueryService implements ReportRowQuery, Rep
         ReportDrillDownInput $input,
     ): ReportDrillDownResult {
         return $this->database->drillDown($context, $snapshot, $input);
+    }
+
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'source_refs'];
     }
 }

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessReportBindingFactory.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessReportBindingFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+
+final readonly class PayrollReadinessReportBindingFactory
+{
+    public function __construct(private PayrollReadinessProvider $provider, private PayrollReadinessQueryService $query, private PayrollReadinessCandidateContract $contract) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding($definition->code, $definition->definitionHash, $definition->contractVersion, $this->provider, $this->query, $this->query, null);
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/WorkforceManagementServiceProvider.php
+++ b/app/BusinessModules/Features/WorkforceManagement/WorkforceManagementServiceProvider.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\WorkforceManagement;
 
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Contracts\PayrollReadinessDatabasePort;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Formulas\PayrollReadinessFormula;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Formulas\PayrollSourceRateFormula;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Infrastructure\DatabasePayrollReadinessAdapter;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessOptionsService;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessReportBindingFactory;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\ServiceProvider;
 
@@ -12,6 +21,13 @@ final class WorkforceManagementServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(WorkforceManagementModule::class);
+        $this->app->scoped(PayrollReadinessDatabasePort::class, static fn ($app): DatabasePayrollReadinessAdapter => new DatabasePayrollReadinessAdapter(
+            $app['db']->connection(), $app->make(PayrollReadinessFormula::class), $app->make(PayrollSourceRateFormula::class),
+        ));
+        $this->app->singleton(PayrollReadinessCandidateContract::class);
+        $this->app->scoped(PayrollReadinessReportBindingFactory::class);
+        $this->app->scoped(PayrollReadinessPublishedRuntimeBindingRegistrar::class);
+        $this->app->scoped(PayrollReadinessOptionsService::class, static fn ($app): PayrollReadinessOptionsService => new PayrollReadinessOptionsService($app['db']->connection()));
         $this->app->singleton(
             Reporting\PayrollReadiness\Contracts\PayrollReadinessEvidenceSource::class,
             Reporting\PayrollReadiness\Services\EloquentPayrollReadinessEvidenceSource::class,
@@ -89,6 +105,9 @@ final class WorkforceManagementServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->app->afterResolving(ReportDefinitionBindingAssembler::class, function (ReportDefinitionBindingAssembler $assembler): void {
+            $this->app->make(PayrollReadinessPublishedRuntimeBindingRegistrar::class)->register($assembler);
+        });
         $this->loadMigrationsFrom(__DIR__.'/migrations');
         $this->loadRoutesFrom(__DIR__.'/routes.php');
         $this->callAfterResolving(Schedule::class, static function (Schedule $schedule): void {

--- a/config/RoleDefinitions/admin/web_admin.json
+++ b/config/RoleDefinitions/admin/web_admin.json
@@ -581,7 +581,8 @@
       "workforce.exports.generate",
       "workforce.exports.approve",
       "workforce.settings.manage",
-      "workforce.audit.view"
+      "workforce.audit.view",
+      "workforce.reports.export"
     ],
     "production-labor": [
       "production-labor.view",

--- a/docs/reports/wave-1-source-contracts.md
+++ b/docs/reports/wave-1-source-contracts.md
@@ -6,7 +6,7 @@ G10 `budget_plan_fact` admitted and published after the owner-approved close, im
 
 G01 and G04 remain blocked by source readiness. G09 is admitted through the canonical runtime after its approved-close, immutable snapshot, replay and scoped provider contracts were completed.
 
-G06, G11, G12, G13 and G21-G24 remain blocked by an explicit source contract. Their binding status is `blocked_by_source_contract`, their provider is `null`, and they are not executable reports.
+G06, G11, G12, G13, workforce capacity and attendance execution remain blocked by an explicit source contract. G21 `project_labor_cost` is published. R22 `payroll_readiness` is admitted by the versioned payroll calculation source, immutable snapshot rows, blocker-dominant formula and scoped runtime binding delivered in its vertical implementation block.
 
 Other candidates retain their status below. The closed candidate-inventory manifest remains historical admission input and must not be used as runtime status for published G09 or G10.
 
@@ -87,7 +87,7 @@ This contract is consumed by both published G09 and G10 runtime bindings and is 
 | G21 workforce_capacity | Workforce management | employee_id, capacity_date, planned_hours, availability_hours, assignment_project_id, absence_hours | Employee, assignment, and calendar day | organization_id + employee_id + capacity_date | Calendar changes and approved absences are visible by the next reporting refresh. | A fixture with assignments and absences verifies capacity aggregation without cross-organization rows. |
 | G22 attendance_execution | Time tracking | employee_id, work_date, planned_hours, actual_hours, attendance_status, approved_at | Employee and work date | organization_id + employee_id + work_date | Only approved attendance is included; corrections are visible by the next reporting refresh. | A corrected attendance row replaces the prior approved value and updates execution hours once. |
 | G23 project_labor_cost | Time tracking and payroll | project_id, employee_id, work_date, approved_hours, labor_rate, rate_currency, rate_effective_at | Project, employee, and work date | organization_id + project_id + employee_id + work_date | Approved hours and the rate effective for the work date are used; later rate changes do not rewrite closed periods. | A period fixture verifies project labor cost with two effective rates and no use of unapproved hours. |
-| G24 payroll_readiness | Payroll | employee_id, payroll_period, payroll_status, required_input_status, approved_at, payment_date | Employee and payroll period | organization_id + employee_id + payroll_period | Readiness changes after approval or required-input correction and is final only after payroll-period close. | A payroll-period fixture verifies that missing required input is not ready and approved complete input is ready. |
+| G24 payroll_readiness | Payroll | Admitted: versioned payroll periods/calculation versions, immutable source and issue rows, transition history, effective rates and explicit currency | Employee, project, source row/issue and payroll period | organization_id + project_id + employee_id + payroll_period | The latest version at exact `as_of` is selected; blocking issues forbid readiness and locked source rows remain immutable. | Formula, source identity, blockers, scoped options, signed drill-down and runtime binding are covered by focused tests. |
 
 ## Source and formula contracts
 

--- a/docs/superpowers/plans/2026-08-04-reports-architecture-simplification.md
+++ b/docs/superpowers/plans/2026-08-04-reports-architecture-simplification.md
@@ -129,7 +129,8 @@ UI различает initial, options loading, ready to run, validation error, 
 1. Reconciliation G10 «План-факт бюджета»: сверить фактический `main` с полным Definition of Done и исправить устаревшие source/handoff документы.
 2. Cleanup отменённой publication/CI-инфраструктуры отдельным блоком.
 3. G09 «Маржинальность проекта»: canonical backend и admin UI опубликованы; server-owned context, закрытый snapshot, totals, drill-down и export доставлены через отдельные PR и успешные deploy.
-4. G21 `project_labor_cost` «Стоимость труда по проектам»: canonical backend опубликован на реальном `DatabaseProjectLaborCostAdapter` — exact definition/binding, server-owned project scope, поисковые options с пагинацией, totals, sensitive-cost permission, signed drill-down и export. Следующий обязательный блок — admin UI с полным Definition of Done.
-5. Остальные отчёты — по одному, в порядке реальной готовности источников.
+4. G21 `project_labor_cost` «Стоимость труда по проектам»: canonical backend и admin UI опубликованы; используются реальный `DatabaseProjectLaborCostAdapter`, server-owned project scope, поисковые options, totals, sensitive-cost permission, signed drill-down и export.
+5. R22 `payroll_readiness` «Готовность к расчёту зарплаты»: следующий вертикальный блок на существующих версионированных payroll calculation sources и `DatabasePayrollReadinessAdapter`; публикация включает project-scoped options, blockers/readiness totals, audit drill-down и export.
+6. Остальные отчёты — по одному, в порядке реальной готовности источников.
 
 Для каждого блока создаются отдельные backend/admin feature-ветки от актуальных `main`; выполняются минимальные релевантные проверки и одно независимое review.

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -24,6 +24,8 @@ use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublish
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -55,12 +57,15 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $registry->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $registry->published('project_labor_cost')->code);
+        self::assertSame('payroll_readiness', $registry->published('payroll_readiness')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
+        self::assertSame('payroll_readiness', $app->make(ReportCatalogMetadataRegistry::class)->published('payroll_readiness')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
+        self::assertSame('payroll_readiness', $app->make(ReportSchedulingCapabilityRegistry::class)->published('payroll_readiness')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -69,10 +74,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->projectMargin(),
             new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract),
             $this->projectLaborCost(),
+            $this->payrollReadiness(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['budget_plan_fact', 'project_labor_cost', 'project_margin'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'project_labor_cost', 'project_margin'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -91,11 +97,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['budget_plan_fact', 'project_labor_cost', 'project_margin', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'project_labor_cost', 'project_margin', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -103,7 +109,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -150,5 +156,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function projectLaborCost(): ProjectLaborCostBuiltinPublishedReport
     {
         return new ProjectLaborCostBuiltinPublishedReport(new ProjectLaborCostCandidateContract);
+    }
+
+    private function payrollReadiness(): PayrollReadinessBuiltinPublishedReport
+    {
+        return new PayrollReadinessBuiltinPublishedReport(new PayrollReadinessCandidateContract);
     }
 }

--- a/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
+++ b/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
@@ -12,6 +12,7 @@ use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\AuthorizeReportDefi
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
@@ -32,7 +33,9 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("Route::get('/projects/{project}/project-margin/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/project-labor-cost/runs'", $routes);
         self::assertStringContainsString("Route::get('/projects/{project}/project-labor-cost/options'", $routes);
-        self::assertSame(6, substr_count($routes, "'report.project-scope'"));
+        self::assertStringContainsString("Route::post('/projects/{project}/payroll-readiness/runs'", $routes);
+        self::assertStringContainsString("Route::get('/projects/{project}/payroll-readiness/options'", $routes);
+        self::assertSame(8, substr_count($routes, "'report.project-scope'"));
 
         $middlewareFile = (new ReflectionClass(AuthorizeReportDefinitionAccess::class))->getFileName();
         self::assertIsString($middlewareFile);
@@ -43,6 +46,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString('private function genericCreateRun', $middleware);
         self::assertStringContainsString('ProjectMarginCandidateContract::CODE', $middleware);
         self::assertStringContainsString('BudgetPlanFactCandidateContract::CODE', $middleware);
+        self::assertStringContainsString('PayrollReadinessCandidateContract::CODE', $middleware);
     }
 
     #[DataProvider('projectScopedReportCodes')]
@@ -76,6 +80,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
             'G09' => [ProjectMarginCandidateContract::CODE],
             'G10' => [BudgetPlanFactCandidateContract::CODE],
             'G21' => [ProjectLaborCostCandidateContract::CODE],
+            'G22' => [PayrollReadinessCandidateContract::CODE],
         ];
     }
 }

--- a/tests/Unit/WorkforceManagement/Reporting/PayrollReadinessOptionsServiceTest.php
+++ b/tests/Unit/WorkforceManagement/Reporting/PayrollReadinessOptionsServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessOptionsService;
+use Illuminate\Database\SQLiteConnection;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class PayrollReadinessOptionsServiceTest extends TestCase
+{
+    public function test_options_are_limited_to_server_owned_organization_and_project(): void
+    {
+        $connection = new SQLiteConnection(new PDO('sqlite::memory:'));
+        foreach ([
+            'CREATE TABLE workforce_payroll_periods (id INTEGER PRIMARY KEY, organization_id INTEGER, project_id INTEGER, period_start TEXT, period_end TEXT, status TEXT)',
+            'CREATE TABLE workforce_payroll_calculation_versions (id INTEGER PRIMARY KEY, organization_id INTEGER, payroll_period_id INTEGER)',
+            'CREATE TABLE workforce_payroll_calculation_source_rows (id INTEGER PRIMARY KEY, organization_id INTEGER, calculation_version_id INTEGER, employee_id INTEGER, employee_name TEXT, source_type TEXT)',
+            'CREATE TABLE workforce_payroll_calculation_issues (id INTEGER PRIMARY KEY, organization_id INTEGER, calculation_version_id INTEGER, issue_code TEXT)',
+        ] as $sql) {
+            $connection->statement($sql);
+        }
+
+        $connection->table('workforce_payroll_periods')->insert([
+            ['id' => 1, 'organization_id' => 10, 'project_id' => 20, 'period_start' => '2026-07-01', 'period_end' => '2026-07-31', 'status' => 'locked'],
+            ['id' => 2, 'organization_id' => 10, 'project_id' => 21, 'period_start' => '2026-07-01', 'period_end' => '2026-07-31', 'status' => 'locked'],
+            ['id' => 3, 'organization_id' => 11, 'project_id' => 20, 'period_start' => '2026-07-01', 'period_end' => '2026-07-31', 'status' => 'locked'],
+        ]);
+        $connection->table('workforce_payroll_calculation_versions')->insert([
+            ['id' => 101, 'organization_id' => 10, 'payroll_period_id' => 1],
+            ['id' => 102, 'organization_id' => 10, 'payroll_period_id' => 2],
+            ['id' => 103, 'organization_id' => 11, 'payroll_period_id' => 3],
+        ]);
+        $connection->table('workforce_payroll_calculation_source_rows')->insert([
+            ['id' => 1, 'organization_id' => 10, 'calculation_version_id' => 101, 'employee_id' => 7, 'employee_name' => 'Ivan Petrov', 'source_type' => 'timesheet'],
+            ['id' => 2, 'organization_id' => 10, 'calculation_version_id' => 102, 'employee_id' => 8, 'employee_name' => 'Чужой проект', 'source_type' => 'production'],
+            ['id' => 3, 'organization_id' => 11, 'calculation_version_id' => 103, 'employee_id' => 9, 'employee_name' => 'Чужая организация', 'source_type' => 'timesheet'],
+        ]);
+        $connection->table('workforce_payroll_calculation_issues')->insert([
+            ['id' => 1, 'organization_id' => 10, 'calculation_version_id' => 101, 'issue_code' => 'MISSING_RATE'],
+            ['id' => 2, 'organization_id' => 10, 'calculation_version_id' => 102, 'issue_code' => 'FOREIGN_PROJECT'],
+        ]);
+
+        $service = new PayrollReadinessOptionsService($connection);
+        self::assertSame([1], array_column($service->summary(10, 20)['periods'], 'id'));
+        self::assertSame([1], array_column($service->search(10, 20, 'periods', '2026-07', 1)['items'], 'id'));
+        self::assertSame(['Ivan Petrov'], array_column($service->search(10, 20, 'employees', 'Ivan', 1)['items'], 'name'));
+        self::assertSame(['MISSING_RATE'], array_column($service->search(10, 20, 'issue_codes', null, 1)['items'], 'id'));
+        self::assertSame(['timesheet'], array_column($service->search(10, 20, 'source_types', null, 1)['items'], 'id'));
+    }
+}

--- a/tests/Unit/WorkforceManagement/Reporting/PayrollReadinessPublishedRuntimeBindingRegistrarTest.php
+++ b/tests/Unit/WorkforceManagement/Reporting/PayrollReadinessPublishedRuntimeBindingRegistrarTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessProvider;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessQueryService;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessReportBindingFactory;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class PayrollReadinessPublishedRuntimeBindingRegistrarTest extends TestCase
+{
+    public function test_registers_existing_provider_query_and_signed_drill_contract(): void
+    {
+        $contract = new PayrollReadinessCandidateContract;
+        $definition = (new PayrollReadinessBuiltinPublishedReport($contract))->definition();
+        $provider = (new ReflectionClass(PayrollReadinessProvider::class))->newInstanceWithoutConstructor();
+        $query = (new ReflectionClass(PayrollReadinessQueryService::class))->newInstanceWithoutConstructor();
+        $assembler = new PayrollReadinessCapturingBindingAssembler;
+        (new PayrollReadinessPublishedRuntimeBindingRegistrar(
+            new PayrollReadinessPublishedRegistry($definition),
+            new PayrollReadinessReportBindingFactory($provider, $query, $contract),
+        ))->register($assembler);
+
+        $binding = $assembler->bindings[PayrollReadinessCandidateContract::CODE];
+        self::assertSame($provider, $binding->dataProvider);
+        self::assertSame($query, $binding->rowQuery);
+        self::assertSame($query, $binding->drillDownProvider);
+        self::assertSame(['drill' => 'source_refs'], $query->drillDownTokenColumns());
+        self::assertSame(['workforce.audit.view'], $definition->payload()->permissionPolicy->auditPermissions);
+    }
+}
+
+final class PayrollReadinessCapturingBindingAssembler implements ReportDefinitionBindingAssembler
+{
+    public array $bindings = [];
+
+    public function register(ReportDefinitionBinding $binding): void
+    {
+        $this->bindings[$binding->code] = $binding;
+    }
+
+    public function assemble(ReportDefinitionRegistry $registry): ReportDefinitionBindingMap
+    {
+        throw new LogicException('not_used');
+    }
+}
+
+final readonly class PayrollReadinessPublishedRegistry implements ReportDefinitionRegistry
+{
+    public function __construct(private PublishedReportDefinition $definition) {}
+
+    public function published(string $code): PublishedReportDefinition
+    {
+        return $code === PayrollReadinessCandidateContract::CODE ? $this->definition : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+    }
+
+    public function publishedCodes(): array
+    {
+        return [PayrollReadinessCandidateContract::CODE];
+    }
+
+    public function manifestSha256(): Sha256Hash
+    {
+        return new Sha256Hash(str_repeat('a', 64));
+    }
+}


### PR DESCRIPTION
## Что сделано
- опубликован canonical backend R22 payroll_readiness на существующем DatabasePayrollReadinessAdapter
- добавлены server-owned project routes и реальные paginated options
- подключены definition, metadata, runtime binding, signed drill-down и export permission
- generic route и клиентские organization/project overrides запрещены
- актуализированы master plan и source handoff

## Проверки
- PHPStan изменённых backend-файлов
- Pint изменённых PHP-файлов
- 37 contract/security тестов, 97 assertions
- options scope test: 5 assertions
- PHP syntax и git diff --check

Миграции, DB-команды, dev-серверы и CI/CD не запускались и не менялись.

Известный старый сбой полного LaborPayrollSourceTest относится к ProjectLaborCostManagementPnlComponentSource и не затрагивает R22; все целевые payroll-тесты кроме общего legacy assertion проходят.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented Payroll Readiness report options functionality, including a new controller and request validation.</li>
<li>Updated authorization middleware to support Payroll Readiness report access.</li>
<li>Registered new report definitions and scheduling capabilities for Payroll Readiness.</li>
<li>Added infrastructure adapters and services to support Payroll Readiness reporting.</li>
<li>Added unit tests for the new reporting components and services.</li>
</ul></div>