### PR TITLE
fix: восстановить доступ к встроенным отчётам

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactBuiltinPublishedReport.php
@@ -58,6 +58,8 @@ final readonly class BudgetPlanFactBuiltinPublishedReport
             'category' => 'finance',
             'grain' => 'budget_period_article_currency',
             'wave' => 1,
+            'source_module' => 'budgeting',
+            'core_access_mode' => 'source_module_report',
             'filters' => $this->contract->filters(),
             'columns' => $this->contract->columns(),
             'sorts' => $this->contract->sorts(),

--- a/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactCandidateContract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Budgeting\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
@@ -101,6 +102,8 @@ final readonly class BudgetPlanFactCandidateContract
     public function assertDefinition(ReportDefinition $definition): void
     {
         if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'budgeting'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
             || $definition->formulaVersion !== $this->formulaVersion
             || $definition->sourceSchemaVersion !== $this->sourceSchemaVersion
             || $definition->filters !== self::canonicalItems($this->filters())

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginBuiltinPublishedReport.php
@@ -57,6 +57,8 @@ final readonly class ProjectMarginBuiltinPublishedReport
             'category' => 'finance',
             'grain' => 'project_article_currency_period',
             'wave' => 1,
+            'source_module' => 'budgeting',
+            'core_access_mode' => 'source_module_report',
             'filters' => $this->contract->filters(),
             'columns' => $this->contract->columns(),
             'sorts' => $this->contract->sorts(),

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginCandidateContract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Budgeting\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
@@ -105,6 +106,8 @@ final readonly class ProjectMarginCandidateContract
     public function assertDefinition(ReportDefinition $definition): void
     {
         if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'budgeting'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
             || $definition->formulaVersion !== $this->formulaVersion
             || $definition->sourceSchemaVersion !== $this->sourceSchemaVersion
             || $definition->filters !== self::canonicalItems($this->filters())

--- a/app/BusinessModules/Features/TimeTracking/Reporting/ProjectLaborCostBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/TimeTracking/Reporting/ProjectLaborCostBuiltinPublishedReport.php
@@ -58,6 +58,8 @@ final readonly class ProjectLaborCostBuiltinPublishedReport
             'category' => 'workforce',
             'grain' => 'approved_entry_employee_day',
             'wave' => 1,
+            'source_module' => 'time-tracking',
+            'core_access_mode' => 'source_module_report',
             'filters' => $this->contract->filters(),
             'columns' => $this->contract->columns(),
             'sorts' => $this->contract->sorts(),

--- a/app/BusinessModules/Features/TimeTracking/Reporting/ProjectLaborCostCandidateContract.php
+++ b/app/BusinessModules/Features/TimeTracking/Reporting/ProjectLaborCostCandidateContract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\TimeTracking\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
@@ -80,6 +81,8 @@ final readonly class ProjectLaborCostCandidateContract
     public function assertDefinition(ReportDefinition $definition): void
     {
         if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'time-tracking'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
             || $definition->formulaVersion !== DatabaseProjectLaborCostAdapter::FORMULA_VERSION
             || $definition->sourceSchemaVersion !== DatabaseProjectLaborCostAdapter::SCHEMA_VERSION
             || $definition->filters !== self::canonicalItems($this->filters())

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessBuiltinPublishedReport.php
@@ -46,6 +46,7 @@ final readonly class PayrollReadinessBuiltinPublishedReport
             'code' => PayrollReadinessCandidateContract::CODE,
             'title_key' => 'reports.catalog.payroll_readiness',
             'catalog_group' => 'team', 'category' => 'workforce', 'grain' => 'period_employee_issue', 'wave' => 1,
+            'source_module' => 'workforce-management', 'core_access_mode' => 'source_module_report',
             'filters' => $this->contract->filters(), 'columns' => $this->contract->columns(),
             'sorts' => $this->contract->sorts(), 'formats' => $this->contract->formats(),
             'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => DatabasePayrollReadinessAdapter::FORMULA_VERSION, 'source_schema' => DatabasePayrollReadinessAdapter::SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION],

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessCandidateContract.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/PayrollReadinessCandidateContract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
@@ -68,6 +69,8 @@ final readonly class PayrollReadinessCandidateContract
     public function assertDefinition(ReportDefinition $definition): void
     {
         if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'workforce-management'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
             || $definition->formulaVersion !== DatabasePayrollReadinessAdapter::FORMULA_VERSION
             || $definition->sourceSchemaVersion !== DatabasePayrollReadinessAdapter::SCHEMA_VERSION
             || $definition->filters !== self::canonicalItems($this->filters())

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityBuiltinPublishedReport.php
@@ -46,6 +46,7 @@ final readonly class WorkforceCapacityBuiltinPublishedReport
             'code' => self::code(),
             'title_key' => 'reports.catalog.workforce_capacity',
             'catalog_group' => 'team', 'category' => 'workforce', 'grain' => 'month_staff_unit_project_rate', 'wave' => 1,
+            'source_module' => 'workforce-management', 'core_access_mode' => 'source_module_report',
             'filters' => $this->contract->filters(), 'columns' => $this->contract->columns(),
             'sorts' => $this->contract->sorts(), 'formats' => $this->contract->formats(),
             'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => DatabaseWorkforceReportAdapter::CAPACITY_FORMULA, 'source_schema' => DatabaseWorkforceReportAdapter::SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION],

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityCandidateContract.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityCandidateContract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
@@ -70,6 +71,8 @@ final readonly class WorkforceCapacityCandidateContract
     public function assertDefinition(ReportDefinition $definition): void
     {
         if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'workforce-management'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
             || $definition->formulaVersion !== DatabaseWorkforceReportAdapter::CAPACITY_FORMULA
             || $definition->sourceSchemaVersion !== DatabaseWorkforceReportAdapter::SCHEMA_VERSION
             || $definition->filters !== self::canonicalItems($this->filters())

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -10,6 +10,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportCatalogMetadataReg
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSchedulingCapabilityRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\BuiltinPublishedReportDefinitionRegistry;
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\CompositePublishedReportDefinitionRegistry;
@@ -97,6 +98,32 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             hash('sha256', CanonicalJson::encode((new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->document())),
             $definition->definitionHash->value,
         );
+    }
+
+    public function test_builtin_reports_use_owner_module_entitlements(): void
+    {
+        $registry = new BuiltinPublishedReportDefinitionRegistry(
+            $this->projectMargin(),
+            new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract),
+            $this->projectLaborCost(),
+            $this->payrollReadiness(),
+            $this->workforceCapacity(),
+        );
+
+        $expectedModules = [
+            'budget_plan_fact' => 'budgeting',
+            'project_margin' => 'budgeting',
+            'project_labor_cost' => 'time-tracking',
+            'payroll_readiness' => 'workforce-management',
+            'workforce_capacity' => 'workforce-management',
+        ];
+
+        foreach ($expectedModules as $code => $module) {
+            $definition = $registry->published($code)->payload();
+
+            self::assertSame($module, $definition->sourceModule);
+            self::assertSame(ReportCoreAccessMode::SOURCE_MODULE_REPORT, $definition->coreAccessMode);
+        }
     }
 
     public function test_database_published_report_remains_available(): void


### PR DESCRIPTION
## Что исправлено
- встроенные отчёты наследуют доступ исходного бизнес-модуля
- удалён ошибочный шлюз отдельного модуля отчётности
- добавлен контрактный тест для всех пяти встроенных отчётов

## Проверки
- PHP syntax: 11/11 файлов
- git diff --check
- PHPUnit локально не стартовал: в рабочем окружении отсутствует vendor/autoload.php; проверка выполняется штатным CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added 'source_module' and 'core_access_mode' fields to multiple built-in report definitions.</li>
<li>Updated corresponding candidate contract test assertions to validate the new report definition fields.</li>
<li>Standardized report access mode to 'source_module_report' across Budgeting, Time Tracking, and Workforce Management modules.</li>
</ul></div>