### PR TITLE
fix: поддержать права исходных модулей отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportDefinition.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportDefinition.php
@@ -53,7 +53,7 @@ final readonly class ReportDefinition
 
         if (preg_match('/^[a-z][a-z0-9-]{1,63}$/D', $sourceModule) !== 1
             || ($coreAccessMode === ReportCoreAccessMode::REPORTING_WORKSPACE && $sourceModule !== 'reports')
-            || ($coreAccessMode === ReportCoreAccessMode::SOURCE_MODULE_REPORT && $sourceModule !== 'act-reporting')) {
+            || ($coreAccessMode === ReportCoreAccessMode::SOURCE_MODULE_REPORT && $sourceModule === 'reports')) {
             throw new InvalidArgumentException('report_core_access_contract_invalid');
         }
 
@@ -61,23 +61,6 @@ final readonly class ReportDefinition
         $this->columns = self::normalizeItems($columns);
         $this->sorts = self::normalizeItems($sorts);
         $this->formats = self::normalizeFormats($formats);
-        if ($coreAccessMode === ReportCoreAccessMode::SOURCE_MODULE_REPORT) {
-            $expectedExportPermissions = [];
-            foreach ($this->formats as $format) {
-                $expectedExportPermissions[] = match ($format) {
-                    'xlsx' => 'act_reports.export.excel',
-                    'pdf' => 'act_reports.export.pdf',
-                    default => throw new InvalidArgumentException('report_source_module_permission_policy_invalid'),
-                };
-            }
-            sort($expectedExportPermissions, SORT_STRING);
-            if ($permissionPolicy->viewPermissions !== ['act_reports.view']
-                || $permissionPolicy->exportPermissions !== $expectedExportPermissions
-                || $permissionPolicy->sensitivePermissions !== []
-                || $permissionPolicy->auditPermissions !== []) {
-                throw new InvalidArgumentException('report_source_module_permission_policy_invalid');
-            }
-        }
         $columnIds = array_fill_keys(array_column($this->columns, 'id'), true);
         foreach (array_merge(
             $outputClassification->sensitiveColumnIds,

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/ReportManifestSemanticValidator.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/ReportManifestSemanticValidator.php
@@ -216,34 +216,10 @@ final class ReportManifestSemanticValidator
 
         if ($mode !== 'source_module_report'
             || ! array_key_exists('source_module', $definition)
-            || $sourceModule !== 'act-reporting') {
+            || ! is_string($sourceModule)
+            || preg_match('/^[a-z][a-z0-9-]{1,63}$/D', $sourceModule) !== 1
+            || $sourceModule === 'reports') {
             throw new LogicException('report_manifest_core_access_invalid');
-        }
-
-        $permissions = $definition['permissions'] ?? null;
-        $formats = $definition['formats'] ?? null;
-        if (! is_array($permissions) || ! is_array($formats) || ! array_is_list($formats)) {
-            throw new LogicException('report_manifest_source_permission_policy_invalid');
-        }
-        $expectedExportPermissions = [];
-        foreach ($formats as $format) {
-            $expectedExportPermissions[] = match ($format) {
-                'xlsx' => 'act_reports.export.excel',
-                'pdf' => 'act_reports.export.pdf',
-                default => throw new LogicException('report_manifest_source_permission_policy_invalid'),
-            };
-        }
-        sort($expectedExportPermissions, SORT_STRING);
-        $actualExportPermissions = $permissions['export'] ?? null;
-        if (! is_array($actualExportPermissions)) {
-            throw new LogicException('report_manifest_source_permission_policy_invalid');
-        }
-        sort($actualExportPermissions, SORT_STRING);
-        if (($permissions['view'] ?? null) !== ['act_reports.view']
-            || $actualExportPermissions !== $expectedExportPermissions
-            || ($permissions['sensitive'] ?? null) !== []
-            || ($permissions['audit'] ?? null) !== []) {
-            throw new LogicException('report_manifest_source_permission_policy_invalid');
         }
     }
 }

--- a/tests/Unit/Reporting/Catalog/ReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/ReportDefinitionRegistryTest.php
@@ -125,10 +125,10 @@ final class ReportDefinitionRegistryTest extends TestCase
         self::assertNotSame($first->definitionHash->value, $source->definitionHash->value);
     }
 
-    public function test_manifest_semantics_reject_arbitrary_source_modules(): void
+    public function test_manifest_semantics_reject_reports_as_source_module(): void
     {
         $definitions = $this->manifest()->definitions;
-        $definitions[0]['source_module'] = 'finance';
+        $definitions[0]['source_module'] = 'reports';
         $definitions[0]['core_access_mode'] = 'source_module_report';
 
         $this->expectException(LogicException::class);
@@ -137,17 +137,15 @@ final class ReportDefinitionRegistryTest extends TestCase
         (new ReportManifestSemanticValidator)->assertManagement(['definitions' => $definitions]);
     }
 
-    public function test_manifest_semantics_reject_source_mode_permission_fallbacks(): void
+    public function test_manifest_semantics_accept_owner_module_permissions(): void
     {
         $definitions = $this->manifest()->definitions;
-        $definitions[0]['source_module'] = 'act-reporting';
+        $definitions[0]['source_module'] = 'budgeting';
         $definitions[0]['core_access_mode'] = 'source_module_report';
-        $definitions[0]['formats'] = ['xlsx'];
-
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('report_manifest_source_permission_policy_invalid');
 
         (new ReportManifestSemanticValidator)->assertManagement(['definitions' => $definitions]);
+
+        self::assertSame('budgeting', $definitions[0]['source_module']);
     }
 
     public function test_metadata_preserves_explicit_contiguous_manifest_ordinal(): void

--- a/tests/Unit/Reporting/Contracts/ReportCoreAccessModeTest.php
+++ b/tests/Unit/Reporting/Contracts/ReportCoreAccessModeTest.php
@@ -65,9 +65,28 @@ final class ReportCoreAccessModeTest extends TestCase
         return [
             'workspace cannot use source module' => ['act-reporting', ReportCoreAccessMode::REPORTING_WORKSPACE],
             'source mode cannot use reports' => ['reports', ReportCoreAccessMode::SOURCE_MODULE_REPORT],
-            'source mode is allow-listed' => ['finance', ReportCoreAccessMode::SOURCE_MODULE_REPORT],
             'slug is canonical' => ['Act Reports', ReportCoreAccessMode::SOURCE_MODULE_REPORT],
         ];
+    }
+
+    public function test_source_mode_uses_owner_module_and_its_exact_permissions(): void
+    {
+        $definition = (new ReportDefinitionBuilder)
+            ->sourceModule('time-tracking')
+            ->coreAccessMode(ReportCoreAccessMode::SOURCE_MODULE_REPORT)
+            ->formats(['csv', 'xlsx'])
+            ->permissionPolicy(new ReportPermissionPolicy(
+                ['time_tracking.view'],
+                ['time_tracking.reports.export'],
+                ['time_tracking.cost.view'],
+                [],
+            ))
+            ->payload();
+
+        self::assertSame('time-tracking', $definition->sourceModule);
+        self::assertSame(['time_tracking.view'], $definition->permissionPolicy->viewPermissions);
+        self::assertSame(['time_tracking.reports.export'], $definition->permissionPolicy->exportPermissions);
+        self::assertSame(['time_tracking.cost.view'], $definition->permissionPolicy->sensitivePermissions);
     }
 
     public function test_access_contract_participates_in_canonical_authorization_identity(): void
@@ -89,24 +108,6 @@ final class ReportCoreAccessModeTest extends TestCase
             (new CurrentReportAuthorizationTarget($generic, ReportOperation::VIEW, null))->canonicalFingerprint(),
             (new CurrentReportAuthorizationTarget($source, ReportOperation::VIEW, null))->canonicalFingerprint(),
         );
-    }
-
-    public function test_source_export_permission_must_match_each_admitted_format(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('report_source_module_permission_policy_invalid');
-
-        (new ReportDefinitionBuilder)
-            ->sourceModule('act-reporting')
-            ->coreAccessMode(ReportCoreAccessMode::SOURCE_MODULE_REPORT)
-            ->formats(['xlsx', 'pdf'])
-            ->permissionPolicy(new ReportPermissionPolicy(
-                ['act_reports.view'],
-                ['act_reports.export.excel'],
-                [],
-                [],
-            ))
-            ->payload();
     }
 
     public function test_requested_export_format_participates_in_authorization_identity(): void


### PR DESCRIPTION
## Что исправлено
- режим source_module_report принимает реальный бизнес-модуль отчёта
- удалена историческая привязка только к модулю актов и его permissions
- общий reports остаётся отдельным workspace-режимом и не может подменять исходный модуль
- обновлены контрактные тесты DTO и manifest validator

## Проверки
- PHP syntax: 4/4 файла
- git diff --check
- предыдущий deploy дал точный bootstrap regression signal; повторная сборка основного workflow проверит package discovery