### PR TITLE
feat: опубликовать отчёт по циклу закупки

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -12,6 +12,7 @@ use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
@@ -27,9 +28,10 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
         PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
+        ProcurementCycleBuiltinPublishedReport $procurementCycle,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -10,6 +10,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportCatalogMetadataReg
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
@@ -22,6 +23,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
         private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         private WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
+        private ProcurementCycleBuiltinPublishedReport $procurementCycle,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -32,6 +34,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->projectLaborCost->metadata()->code => $this->projectLaborCost->metadata(),
             $this->payrollReadiness->metadata()->code => $this->payrollReadiness->metadata(),
             $this->workforceCapacity->metadata()->code => $this->workforceCapacity->metadata(),
+            $this->procurementCycle->metadata()->code => $this->procurementCycle->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -10,6 +10,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSchedulingCapabili
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
@@ -22,6 +23,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
         private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         private WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
+        private ProcurementCycleBuiltinPublishedReport $procurementCycle,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -32,6 +34,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->projectLaborCost->scheduling()->code => $this->projectLaborCost->scheduling(),
             $this->payrollReadiness->scheduling()->code => $this->payrollReadiness->scheduling(),
             $this->workforceCapacity->scheduling()->code => $this->workforceCapacity->scheduling(),
+            $this->procurementCycle->scheduling()->code => $this->procurementCycle->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -59,6 +59,8 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Publication\EloquentReport
 use App\BusinessModules\Core\Reporting\Infrastructure\Queue\LaravelReportSubscriptionDeliveryDispatcher;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
@@ -103,6 +105,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(WorkforceCapacityBuiltinPublishedReport::class, fn (Application $app): WorkforceCapacityBuiltinPublishedReport => new WorkforceCapacityBuiltinPublishedReport(
             $app->make(WorkforceCapacityCandidateContract::class),
         ));
+        $this->app->singleton(ProcurementCycleCandidateContract::class);
+        $this->app->singleton(ProcurementCycleBuiltinPublishedReport::class, fn (Application $app): ProcurementCycleBuiltinPublishedReport => new ProcurementCycleBuiltinPublishedReport(
+            $app->make(ProcurementCycleCandidateContract::class),
+        ));
         $this->app->singleton(
             BuiltinPublishedReportDefinitionRegistry::class,
             fn (Application $app): BuiltinPublishedReportDefinitionRegistry => new BuiltinPublishedReportDefinitionRegistry(
@@ -111,6 +117,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(ProjectLaborCostBuiltinPublishedReport::class),
                 $app->make(PayrollReadinessBuiltinPublishedReport::class),
                 $app->make(WorkforceCapacityBuiltinPublishedReport::class),
+                $app->make(ProcurementCycleBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -120,9 +127,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/Procurement/ProcurementServiceProvider.php
+++ b/app/BusinessModules/Features/Procurement/ProcurementServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\Procurement;
 
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -29,6 +30,10 @@ class ProcurementServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->app->afterResolving(ReportDefinitionBindingAssembler::class, function (ReportDefinitionBindingAssembler $assembler): void {
+            $this->app->make(Reporting\Cycle\ProcurementCyclePublishedRuntimeBindingRegistrar::class)->register($assembler);
+        });
+
         // Загружаем миграции
         $this->loadMigrations();
 
@@ -65,6 +70,7 @@ class ProcurementServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\Cycle\Services\ProcurementCycleReportAdapter::class);
         $this->app->singleton(Reporting\Cycle\Services\ProcurementCycleReadinessProbe::class);
         $this->app->singleton(Reporting\Cycle\Services\ProcurementCycleReportBindingFactory::class);
+        $this->app->singleton(Reporting\Cycle\ProcurementCyclePublishedRuntimeBindingRegistrar::class);
 
         $this->app->singleton(
             Reporting\Cycle\Contracts\ProcurementProcessEventStore::class,

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleBuiltinPublishedReport.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Procurement\Reporting\Cycle;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Services\ProcurementCycleReportAdapter;
+
+final readonly class ProcurementCycleBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+
+    public const RENDERER_VERSION = '1.0.0';
+
+    public const MANIFEST_ORDINAL = 15;
+
+    public function __construct(private ProcurementCycleCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(ProcurementCycleCandidateContract::CODE, 'reports.catalog.procurement_cycle', ReportCatalogGroup::PROCUREMENT_WAREHOUSE, 'procurement', 'request_line_process', 2, self::MANIFEST_ORDINAL);
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(ProcurementCycleCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => ProcurementCycleCandidateContract::CODE,
+            'title_key' => 'reports.catalog.procurement_cycle',
+            'catalog_group' => 'procurement_warehouse', 'category' => 'procurement', 'grain' => 'request_line_process', 'wave' => 2,
+            'source_module' => 'procurement',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(), 'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(), 'formats' => $this->contract->formats(),
+            'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => ProcurementCycleReportAdapter::FORMULA_VERSION, 'source_schema' => ProcurementCycleReportAdapter::SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION],
+            'semantic_fingerprints' => ['formula' => ProcurementCycleCandidateContract::FORMULA_HASH, 'source' => ProcurementCycleCandidateContract::SOURCE_HASH],
+            'permissions' => ['view' => ['procurement.dashboard.view'], 'export' => ['procurement.reports.export'], 'sensitive' => [], 'audit' => ['procurement.audit.view']],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleCandidateContract.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleCandidateContract.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Procurement\Reporting\Cycle;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Services\ProcurementCycleFormula;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Services\ProcurementCycleReportAdapter;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class ProcurementCycleCandidateContract
+{
+    public const CODE = 'procurement_cycle';
+
+    public const FORMULA_HASH = '7fa0c79e701d081930247ed67ebe233b5318b16127341898b586600a43463d71';
+
+    public const SOURCE_HASH = '38036ba2c63d19ae8b570ba94244e282f59488577a8b96d33a8487e12f940156';
+
+    public function filters(): array
+    {
+        return array_map(static fn (string $id): array => [
+            'id' => $id,
+            'required' => in_array($id, ['period_start', 'period_end'], true),
+        ], [
+            'period_start', 'period_end', 'project_ids', 'cohort_basis', 'current_stage', 'outcome',
+            'priority', 'requester_id', 'buyer_id', 'material_id', 'material_category_id',
+            'supplier_party_id', 'currency', 'award_amount_min', 'award_amount_max',
+        ]);
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'cohort_date', 'purchase_request_line_id', 'request_number', 'material_name',
+            'requester_id', 'buyer_id', 'priority', 'current_stage', 'outcome', 'total_cycle_seconds',
+            'open_age_seconds', 'awarded_supplier_party_id', 'awarded_amount', 'currency', 'quality_status',
+            'gap_codes', ProcurementCycleReportAdapter::STAGE_DRILL_COLUMN, ProcurementCycleReportAdapter::AUDIT_DRILL_COLUMN,
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return [['id' => ProcurementCycleReportAdapter::SORT_FIELD, 'direction' => 'asc']];
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx', 'pdf'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(ProcurementCycleFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(ProcurementCycleReportAdapter::class))) {
+            throw new InvalidArgumentException('procurement_cycle_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'procurement'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== ProcurementCycleReportAdapter::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== ProcurementCycleReportAdapter::SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['procurement.dashboard.view']
+            || $definition->permissionPolicy->exportPermissions !== ['procurement.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== ['procurement.audit.view']) {
+            throw new InvalidArgumentException('procurement_cycle_candidate_definition_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('procurement_cycle_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR), $items);
+    }
+}

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCyclePublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCyclePublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Procurement\Reporting\Cycle;
+
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Services\ProcurementCycleReportBindingFactory;
+use LogicException;
+
+final readonly class ProcurementCyclePublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private ProcurementCycleReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        $definition = $this->definitions->published(ProcurementCycleCandidateContract::CODE);
+        if ($definition->code !== ProcurementCycleCandidateContract::CODE) {
+            throw new LogicException('procurement_cycle_published_definition_invalid');
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/config/RoleDefinitions/admin/finance_admin.json
+++ b/config/RoleDefinitions/admin/finance_admin.json
@@ -76,6 +76,7 @@
       "procurement.contracts.view",
       "procurement.contracts.create",
       "procurement.dashboard.view",
+      "procurement.reports.export",
       "procurement.statistics.view"
     ],
     "advance-accounts": [

--- a/config/RoleDefinitions/admin/web_admin.json
+++ b/config/RoleDefinitions/admin/web_admin.json
@@ -148,6 +148,7 @@
       "procurement.contracts.view",
       "procurement.contracts.create",
       "procurement.dashboard.view",
+      "procurement.reports.export",
       "procurement.statistics.view",
       "procurement.settings.view",
       "procurement.settings.manage"

--- a/config/RoleDefinitions/lk/organization_admin.json
+++ b/config/RoleDefinitions/lk/organization_admin.json
@@ -602,6 +602,7 @@
       "procurement.contracts.create",
       "procurement.contracts.edit",
       "procurement.dashboard.view",
+      "procurement.reports.export",
       "procurement.statistics.view",
       "procurement.settings.view",
       "procurement.settings.manage"

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -23,6 +23,8 @@ use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublis
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
@@ -62,16 +64,19 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('project_labor_cost', $registry->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $registry->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $registry->published('workforce_capacity')->code);
+        self::assertSame('procurement_cycle', $registry->published('procurement_cycle')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $app->make(ReportCatalogMetadataRegistry::class)->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $app->make(ReportCatalogMetadataRegistry::class)->published('workforce_capacity')->code);
+        self::assertSame('procurement_cycle', $app->make(ReportCatalogMetadataRegistry::class)->published('procurement_cycle')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $app->make(ReportSchedulingCapabilityRegistry::class)->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $app->make(ReportSchedulingCapabilityRegistry::class)->published('workforce_capacity')->code);
+        self::assertSame('procurement_cycle', $app->make(ReportSchedulingCapabilityRegistry::class)->published('procurement_cycle')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -82,10 +87,12 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->projectLaborCost(),
             $this->payrollReadiness(),
             $this->workforceCapacity(),
+            $this->procurementCycle(),
+            $this->procurementCycle(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'project_labor_cost', 'project_margin', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -116,6 +123,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'project_labor_cost' => 'time-tracking',
             'payroll_readiness' => 'workforce-management',
             'workforce_capacity' => 'workforce-management',
+            'procurement_cycle' => 'procurement',
         ];
 
         foreach ($expectedModules as $code => $module) {
@@ -130,11 +138,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'project_labor_cost', 'project_margin', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -142,7 +150,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -199,5 +207,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function workforceCapacity(): WorkforceCapacityBuiltinPublishedReport
     {
         return new WorkforceCapacityBuiltinPublishedReport(new WorkforceCapacityCandidateContract);
+    }
+
+    private function procurementCycle(): ProcurementCycleBuiltinPublishedReport
+    {
+        return new ProcurementCycleBuiltinPublishedReport(new ProcurementCycleCandidateContract);
     }
 }


### PR DESCRIPTION
## Результат
- R15 procurement_cycle зарегистрирован как встроенный отчёт без DB-публикации
- подключены реальный adapter, snapshot, drill-down и export runtime
- источник доступа — модуль procurement, scope организации/проектов серверный
- права экспорта добавлены ответственным ролям
- каталог, metadata и scheduling registry синхронизированы

## Проверки
- PHP syntax: 9/9 изменённых PHP-файлов
- JSON parse: 3/3 role definitions
- formula/source SHA256 соответствуют candidate contract
- git diff --check
- полный bootstrap проверяется основным deploy workflow

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated the new Procurement Cycle report into the core reporting infrastructure.</li>
<li>Registered ProcurementCycleBuiltinPublishedReport and its associated candidate contract in the ReportingCatalogServiceProvider.</li>
<li>Updated registry classes (Definition, Metadata, Scheduling) to include the new Procurement Cycle report.</li>
<li>Added new role definitions for finance_admin, web_admin, and organization_admin to support the new report.</li>
<li>Implemented the ProcurementCycleBuiltinPublishedReport class and its candidate contract.</li>
</ul></div>