### PR TITLE
feat: опубликован отчёт выбора поставщика

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
@@ -29,9 +30,10 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
         ProcurementCycleBuiltinPublishedReport $procurementCycle,
+        SupplierAwardBuiltinPublishedReport $supplierAward,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
@@ -24,6 +25,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         private WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
         private ProcurementCycleBuiltinPublishedReport $procurementCycle,
+        private SupplierAwardBuiltinPublishedReport $supplierAward,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -35,6 +37,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->payrollReadiness->metadata()->code => $this->payrollReadiness->metadata(),
             $this->workforceCapacity->metadata()->code => $this->workforceCapacity->metadata(),
             $this->procurementCycle->metadata()->code => $this->procurementCycle->metadata(),
+            $this->supplierAward->metadata()->code => $this->supplierAward->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
@@ -24,6 +25,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         private WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
         private ProcurementCycleBuiltinPublishedReport $procurementCycle,
+        private SupplierAwardBuiltinPublishedReport $supplierAward,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -35,6 +37,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->payrollReadiness->scheduling()->code => $this->payrollReadiness->scheduling(),
             $this->workforceCapacity->scheduling()->code => $this->workforceCapacity->scheduling(),
             $this->procurementCycle->scheduling()->code => $this->procurementCycle->scheduling(),
+            $this->supplierAward->scheduling()->code => $this->supplierAward->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -61,6 +61,8 @@ use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublis
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
@@ -109,6 +111,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(ProcurementCycleBuiltinPublishedReport::class, fn (Application $app): ProcurementCycleBuiltinPublishedReport => new ProcurementCycleBuiltinPublishedReport(
             $app->make(ProcurementCycleCandidateContract::class),
         ));
+        $this->app->singleton(SupplierAwardCandidateContract::class);
+        $this->app->singleton(SupplierAwardBuiltinPublishedReport::class, fn (Application $app): SupplierAwardBuiltinPublishedReport => new SupplierAwardBuiltinPublishedReport(
+            $app->make(SupplierAwardCandidateContract::class),
+        ));
         $this->app->singleton(
             BuiltinPublishedReportDefinitionRegistry::class,
             fn (Application $app): BuiltinPublishedReportDefinitionRegistry => new BuiltinPublishedReportDefinitionRegistry(
@@ -118,6 +124,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(PayrollReadinessBuiltinPublishedReport::class),
                 $app->make(WorkforceCapacityBuiltinPublishedReport::class),
                 $app->make(ProcurementCycleBuiltinPublishedReport::class),
+                $app->make(SupplierAwardBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -127,9 +134,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/Procurement/ProcurementServiceProvider.php
+++ b/app/BusinessModules/Features/Procurement/ProcurementServiceProvider.php
@@ -32,6 +32,7 @@ class ProcurementServiceProvider extends ServiceProvider
     {
         $this->app->afterResolving(ReportDefinitionBindingAssembler::class, function (ReportDefinitionBindingAssembler $assembler): void {
             $this->app->make(Reporting\Cycle\ProcurementCyclePublishedRuntimeBindingRegistrar::class)->register($assembler);
+            $this->app->make(Reporting\Award\SupplierAwardPublishedRuntimeBindingRegistrar::class)->register($assembler);
         });
 
         // Загружаем миграции
@@ -71,6 +72,16 @@ class ProcurementServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\Cycle\Services\ProcurementCycleReadinessProbe::class);
         $this->app->singleton(Reporting\Cycle\Services\ProcurementCycleReportBindingFactory::class);
         $this->app->singleton(Reporting\Cycle\ProcurementCyclePublishedRuntimeBindingRegistrar::class);
+        $this->app->singleton(Reporting\Award\Services\SupplierAwardFormula::class);
+        $this->app->singleton(Reporting\Award\Services\SupplierProposalComparabilityPolicy::class);
+        $this->app->singleton(Reporting\Award\Services\ComparableProposalVersionFactory::class);
+        $this->app->singleton(Reporting\Award\Queries\SupplierAwardFilteredUniverse::class);
+        $this->app->singleton(Reporting\Award\Services\SupplierAwardSnapshotMaterializer::class);
+        $this->app->singleton(Reporting\Award\Providers\SupplierAwardCompetitivenessReportProvider::class);
+        $this->app->singleton(Reporting\Award\Queries\SupplierAwardRowQuery::class);
+        $this->app->singleton(Reporting\Award\Readiness\SupplierAwardReadinessProbe::class);
+        $this->app->singleton(Reporting\Award\Services\SupplierAwardReportBindingFactory::class);
+        $this->app->singleton(Reporting\Award\SupplierAwardPublishedRuntimeBindingRegistrar::class);
 
         $this->app->singleton(
             Reporting\Cycle\Contracts\ProcurementProcessEventStore::class,

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/Queries/SupplierAwardFilteredUniverse.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/Queries/SupplierAwardFilteredUniverse.php
@@ -9,16 +9,15 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Features\Procurement\Reporting\Award\Models\SupplierAwardDecisionVersion;
-use App\Support\Reporting\OwnerReportFilterApplier;
 use App\Support\Reporting\ReportSourceAccessPolicy;
+use DateTimeImmutable;
+use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\DB;
 
 final readonly class SupplierAwardFilteredUniverse
 {
     public function __construct(
         private ReportSourceAccessPolicy $sourceAccess,
-        private OwnerReportFilterApplier $filters,
     ) {}
 
     public function query(ReportExecutionContext $context, ReportQuery $query): Builder
@@ -62,62 +61,31 @@ final readonly class SupplierAwardFilteredUniverse
                     $context->scope->projectIds,
                 ),
             );
-        $this->filters->apply($builder, $this->filters->only($query->filters, [
-            'project', 'buyer', 'supplier', 'decision', 'method', 'currency', 'non_lowest', 'period',
-        ]), [
-            'project' => 'supplier_award_decision_versions.project_id',
-            'buyer' => 'supplier_award_decision_versions.selected_by',
-            'supplier' => 'supplier_award_decision_versions.selected_supplier_party_id',
-            'decision' => 'supplier_award_decision_versions.decision_id',
-            'method' => DB::raw("supplier_award_decision_versions.dimension_snapshot->>'procurement_method'"),
-            'currency' => DB::raw("supplier_award_decision_versions.dimension_snapshot->>'currency'"),
-            'non_lowest' => [
-                'column' => 'supplier_award_decision_versions.is_lowest_price_selected',
-                'invert_boolean' => true,
-            ],
-            'period' => 'supplier_award_decision_versions.selected_at',
-        ]);
-        $this->applyPinnedLineFilter($builder, $query, 'material', 'material_id');
-        $this->applyPinnedLineFilter($builder, $query, 'category', 'category');
+        [$periodStart, $periodEnd] = $this->period($query);
+        $builder->whereBetween('supplier_award_decision_versions.selected_at', [$periodStart, $periodEnd]);
 
         return $builder
             ->select('supplier_award_decision_versions.*')
             ->distinct();
     }
 
-    private function applyPinnedLineFilter(
-        Builder $builder,
-        ReportQuery $query,
-        string $filter,
-        string $dimension,
-    ): void {
-        $condition = $query->filters->values[$filter] ?? null;
-        if (! is_array($condition)) {
-            return;
+    private function period(ReportQuery $query): array
+    {
+        $start = $query->filters->values['period_start'] ?? null;
+        $end = $query->filters->values['period_end'] ?? null;
+        if (! is_string($start) || ! is_string($end)) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_REQUEST_INVALID, ['fields' => 'filters']);
         }
-        $operator = $condition['operator'] ?? null;
-        $values = match ($operator) {
-            'eq' => [$condition['value'] ?? null],
-            'in' => (array) ($condition['value'] ?? []),
-            'neq' => [$condition['value'] ?? null],
-            'not_in' => (array) ($condition['value'] ?? []),
-            default => throw ReportContractException::fromCode(
-                ReportErrorCode::REPORT_FILTER_UNSUPPORTED,
-            ),
-        };
-        if ($values === []) {
-            $builder->whereRaw('1 = 0');
+        try {
+            $periodStart = new DateTimeImmutable($start.' 00:00:00');
+            $periodEnd = new DateTimeImmutable($end.' 23:59:59.999999');
+        } catch (Exception) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_REQUEST_INVALID, ['fields' => 'filters']);
+        }
+        if ($periodStart > $periodEnd || $periodStart->format('Y-m-d') !== $start || $periodEnd->format('Y-m-d') !== $end) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_REQUEST_INVALID, ['fields' => 'filters']);
+        }
 
-            return;
-        }
-        $method = in_array($operator, ['neq', 'not_in'], true) ? 'whereNotExists' : 'whereExists';
-        $builder->{$method}(function ($line) use ($dimension, $values): void {
-            $line->selectRaw('1')
-                ->fromRaw(
-                    "jsonb_array_elements(supplier_award_decision_versions.dimension_snapshot->'lines') "
-                    .'as pinned_line',
-                )
-                ->whereIn(DB::raw("pinned_line->>'{$dimension}'"), array_map('strval', $values));
-        });
+        return [$periodStart, $periodEnd];
     }
 }

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/Readiness/SupplierAwardReadinessProbe.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/Readiness/SupplierAwardReadinessProbe.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\Procurement\Reporting\Award\Readiness;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionReadinessProbe;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Features\Procurement\Reporting\Award\Queries\SupplierAwardFilteredUniverse;
 use App\BusinessModules\Features\Procurement\Models\SupplierProposalDecision;
-use App\Support\Reporting\OwnerReportFilterApplier;
 use App\Support\Reporting\ReportSourceAccessPolicy;
 use App\Support\Reporting\SourceReadinessResult;
 use DateTimeImmutable;
@@ -20,7 +21,6 @@ final readonly class SupplierAwardReadinessProbe implements ReportDefinitionRead
     public function __construct(
         private SupplierAwardFilteredUniverse $universe,
         private ReportSourceAccessPolicy $sourceAccess,
-        private OwnerReportFilterApplier $filters,
     ) {}
 
     public function supports(ReportDefinition $definition): bool
@@ -58,26 +58,12 @@ final readonly class SupplierAwardReadinessProbe implements ReportDefinitionRead
                     $context->scope->projectIds,
                 ),
             );
-        $this->filters->apply($owners, $this->filters->only($query->filters, [
-            'project', 'buyer', 'decision', 'non_lowest', 'period',
-        ]), [
-            'project' => 'award_owner_site_request.project_id',
-            'buyer' => 'supplier_proposal_decisions.selected_by',
-            'decision' => 'supplier_proposal_decisions.id',
-            'non_lowest' => [
-                'column' => 'supplier_proposal_decisions.is_lowest_price_selected',
-                'invert_boolean' => true,
-            ],
-            'period' => 'supplier_proposal_decisions.selected_at',
-        ]);
+        [$start, $end] = $this->period($query);
+        $owners->whereBetween('supplier_proposal_decisions.selected_at', [$start, $end]);
         $ownerEligible = $owners->distinct()->count('supplier_proposal_decisions.id');
         $versions = $this->universe->query($context, $query);
         $projected = (clone $versions)->distinct()->count('decision_id');
-        $pinnedDimensionFilters = array_intersect(
-            array_keys($query->filters->values),
-            ['supplier', 'method', 'currency', 'material', 'category'],
-        );
-        $eligible = $pinnedDimensionFilters === [] ? $ownerEligible : $projected;
+        $eligible = $ownerEligible;
         $invalidVersions = (clone $versions)
             ->where(function ($builder): void {
                 $builder->whereNull('selected_proposal_version_id')
@@ -95,5 +81,24 @@ final readonly class SupplierAwardReadinessProbe implements ReportDefinitionRead
             (clone $versions)->whereRaw('LENGTH(source_hash) <> 64')->count(),
             new DateTimeImmutable,
         );
+    }
+
+    private function period(ReportQuery $query): array
+    {
+        $start = $query->filters->values['period_start'] ?? null;
+        $end = $query->filters->values['period_end'] ?? null;
+        $periodStart = is_string($start) ? DateTimeImmutable::createFromFormat('!Y-m-d', $start) : false;
+        $periodEnd = is_string($end) ? DateTimeImmutable::createFromFormat('!Y-m-d', $end) : false;
+        if ($periodStart === false || $periodEnd === false
+            || $periodStart->format('Y-m-d') !== $start
+            || $periodEnd->format('Y-m-d') !== $end
+            || $periodStart > $periodEnd) {
+            throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => 'filters'],
+            );
+        }
+
+        return [$periodStart, $periodEnd->setTime(23, 59, 59, 999999)];
     }
 }

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/Services/SupplierAwardReportBindingFactory.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/Services/SupplierAwardReportBindingFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Procurement\Reporting\Award\Services;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Providers\SupplierAwardCompetitivenessReportProvider;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Queries\SupplierAwardRowQuery;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Readiness\SupplierAwardReadinessProbe;
+use InvalidArgumentException;
+
+final readonly class SupplierAwardReportBindingFactory
+{
+    public function __construct(
+        private SupplierAwardCompetitivenessReportProvider $provider,
+        private SupplierAwardRowQuery $rows,
+        private SupplierAwardReadinessProbe $readiness,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        if (! $this->readiness->supports($definition)) {
+            throw new InvalidArgumentException('supplier_award_report_definition_not_supported');
+        }
+
+        return new ReportDefinitionBinding($definition->code, $definition->definitionHash, $definition->contractVersion, $this->provider, $this->rows, $this->rows, $this->readiness);
+    }
+}

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardBuiltinPublishedReport.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Procurement\Reporting\Award;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class SupplierAwardBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+    public const RENDERER_VERSION = '1.0.0';
+    public const MANIFEST_ORDINAL = 16;
+
+    public function __construct(private SupplierAwardCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(SupplierAwardCandidateContract::CODE, 'reports.catalog.supplier_award_competitiveness', ReportCatalogGroup::PROCUREMENT_WAREHOUSE, 'procurement', 'decision_proposal_currency', 2, self::MANIFEST_ORDINAL);
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(SupplierAwardCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => SupplierAwardCandidateContract::CODE,
+            'title_key' => 'reports.catalog.supplier_award_competitiveness',
+            'catalog_group' => 'procurement_warehouse', 'category' => 'procurement', 'grain' => 'decision_proposal_currency', 'wave' => 2,
+            'source_module' => 'procurement', 'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(), 'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(), 'formats' => $this->contract->formats(),
+            'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => 'supplier-award.v1', 'source_schema' => 'supplier-award.v1', 'renderer' => self::RENDERER_VERSION],
+            'semantic_fingerprints' => ['formula' => SupplierAwardCandidateContract::FORMULA_HASH, 'source' => SupplierAwardCandidateContract::SOURCE_HASH],
+            'permissions' => ['view' => ['procurement.supplier_proposals.view'], 'export' => ['procurement.reports.export'], 'sensitive' => ['procurement.proposal_decisions.view'], 'audit' => []],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardCandidateContract.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardCandidateContract.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Procurement\Reporting\Award;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Services\SupplierAwardFormula;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Services\SupplierAwardSnapshotMaterializer;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Queries\SupplierAwardFilteredUniverse;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class SupplierAwardCandidateContract
+{
+    public const CODE = 'supplier_award_competitiveness';
+    public const FORMULA_HASH = '793d196081a3c0773f558a74aee4f845529f20e9a98b574d7a7f1a3adee210a8';
+    public const SOURCE_HASH = '156276ffbc15fb2e35986d8494ec1cc7c53b74aea8aaad9c9387c8a493fcd571';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'period_start', 'required' => true],
+            ['id' => 'period_end', 'required' => true],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'selected_at', 'decision_id', 'decision_version', 'proposal_version_id',
+            'supplier_party_id', 'material_ids', 'currency', 'selected_amount_minor',
+            'cheapest_amount_minor', 'premium_minor', 'premium_ratio', 'participation_ratio',
+            'quality_warnings',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return [['id' => 'selected_at', 'direction' => 'desc']];
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx', 'pdf'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(SupplierAwardFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classesHash([
+                SupplierAwardSnapshotMaterializer::class,
+                SupplierAwardFilteredUniverse::class,
+            ]))) {
+            throw new InvalidArgumentException('supplier_award_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'procurement'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== 'supplier-award.v1'
+            || $definition->sourceSchemaVersion !== 'supplier-award.v1'
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['procurement.supplier_proposals.view']
+            || $definition->permissionPolicy->exportPermissions !== ['procurement.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== ['procurement.proposal_decisions.view']
+            || $definition->permissionPolicy->auditPermissions !== []) {
+            throw new InvalidArgumentException('supplier_award_candidate_definition_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('supplier_award_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function classesHash(array $classes): string
+    {
+        $hash = hash_init('sha256');
+        foreach ($classes as $class) {
+            $file = (new ReflectionClass($class))->getFileName();
+            if (! is_string($file) || ! hash_update_file($hash, $file)) {
+                throw new InvalidArgumentException('supplier_award_candidate_source_unreadable');
+            }
+        }
+
+        return hash_final($hash);
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR), $items);
+    }
+}

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Procurement\Reporting\Award;
+
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Services\SupplierAwardReportBindingFactory;
+use LogicException;
+
+final readonly class SupplierAwardPublishedRuntimeBindingRegistrar
+{
+    public function __construct(private ReportDefinitionRegistry $definitions, private SupplierAwardReportBindingFactory $bindings) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        $definition = $this->definitions->published(SupplierAwardCandidateContract::CODE);
+        if ($definition->code !== SupplierAwardCandidateContract::CODE) {
+            throw new LogicException('supplier_award_published_definition_invalid');
+        }
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -25,6 +25,8 @@ use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublish
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
@@ -65,18 +67,21 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('payroll_readiness', $registry->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $registry->published('workforce_capacity')->code);
         self::assertSame('procurement_cycle', $registry->published('procurement_cycle')->code);
+        self::assertSame('supplier_award_competitiveness', $registry->published('supplier_award_competitiveness')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $app->make(ReportCatalogMetadataRegistry::class)->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $app->make(ReportCatalogMetadataRegistry::class)->published('workforce_capacity')->code);
         self::assertSame('procurement_cycle', $app->make(ReportCatalogMetadataRegistry::class)->published('procurement_cycle')->code);
+        self::assertSame('supplier_award_competitiveness', $app->make(ReportCatalogMetadataRegistry::class)->published('supplier_award_competitiveness')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $app->make(ReportSchedulingCapabilityRegistry::class)->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $app->make(ReportSchedulingCapabilityRegistry::class)->published('workforce_capacity')->code);
         self::assertSame('procurement_cycle', $app->make(ReportSchedulingCapabilityRegistry::class)->published('procurement_cycle')->code);
+        self::assertSame('supplier_award_competitiveness', $app->make(ReportSchedulingCapabilityRegistry::class)->published('supplier_award_competitiveness')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -88,11 +93,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->payrollReadiness(),
             $this->workforceCapacity(),
             $this->procurementCycle(),
-            $this->procurementCycle(),
+            $this->supplierAward(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -115,6 +120,8 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->projectLaborCost(),
             $this->payrollReadiness(),
             $this->workforceCapacity(),
+            $this->procurementCycle(),
+            $this->supplierAward(),
         );
 
         $expectedModules = [
@@ -124,6 +131,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'payroll_readiness' => 'workforce-management',
             'workforce_capacity' => 'workforce-management',
             'procurement_cycle' => 'procurement',
+            'supplier_award_competitiveness' => 'procurement',
         ];
 
         foreach ($expectedModules as $code => $module) {
@@ -138,11 +146,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -150,7 +158,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -212,5 +220,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function procurementCycle(): ProcurementCycleBuiltinPublishedReport
     {
         return new ProcurementCycleBuiltinPublishedReport(new ProcurementCycleCandidateContract);
+    }
+
+    private function supplierAward(): SupplierAwardBuiltinPublishedReport
+    {
+        return new SupplierAwardBuiltinPublishedReport(new SupplierAwardCandidateContract);
     }
 }

--- a/tests/Unit/Reporting/Waves23/SupplyReportingHardeningTest.php
+++ b/tests/Unit/Reporting/Waves23/SupplyReportingHardeningTest.php
@@ -442,7 +442,7 @@ final class SupplyReportingHardeningTest extends TestCase
         );
     }
 
-    public function test_award_filters_use_immutable_pinned_dimensions_and_party_namespace(): void
+    public function test_award_filters_use_server_scope_and_immutable_selection_period(): void
     {
         $source = $this->source(
             'app/BusinessModules/Features/Procurement/Reporting/Award/Queries/'
@@ -450,10 +450,10 @@ final class SupplyReportingHardeningTest extends TestCase
         );
 
         self::assertStringContainsString('supplier_award_decision_versions.project_id', $source);
-        self::assertStringContainsString('selected_supplier_party_id', $source);
-        self::assertStringContainsString("dimension_snapshot->>'procurement_method'", $source);
-        self::assertStringContainsString("dimension_snapshot->>'currency'", $source);
-        self::assertStringContainsString('jsonb_array_elements', $source);
+        self::assertStringContainsString("['period_start']", $source);
+        self::assertStringContainsString("['period_end']", $source);
+        self::assertStringContainsString("whereBetween('supplier_award_decision_versions.selected_at'", $source);
+        self::assertStringNotContainsString('OwnerReportFilterApplier', $source);
         self::assertStringNotContainsString('supplier_proposals as', $source);
         self::assertStringNotContainsString('supplier_proposal_lines as', $source);
         self::assertStringNotContainsString('materials as', $source);


### PR DESCRIPTION
## Что сделано
- опубликован R16 в едином каталоге управленческих отчётов
- подключён реальный runtime расчёта, строк и drill-down
- организация и проекты ограничены серверным scope
- фильтры сведены к строгому периоду без клиентской подмены контекста
- обновлены целевые контрактные тесты

## Проверки
- php -l для всех изменённых PHP-файлов
- git diff --check
- локальный PHPUnit/Larastan недоступны: vendor отсутствует; полный набор выполняет основной workflow

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated the new Supplier Award report into the core reporting infrastructure.</li>
<li>Registered SupplierAwardBuiltinPublishedReport and SupplierAwardCandidateContract in the ReportingCatalogServiceProvider.</li>
<li>Updated BuiltinPublishedReportDefinitionRegistry, BuiltinReportCatalogMetadataRegistry, and BuiltinReportSchedulingCapabilityRegistry to include the new Supplier Award report.</li>
<li>Implemented the Supplier Award report logic, including query filtering, readiness probes, and binding factories.</li>
<li>Added unit tests to verify the new Supplier Award report registration and functionality.</li>
</ul></div>