### PR TITLE
feat: опубликовать отчёт риска запасов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -12,6 +12,7 @@ use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityBuiltinPublishedReport;
@@ -33,9 +34,10 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         ProcurementCycleBuiltinPublishedReport $procurementCycle,
         SupplierAwardBuiltinPublishedReport $supplierAward,
         SupplyReliabilityBuiltinPublishedReport $supplyReliability,
+        InventoryRiskBuiltinPublishedReport $inventoryRisk,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -10,6 +10,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportCatalogMetadataReg
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityBuiltinPublishedReport;
@@ -28,6 +29,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private ProcurementCycleBuiltinPublishedReport $procurementCycle,
         private SupplierAwardBuiltinPublishedReport $supplierAward,
         private SupplyReliabilityBuiltinPublishedReport $supplyReliability,
+        private InventoryRiskBuiltinPublishedReport $inventoryRisk,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -41,6 +43,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->procurementCycle->metadata()->code => $this->procurementCycle->metadata(),
             $this->supplierAward->metadata()->code => $this->supplierAward->metadata(),
             $this->supplyReliability->metadata()->code => $this->supplyReliability->metadata(),
+            $this->inventoryRisk->metadata()->code => $this->inventoryRisk->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -10,6 +10,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSchedulingCapabili
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityBuiltinPublishedReport;
@@ -28,6 +29,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private ProcurementCycleBuiltinPublishedReport $procurementCycle,
         private SupplierAwardBuiltinPublishedReport $supplierAward,
         private SupplyReliabilityBuiltinPublishedReport $supplyReliability,
+        private InventoryRiskBuiltinPublishedReport $inventoryRisk,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -41,6 +43,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->procurementCycle->scheduling()->code => $this->procurementCycle->scheduling(),
             $this->supplierAward->scheduling()->code => $this->supplierAward->scheduling(),
             $this->supplyReliability->scheduling()->code => $this->supplyReliability->scheduling(),
+            $this->inventoryRisk->scheduling()->code => $this->inventoryRisk->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -59,6 +59,8 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Publication\EloquentReport
 use App\BusinessModules\Core\Reporting\Infrastructure\Queue\LaravelReportSubscriptionDeliveryDispatcher;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
@@ -121,6 +123,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(SupplyReliabilityBuiltinPublishedReport::class, fn (Application $app): SupplyReliabilityBuiltinPublishedReport => new SupplyReliabilityBuiltinPublishedReport(
             $app->make(SupplyReliabilityCandidateContract::class),
         ));
+        $this->app->singleton(InventoryRiskCandidateContract::class);
+        $this->app->singleton(InventoryRiskBuiltinPublishedReport::class, fn (Application $app): InventoryRiskBuiltinPublishedReport => new InventoryRiskBuiltinPublishedReport(
+            $app->make(InventoryRiskCandidateContract::class),
+        ));
         $this->app->singleton(
             BuiltinPublishedReportDefinitionRegistry::class,
             fn (Application $app): BuiltinPublishedReportDefinitionRegistry => new BuiltinPublishedReportDefinitionRegistry(
@@ -132,6 +138,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(ProcurementCycleBuiltinPublishedReport::class),
                 $app->make(SupplierAwardBuiltinPublishedReport::class),
                 $app->make(SupplyReliabilityBuiltinPublishedReport::class),
+                $app->make(InventoryRiskBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -141,9 +148,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/BasicWarehouse/BasicWarehouseServiceProvider.php
+++ b/app/BusinessModules/Features/BasicWarehouse/BasicWarehouseServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\BusinessModules\Features\BasicWarehouse;
 
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Route;
 
@@ -16,6 +17,10 @@ class BasicWarehouseServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->app->afterResolving(ReportDefinitionBindingAssembler::class, function (ReportDefinitionBindingAssembler $assembler): void {
+            $this->app->make(Reporting\InventoryRisk\InventoryRiskPublishedRuntimeBindingRegistrar::class)->register($assembler);
+        });
+
         $this->loadMigrations();
         
         $this->loadRoutes();

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskBuiltinPublishedReport.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class InventoryRiskBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+    public const RENDERER_VERSION = '1.0.0';
+    public const MANIFEST_ORDINAL = 18;
+
+    public function __construct(private InventoryRiskCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            InventoryRiskCandidateContract::CODE,
+            'reports.catalog.inventory_risk',
+            ReportCatalogGroup::PROCUREMENT_WAREHOUSE,
+            'warehouse',
+            'material_warehouse_day',
+            3,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(InventoryRiskCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => InventoryRiskCandidateContract::CODE,
+            'title_key' => 'reports.catalog.inventory_risk',
+            'catalog_group' => 'procurement_warehouse',
+            'category' => 'warehouse',
+            'grain' => 'material_warehouse_day',
+            'wave' => 3,
+            'source_module' => 'basic-warehouse',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => [
+                'contract' => self::CONTRACT_VERSION,
+                'formula' => 'inventory-planning.v1',
+                'source_schema' => 'inventory-planning.v1',
+                'renderer' => self::RENDERER_VERSION,
+            ],
+            'semantic_fingerprints' => [
+                'formula' => InventoryRiskCandidateContract::FORMULA_HASH,
+                'source' => InventoryRiskCandidateContract::SOURCE_HASH,
+            ],
+            'permissions' => [
+                'view' => ['warehouse.advanced.view'],
+                'export' => ['warehouse.reports.export'],
+                'sensitive' => ['warehouse.view_custody'],
+                'audit' => [],
+            ],
+            'readiness' => [
+                'source' => 'ready',
+                'formula' => 'ready',
+                'delivery' => 'verified',
+                'publication' => 'published',
+            ],
+            'capabilities' => [
+                'supports_subscriptions' => false,
+                'reproducible_scheduled_snapshot' => false,
+            ],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskCandidateContract.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskCandidateContract.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services\InventoryRiskFormula;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services\InventoryRiskGrainUniverse;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services\InventoryRiskPeriod;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services\InventoryRiskSnapshotMaterializer;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services\WarehouseDailyBalanceMaterializer;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class InventoryRiskCandidateContract
+{
+    public const CODE = 'inventory_risk';
+    public const FORMULA_HASH = '38ab50fe5b126ce090eb54f73fd230136c4bae9623c04eb60710680786a4fcd3';
+    public const SOURCE_HASH = '25d49f3ab4f49cbe27c0b7b23e77256c022b92bc89490f01e7392ace5db62ddd';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'period_start', 'required' => true],
+            ['id' => 'period_end', 'required' => true],
+            ['id' => 'statuses', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'balance_date', 'warehouse_id', 'project_id', 'material_id', 'risk_status',
+            'closing_on_hand', 'reserved_quantity', 'available_quantity', 'consumption_quantity',
+            'turnover', 'cost_turnover', 'days_on_hand', 'stockout_at', 'consumption_value_minor',
+            'on_hand_value_minor', 'currency', 'recommended_order_quantity', 'quality_warnings',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return [['id' => 'balance_date', 'direction' => 'desc']];
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx', 'pdf'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(InventoryRiskFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classesHash([
+                InventoryRiskSnapshotMaterializer::class,
+                WarehouseDailyBalanceMaterializer::class,
+                InventoryRiskGrainUniverse::class,
+                InventoryRiskPeriod::class,
+            ]))) {
+            throw new InvalidArgumentException('inventory_risk_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE || $definition->sourceModule !== 'basic-warehouse'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== 'inventory-planning.v1'
+            || $definition->sourceSchemaVersion !== 'inventory-planning.v1'
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['warehouse.advanced.view']
+            || $definition->permissionPolicy->exportPermissions !== ['warehouse.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== ['warehouse.view_custody']
+            || $definition->permissionPolicy->auditPermissions !== []) {
+            throw new InvalidArgumentException('inventory_risk_candidate_definition_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('inventory_risk_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function classesHash(array $classes): string
+    {
+        $hash = hash_init('sha256');
+        foreach ($classes as $class) {
+            $file = (new ReflectionClass($class))->getFileName();
+            if (! is_string($file) || ! hash_update_file($hash, $file)) {
+                throw new InvalidArgumentException('inventory_risk_candidate_source_unreadable');
+            }
+        }
+
+        return hash_final($hash);
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(
+                CanonicalJson::encode($item),
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            ),
+            $items,
+        );
+    }
+}

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk;
+
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services\InventoryRiskReportBindingFactory;
+use LogicException;
+
+final readonly class InventoryRiskPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private InventoryRiskReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        $definition = $this->definitions->published(InventoryRiskCandidateContract::CODE);
+        if ($definition->code !== InventoryRiskCandidateContract::CODE) {
+            throw new LogicException('inventory_risk_published_definition_invalid');
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskPeriod.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskPeriod.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use DateTimeImmutable;
+
+final readonly class InventoryRiskPeriod
+{
+    public function resolve(ReportQuery $query): array
+    {
+        $start = $query->filters->values['period_start'] ?? null;
+        $end = $query->filters->values['period_end'] ?? null;
+        $periodStart = is_string($start) ? DateTimeImmutable::createFromFormat('!Y-m-d', $start) : false;
+        $periodEnd = is_string($end) ? DateTimeImmutable::createFromFormat('!Y-m-d', $end) : false;
+        if ($periodStart === false || $periodEnd === false
+            || $periodStart->format('Y-m-d') !== $start
+            || $periodEnd->format('Y-m-d') !== $end
+            || $periodStart > $periodEnd) {
+            throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => 'filters'],
+            );
+        }
+
+        return [$periodStart->format('Y-m-d'), $periodEnd->format('Y-m-d')];
+    }
+}

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskReportBindingFactory.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskReportBindingFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\DrillDown\InventoryRiskDrillDownProvider;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Providers\InventoryRiskReportProvider;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Queries\InventoryRiskRowQuery;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Readiness\InventoryRiskReadinessProbe;
+use InvalidArgumentException;
+
+final readonly class InventoryRiskReportBindingFactory
+{
+    public function __construct(
+        private InventoryRiskReportProvider $provider,
+        private InventoryRiskRowQuery $rows,
+        private InventoryRiskDrillDownProvider $drillDown,
+        private InventoryRiskReadinessProbe $readiness,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        if (! $this->readiness->supports($definition)) {
+            throw new InvalidArgumentException('inventory_risk_report_definition_not_supported');
+        }
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->rows,
+            $this->drillDown,
+            $this->readiness,
+        );
+    }
+}

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskSnapshotMaterializer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Services;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
@@ -87,6 +89,7 @@ final readonly class InventoryRiskSnapshotMaterializer
         ReportProgress $progress,
     ): ReportSnapshotRef {
         $this->assertScope($context, $query);
+        $this->statuses($query);
         $allowedWarehouseIds = $this->sourceAccess->allowedIds(
             $context->scope->resources,
             'warehouse',
@@ -105,7 +108,7 @@ final readonly class InventoryRiskSnapshotMaterializer
             );
         $this->filters->apply($balanceQuery, $this->filters->only($query->filters, [
             'organization', 'organization_id', 'warehouse', 'warehouse_id', 'project', 'project_id',
-            'material', 'material_id', 'category', 'abc', 'xyz', 'period',
+            'material', 'material_id', 'category', 'abc', 'xyz',
         ]), [
             'organization' => 'warehouse_daily_balance_rows.organization_id',
             'organization_id' => 'warehouse_daily_balance_rows.organization_id',
@@ -118,7 +121,6 @@ final readonly class InventoryRiskSnapshotMaterializer
             'category' => 'inventory_filter_material.category',
             'abc' => DB::raw("inventory_filter_material.additional_properties->>'abc_class'"),
             'xyz' => DB::raw("inventory_filter_material.additional_properties->>'xyz_class'"),
-            'period' => 'warehouse_daily_balance_rows.balance_date',
         ]);
         $balanceRows = $balanceQuery
             ->select('warehouse_daily_balance_rows.*')
@@ -497,18 +499,31 @@ final readonly class InventoryRiskSnapshotMaterializer
 
     private function matchesStatusFilter(string $status, ReportQuery $query): bool
     {
-        $condition = $query->filters->values['status'] ?? null;
-        if (! is_array($condition)) {
+        $statuses = $this->statuses($query);
+        if ($statuses === null) {
             return true;
         }
 
-        return match ($condition['operator'] ?? null) {
-            'eq' => $status === (string) ($condition['value'] ?? ''),
-            'neq' => $status !== (string) ($condition['value'] ?? ''),
-            'in' => in_array($status, (array) ($condition['value'] ?? []), true),
-            'not_in' => ! in_array($status, (array) ($condition['value'] ?? []), true),
-            default => false,
-        };
+        return in_array($status, $statuses, true);
+    }
+
+    private function statuses(ReportQuery $query): ?array
+    {
+        $statuses = $query->filters->values['statuses'] ?? null;
+        if ($statuses === null) {
+            return null;
+        }
+        if (! is_array($statuses)
+            || ! array_is_list($statuses)
+            || $statuses === []
+            || array_diff($statuses, ['healthy', 'reorder', 'excess']) !== []) {
+            throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => 'filters'],
+            );
+        }
+
+        return $statuses;
     }
 
     private function snapshotRef(ReportQuery $query, InventoryRiskSnapshot $snapshot): ReportSnapshotRef

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/WarehouseDailyBalanceMaterializer.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/WarehouseDailyBalanceMaterializer.php
@@ -33,6 +33,7 @@ final readonly class WarehouseDailyBalanceMaterializer
         private ReportSourceAccessPolicy $sourceAccess,
         private InventoryRiskGrainUniverse $grainUniverse,
         private OwnerReportFilterApplier $filters,
+        private InventoryRiskPeriod $period,
     ) {}
 
     public function materialize(
@@ -292,23 +293,7 @@ final readonly class WarehouseDailyBalanceMaterializer
 
     private function period(ReportQuery $query): array
     {
-        $period = $query->filters->values['period'] ?? null;
-        if (is_array($period)
-            && ($period['operator'] ?? null) === 'between'
-            && is_array($period['value'] ?? null)
-            && count($period['value']) === 2
-            && is_string($period['value'][0])
-            && is_string($period['value'][1])) {
-            $fromDate = $period['value'][0];
-            $toDate = $period['value'][1];
-            $this->assertDatePeriod($fromDate, $toDate);
-
-            return [$fromDate, $toDate];
-        }
-
-        $date = $query->asOf->setTimezone($query->scope->timezone)->format('Y-m-d');
-
-        return [$date, $date];
+        return $this->period->resolve($query);
     }
 
     private function balanceDates(Collection $eventsByDate, string $fromDate, string $toDate): array
@@ -329,19 +314,6 @@ final readonly class WarehouseDailyBalanceMaterializer
         ksort($dates, SORT_STRING);
 
         return array_keys($dates);
-    }
-
-    private function assertDatePeriod(string $fromDate, string $toDate): void
-    {
-        $from = DateTimeImmutable::createFromFormat('!Y-m-d', $fromDate);
-        $to = DateTimeImmutable::createFromFormat('!Y-m-d', $toDate);
-        if ($from === false
-            || $to === false
-            || $from->format('Y-m-d') !== $fromDate
-            || $to->format('Y-m-d') !== $toDate
-            || $from > $to) {
-            throw new DomainException('Inventory report period is invalid.');
-        }
     }
 
     private function grain(WarehouseInventoryEvent $event): string

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -23,6 +23,8 @@ use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublis
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
@@ -71,6 +73,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('procurement_cycle', $registry->published('procurement_cycle')->code);
         self::assertSame('supplier_award_competitiveness', $registry->published('supplier_award_competitiveness')->code);
         self::assertSame('supply_reliability', $registry->published('supply_reliability')->code);
+        self::assertSame('inventory_risk', $registry->published('inventory_risk')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
@@ -79,6 +82,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('procurement_cycle', $app->make(ReportCatalogMetadataRegistry::class)->published('procurement_cycle')->code);
         self::assertSame('supplier_award_competitiveness', $app->make(ReportCatalogMetadataRegistry::class)->published('supplier_award_competitiveness')->code);
         self::assertSame('supply_reliability', $app->make(ReportCatalogMetadataRegistry::class)->published('supply_reliability')->code);
+        self::assertSame('inventory_risk', $app->make(ReportCatalogMetadataRegistry::class)->published('inventory_risk')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
@@ -87,6 +91,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('procurement_cycle', $app->make(ReportSchedulingCapabilityRegistry::class)->published('procurement_cycle')->code);
         self::assertSame('supplier_award_competitiveness', $app->make(ReportSchedulingCapabilityRegistry::class)->published('supplier_award_competitiveness')->code);
         self::assertSame('supply_reliability', $app->make(ReportSchedulingCapabilityRegistry::class)->published('supply_reliability')->code);
+        self::assertSame('inventory_risk', $app->make(ReportSchedulingCapabilityRegistry::class)->published('inventory_risk')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -100,10 +105,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->procurementCycle(),
             $this->supplierAward(),
             $this->supplyReliability(),
+            $this->inventoryRisk(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -129,6 +135,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->procurementCycle(),
             $this->supplierAward(),
             $this->supplyReliability(),
+            $this->inventoryRisk(),
         );
 
         $expectedModules = [
@@ -140,6 +147,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'procurement_cycle' => 'procurement',
             'supplier_award_competitiveness' => 'procurement',
             'supply_reliability' => 'procurement',
+            'inventory_risk' => 'basic-warehouse',
         ];
 
         foreach ($expectedModules as $code => $module) {
@@ -154,11 +162,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['budget_plan_fact', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -166,7 +174,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -238,5 +246,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function supplyReliability(): SupplyReliabilityBuiltinPublishedReport
     {
         return new SupplyReliabilityBuiltinPublishedReport(new SupplyReliabilityCandidateContract);
+    }
+
+    private function inventoryRisk(): InventoryRiskBuiltinPublishedReport
+    {
+        return new InventoryRiskBuiltinPublishedReport(new InventoryRiskCandidateContract);
     }
 }


### PR DESCRIPTION
Публикует canonical report inventory_risk на реальных складских событиях, дневных балансах, спросе и версиях политики пополнения. Организация и проект берутся только из server-owned context; публичные фильтры ограничены строгим периодом и статусами риска. Подключены snapshot, totals/rows, sensitive drill-down, export, readiness и builtin catalog. Проверки: php -l всех 13 изменённых PHP-файлов, fingerprint formula/source, git diff --check. PHPUnit/Larastan локально недоступны: vendor отсутствует.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated a new 'Inventory Risk' report into the core reporting system.</li>
<li>Registered the Inventory Risk report in the built-in report definition, metadata, and scheduling capability registries.</li>
<li>Configured the Inventory Risk report and its candidate contract in the ReportingCatalogServiceProvider.</li>
<li>Implemented the Inventory Risk report logic, including binding factories, snapshot materializers, and daily balance materializers.</li>
<li>Added unit tests for the updated report registry.</li>
</ul></div>