### PR TITLE
fix: добавить серверные итоги риска запасов

### DIFF
--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskCandidateContract.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskCandidateContract.php
@@ -19,7 +19,7 @@ final readonly class InventoryRiskCandidateContract
 {
     public const CODE = 'inventory_risk';
     public const FORMULA_HASH = '38ab50fe5b126ce090eb54f73fd230136c4bae9623c04eb60710680786a4fcd3';
-    public const SOURCE_HASH = '25d49f3ab4f49cbe27c0b7b23e77256c022b92bc89490f01e7392ace5db62ddd';
+    public const SOURCE_HASH = '103febb9a32f643e26ce3e2e87c8512467f140cc754e46b8c6f97fedb6590233';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskSnapshotMaterializer.php
@@ -210,6 +210,7 @@ final readonly class InventoryRiskSnapshotMaterializer
             $rows = [];
             $gapCount = 0;
             $valueByCurrency = [];
+            $riskStatusCounts = ['healthy' => 0, 'reorder' => 0, 'excess' => 0];
             foreach ($balanceRows as $balance) {
                 $warnings = is_array($balance->quality_warnings) ? $balance->quality_warnings : [];
                 $demand = $this->demandFor($balance, $demands);
@@ -246,6 +247,7 @@ final readonly class InventoryRiskSnapshotMaterializer
                 if ($warnings !== []) {
                     $gapCount++;
                 }
+                $riskStatusCounts[$riskStatus]++;
                 if ($metric->onHandValueMinor !== null && $metric->currency !== null) {
                     $valueByCurrency[$metric->currency] = ($valueByCurrency[$metric->currency] ?? 0)
                         + $metric->onHandValueMinor;
@@ -316,6 +318,7 @@ final readonly class InventoryRiskSnapshotMaterializer
                 'reconciliation_status' => $gapCount === 0 ? 'matched' : 'mismatch',
                 'totals' => [
                     'row_count' => count($rows),
+                    'risk_status_counts' => $riskStatusCounts,
                     'value_by_currency' => $valueByCurrency,
                 ],
             ]);


### PR DESCRIPTION
Добавляет authoritative counts healthy/reorder/excess в immutable snapshot totals, чтобы admin не пересчитывал управленческие итоги из текущей страницы. Source fingerprint обновлён. Проверки: php -l, fingerprint, git diff --check.