### PR TITLE
feat: опубликован отчёт исполнения рабочего времени

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -19,6 +19,7 @@ use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityB
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
 {
@@ -35,9 +36,10 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         SupplierAwardBuiltinPublishedReport $supplierAward,
         SupplyReliabilityBuiltinPublishedReport $supplyReliability,
         InventoryRiskBuiltinPublishedReport $inventoryRisk,
+        AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -17,6 +17,7 @@ use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityB
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
 {
@@ -30,6 +31,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private SupplierAwardBuiltinPublishedReport $supplierAward,
         private SupplyReliabilityBuiltinPublishedReport $supplyReliability,
         private InventoryRiskBuiltinPublishedReport $inventoryRisk,
+        private AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -44,6 +46,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->supplierAward->metadata()->code => $this->supplierAward->metadata(),
             $this->supplyReliability->metadata()->code => $this->supplyReliability->metadata(),
             $this->inventoryRisk->metadata()->code => $this->inventoryRisk->metadata(),
+            $this->attendanceExecution->metadata()->code => $this->attendanceExecution->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -17,6 +17,7 @@ use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityB
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
 {
@@ -30,6 +31,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private SupplierAwardBuiltinPublishedReport $supplierAward,
         private SupplyReliabilityBuiltinPublishedReport $supplyReliability,
         private InventoryRiskBuiltinPublishedReport $inventoryRisk,
+        private AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -44,6 +46,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->supplierAward->scheduling()->code => $this->supplierAward->scheduling(),
             $this->supplyReliability->scheduling()->code => $this->supplyReliability->scheduling(),
             $this->inventoryRisk->scheduling()->code => $this->inventoryRisk->scheduling(),
+            $this->attendanceExecution->scheduling()->code => $this->attendanceExecution->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -73,6 +73,8 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessB
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -111,6 +113,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(WorkforceCapacityBuiltinPublishedReport::class, fn (Application $app): WorkforceCapacityBuiltinPublishedReport => new WorkforceCapacityBuiltinPublishedReport(
             $app->make(WorkforceCapacityCandidateContract::class),
         ));
+        $this->app->singleton(AttendanceExecutionCandidateContract::class);
+        $this->app->singleton(AttendanceExecutionBuiltinPublishedReport::class, fn (Application $app): AttendanceExecutionBuiltinPublishedReport => new AttendanceExecutionBuiltinPublishedReport(
+            $app->make(AttendanceExecutionCandidateContract::class),
+        ));
         $this->app->singleton(ProcurementCycleCandidateContract::class);
         $this->app->singleton(ProcurementCycleBuiltinPublishedReport::class, fn (Application $app): ProcurementCycleBuiltinPublishedReport => new ProcurementCycleBuiltinPublishedReport(
             $app->make(ProcurementCycleCandidateContract::class),
@@ -139,6 +145,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(SupplierAwardBuiltinPublishedReport::class),
                 $app->make(SupplyReliabilityBuiltinPublishedReport::class),
                 $app->make(InventoryRiskBuiltinPublishedReport::class),
+                $app->make(AttendanceExecutionBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -148,9 +155,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionBuiltinPublishedReport.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Infrastructure\DatabaseWorkforceReportAdapter;
+
+final readonly class AttendanceExecutionBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+
+    public const RENDERER_VERSION = '1.0.0';
+
+    public const MANIFEST_ORDINAL = 20;
+
+    public function __construct(private AttendanceExecutionCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            self::code(),
+            'reports.catalog.attendance_execution',
+            ReportCatalogGroup::TEAM,
+            'workforce',
+            'employee_shift_day',
+            1,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(self::code(), false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => self::code(),
+            'title_key' => 'reports.catalog.attendance_execution',
+            'catalog_group' => 'team',
+            'category' => 'workforce',
+            'grain' => 'employee_shift_day',
+            'wave' => 1,
+            'source_module' => 'workforce-management',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => [
+                'contract' => self::CONTRACT_VERSION,
+                'formula' => DatabaseWorkforceReportAdapter::ATTENDANCE_FORMULA,
+                'source_schema' => DatabaseWorkforceReportAdapter::SCHEMA_VERSION,
+                'renderer' => self::RENDERER_VERSION,
+            ],
+            'semantic_fingerprints' => [
+                'formula' => AttendanceExecutionCandidateContract::FORMULA_HASH,
+                'source' => AttendanceExecutionCandidateContract::SOURCE_HASH,
+            ],
+            'permissions' => [
+                'view' => ['workforce.view'],
+                'export' => ['workforce.reports.export'],
+                'sensitive' => ['workforce.audit.view'],
+                'audit' => [],
+            ],
+            'readiness' => [
+                'source' => 'ready',
+                'formula' => 'ready',
+                'delivery' => 'verified',
+                'publication' => 'published',
+            ],
+            'capabilities' => [
+                'supports_subscriptions' => false,
+                'reproducible_scheduled_snapshot' => false,
+            ],
+        ];
+    }
+
+    private static function code(): string
+    {
+        return AttendanceExecutionCandidateContract::CODE;
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionCandidateContract.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionCandidateContract.php
@@ -5,45 +5,39 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
-use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\Formulas\WorkforceCapacityFormula;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\Formulas\AttendanceExecutionFormula;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\Infrastructure\DatabaseWorkforceReportAdapter;
 use InvalidArgumentException;
 use ReflectionClass;
 
-final readonly class WorkforceCapacityCandidateContract
+final readonly class AttendanceExecutionCandidateContract
 {
-    public const CODE = 'workforce_capacity';
+    public const CODE = 'attendance_execution';
 
-    public const FORMULA_HASH = 'ec5f0c7c6f0c55c5cb97ae69587c3ca695da41746bcd51b11b1f477e961a18b3';
+    public const FORMULA_HASH = 'e6a3ad9e002e7c77ad662ded9ee460b8175783aeae31e41b7176a68a5fadab02';
 
     public const SOURCE_HASH = '2e03ae7b74e26289677f62ee7835b1f0cd8b774c0e38231338f5594904594295';
 
     public function filters(): array
     {
         return [
-            ['id' => 'organization_id', 'required' => true],
-            ['id' => 'month_from', 'required' => true],
-            ['id' => 'month_to', 'required' => true],
-            ['id' => 'project_ids', 'required' => false],
-            ['id' => 'department_ids', 'required' => false],
-            ['id' => 'position_ids', 'required' => false],
-            ['id' => 'employment_types', 'required' => false],
-            ['id' => 'rate_types', 'required' => false],
-            ['id' => 'currencies', 'required' => false],
+            ['id' => 'day_from', 'required' => true],
+            ['id' => 'day_to', 'required' => true],
+            ['id' => 'statuses', 'required' => false],
         ];
     }
 
     public function columns(): array
     {
         return array_map(static fn (string $id): array => ['id' => $id], [
-            'row_key', 'month', 'department_name', 'position_name', 'project_name',
-            'employment_type', 'rate_as_of', 'planned_fte', 'assigned_fte', 'vacancy_fte',
-            'overstaffing_fte', 'vacancy_percent', 'planned_capacity_hours', 'capacity_hours',
-            'rate_type', 'rate', 'currency', 'period_cost_run_rate', 'quality_warnings', 'drill',
+            'row_key', 'work_date', 'employee_name', 'project_name', 'site_name', 'shift',
+            'eligible_hours', 'present_hours', 'approved_absence_hours',
+            'unexplained_absence_hours', 'overtime_hours', 'late_hours', 'early_hours',
+            'execution_percent', 'correction_rate', 'status', 'close_version',
         ]);
     }
 
@@ -51,7 +45,9 @@ final readonly class WorkforceCapacityCandidateContract
     {
         return array_map(static fn (string $id): array => [
             'id' => $id,
-            'direction' => $id === 'month' ? ReportSortDirection::DESC->value : ReportSortDirection::ASC->value,
+            'direction' => $id === 'work_date'
+                ? ReportSortDirection::DESC->value
+                : ReportSortDirection::ASC->value,
         ], DatabaseWorkforceReportAdapter::SORTS[self::CODE]);
     }
 
@@ -62,9 +58,9 @@ final readonly class WorkforceCapacityCandidateContract
 
     public function assertRuntimeMatches(): void
     {
-        if (! hash_equals(self::FORMULA_HASH, self::classHash(WorkforceCapacityFormula::class))
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(AttendanceExecutionFormula::class))
             || ! hash_equals(self::SOURCE_HASH, self::classHash(DatabaseWorkforceReportAdapter::class))) {
-            throw new InvalidArgumentException('workforce_capacity_candidate_contract_drift');
+            throw new InvalidArgumentException('attendance_execution_candidate_contract_drift');
         }
     }
 
@@ -73,7 +69,7 @@ final readonly class WorkforceCapacityCandidateContract
         if ($definition->code !== self::CODE
             || $definition->sourceModule !== 'workforce-management'
             || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
-            || $definition->formulaVersion !== DatabaseWorkforceReportAdapter::CAPACITY_FORMULA
+            || $definition->formulaVersion !== DatabaseWorkforceReportAdapter::ATTENDANCE_FORMULA
             || $definition->sourceSchemaVersion !== DatabaseWorkforceReportAdapter::SCHEMA_VERSION
             || $definition->filters !== self::canonicalItems($this->filters())
             || $definition->columns !== self::canonicalItems($this->columns())
@@ -83,14 +79,14 @@ final readonly class WorkforceCapacityCandidateContract
             || $definition->permissionPolicy->exportPermissions !== ['workforce.reports.export']
             || $definition->permissionPolicy->sensitivePermissions !== ['workforce.audit.view']
             || $definition->permissionPolicy->auditPermissions !== []) {
-            throw new InvalidArgumentException('workforce_capacity_candidate_definition_invalid');
+            throw new InvalidArgumentException('attendance_execution_candidate_definition_invalid');
         }
     }
 
     public function assertSort(ReportWindowSort $sort): void
     {
         if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
-            throw new InvalidArgumentException('workforce_capacity_candidate_sort_invalid');
+            throw new InvalidArgumentException('attendance_execution_candidate_sort_invalid');
         }
     }
 
@@ -99,7 +95,7 @@ final readonly class WorkforceCapacityCandidateContract
         $file = (new ReflectionClass($class))->getFileName();
         $hash = is_string($file) ? hash_file('sha256', $file) : false;
         if (! is_string($hash)) {
-            throw new InvalidArgumentException('workforce_capacity_candidate_source_unreadable');
+            throw new InvalidArgumentException('attendance_execution_candidate_source_unreadable');
         }
 
         return $hash;
@@ -107,6 +103,14 @@ final readonly class WorkforceCapacityCandidateContract
 
     private static function canonicalItems(array $items): array
     {
-        return array_map(static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR), $items);
+        return array_map(
+            static fn (array $item): array => json_decode(
+                CanonicalJson::encode($item),
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            ),
+            $items,
+        );
     }
 }

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class AttendanceExecutionPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private AttendanceExecutionReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(AttendanceExecutionCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+
+            throw $exception;
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionReportBindingFactory.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionReportBindingFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+
+final readonly class AttendanceExecutionReportBindingFactory
+{
+    public function __construct(
+        private AttendanceExecutionProvider $provider,
+        private WorkforceReportQueryService $query,
+        private AttendanceExecutionCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->query,
+            $this->query,
+            null,
+        );
+    }
+}

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabaseWorkforceReportAdapter.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabaseWorkforceReportAdapter.php
@@ -51,7 +51,7 @@ final readonly class DatabaseWorkforceReportAdapter implements WorkforceReportDa
 {
     public const CAPACITY_FORMULA = 'workforce-capacity.v1';
 
-    private const ATTENDANCE_FORMULA = 'attendance.v1';
+    public const ATTENDANCE_FORMULA = 'attendance.v1';
 
     public const SCHEMA_VERSION = 'workforce-report-source.v1';
 
@@ -506,6 +506,9 @@ final readonly class DatabaseWorkforceReportAdapter implements WorkforceReportDa
         $siteIds = $this->authorizedIds($scope, 'site', $this->ids($query, 'site_ids'));
         $shiftIds = $this->authorizedIds($scope, 'shift', $this->ids($query, 'shift_ids'));
         $statuses = $this->strings($query, 'statuses');
+        if (array_diff($statuses, ['covered', 'unexplained_absence']) !== []) {
+            throw new DomainException('REPORT_FILTER_VALUE_NOT_FOUND');
+        }
         $this->assertOrganizationIds('workforce_employees', $scope, $employeeFilterIds);
         $this->assertOrganizationIds('workforce_absence_types', $scope, $absenceTypeIds);
         $this->assertOrganizationIds('projects', $scope, $siteIds);

--- a/app/BusinessModules/Features/WorkforceManagement/WorkforceManagementServiceProvider.php
+++ b/app/BusinessModules/Features/WorkforceManagement/WorkforceManagementServiceProvider.php
@@ -7,6 +7,9 @@ namespace App\BusinessModules\Features\WorkforceManagement;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\Contracts\PayrollReadinessDatabasePort;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\Contracts\WorkforceReportDatabasePort;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionReportBindingFactory;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\Formulas\PayrollReadinessFormula;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\Formulas\PayrollSourceRateFormula;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\Infrastructure\DatabasePayrollReadinessAdapter;
@@ -42,6 +45,9 @@ final class WorkforceManagementServiceProvider extends ServiceProvider
         $this->app->singleton(WorkforceCapacityCandidateContract::class);
         $this->app->scoped(WorkforceCapacityReportBindingFactory::class);
         $this->app->scoped(WorkforceCapacityPublishedRuntimeBindingRegistrar::class);
+        $this->app->singleton(AttendanceExecutionCandidateContract::class);
+        $this->app->scoped(AttendanceExecutionReportBindingFactory::class);
+        $this->app->scoped(AttendanceExecutionPublishedRuntimeBindingRegistrar::class);
         $this->app->scoped(WorkforceCapacityOptionsService::class, static fn ($app): WorkforceCapacityOptionsService => new WorkforceCapacityOptionsService($app['db']->connection()));
         $this->app->singleton(
             Reporting\PayrollReadiness\Contracts\PayrollReadinessEvidenceSource::class,
@@ -123,6 +129,7 @@ final class WorkforceManagementServiceProvider extends ServiceProvider
         $this->app->afterResolving(ReportDefinitionBindingAssembler::class, function (ReportDefinitionBindingAssembler $assembler): void {
             $this->app->make(PayrollReadinessPublishedRuntimeBindingRegistrar::class)->register($assembler);
             $this->app->make(WorkforceCapacityPublishedRuntimeBindingRegistrar::class)->register($assembler);
+            $this->app->make(AttendanceExecutionPublishedRuntimeBindingRegistrar::class)->register($assembler);
         });
         $this->loadMigrationsFrom(__DIR__.'/migrations');
         $this->loadRoutesFrom(__DIR__.'/routes.php');

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -37,6 +37,8 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessB
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -74,6 +76,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('supplier_award_competitiveness', $registry->published('supplier_award_competitiveness')->code);
         self::assertSame('supply_reliability', $registry->published('supply_reliability')->code);
         self::assertSame('inventory_risk', $registry->published('inventory_risk')->code);
+        self::assertSame('attendance_execution', $registry->published('attendance_execution')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
@@ -83,6 +86,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('supplier_award_competitiveness', $app->make(ReportCatalogMetadataRegistry::class)->published('supplier_award_competitiveness')->code);
         self::assertSame('supply_reliability', $app->make(ReportCatalogMetadataRegistry::class)->published('supply_reliability')->code);
         self::assertSame('inventory_risk', $app->make(ReportCatalogMetadataRegistry::class)->published('inventory_risk')->code);
+        self::assertSame('attendance_execution', $app->make(ReportCatalogMetadataRegistry::class)->published('attendance_execution')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
@@ -92,6 +96,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('supplier_award_competitiveness', $app->make(ReportSchedulingCapabilityRegistry::class)->published('supplier_award_competitiveness')->code);
         self::assertSame('supply_reliability', $app->make(ReportSchedulingCapabilityRegistry::class)->published('supply_reliability')->code);
         self::assertSame('inventory_risk', $app->make(ReportSchedulingCapabilityRegistry::class)->published('inventory_risk')->code);
+        self::assertSame('attendance_execution', $app->make(ReportSchedulingCapabilityRegistry::class)->published('attendance_execution')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -106,10 +111,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->supplierAward(),
             $this->supplyReliability(),
             $this->inventoryRisk(),
+            $this->attendanceExecution(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -136,6 +142,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->supplierAward(),
             $this->supplyReliability(),
             $this->inventoryRisk(),
+            $this->attendanceExecution(),
         );
 
         $expectedModules = [
@@ -148,6 +155,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'supplier_award_competitiveness' => 'procurement',
             'supply_reliability' => 'procurement',
             'inventory_risk' => 'basic-warehouse',
+            'attendance_execution' => 'workforce-management',
         ];
 
         foreach ($expectedModules as $code => $module) {
@@ -162,11 +170,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -174,7 +182,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -251,5 +259,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function inventoryRisk(): InventoryRiskBuiltinPublishedReport
     {
         return new InventoryRiskBuiltinPublishedReport(new InventoryRiskCandidateContract);
+    }
+
+    private function attendanceExecution(): AttendanceExecutionBuiltinPublishedReport
+    {
+        return new AttendanceExecutionBuiltinPublishedReport(new AttendanceExecutionCandidateContract);
     }
 }


### PR DESCRIPTION
## Что изменено
- опубликован R20 attendance_execution на реальных назначениях, графиках, подтверждённых проходах, согласованных отсутствиях и корректировках
- публичные фильтры ограничены периодом и допустимыми состояниями
- организация и проект берутся только из server-owned scope
- аудит корректировок раскрывается только с workforce.audit.view
- подключены canonical definition, metadata, runtime binding, drill-down и export

## Проверки
- php -l для всех 12 изменённых PHP-файлов
- git diff --check
- сверка formula/source fingerprints
- PHPUnit/Larastan недоступны локально: отсутствует vendor

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new 'AttendanceExecution' report to the system.</li>
<li>Registered the new report in the core reporting registries (Definition, Metadata, and Scheduling).</li>
<li>Configured the 'AttendanceExecution' report and its candidate contract in the ReportingCatalogServiceProvider.</li>
<li>Implemented the 'AttendanceExecution' report logic, including its binding factory and runtime binding registrar.</li>
<li>Added a unit test for the updated BuiltinPublishedReportDefinitionRegistry.</li>
</ul></div>