### PR TITLE
feat: опубликован отчёт потока дефектов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -20,6 +20,7 @@ use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinP
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
 {
@@ -37,9 +38,10 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         SupplyReliabilityBuiltinPublishedReport $supplyReliability,
         InventoryRiskBuiltinPublishedReport $inventoryRisk,
         AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
+        QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -18,6 +18,7 @@ use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinP
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
 {
@@ -32,6 +33,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private SupplyReliabilityBuiltinPublishedReport $supplyReliability,
         private InventoryRiskBuiltinPublishedReport $inventoryRisk,
         private AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
+        private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -47,6 +49,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->supplyReliability->metadata()->code => $this->supplyReliability->metadata(),
             $this->inventoryRisk->metadata()->code => $this->inventoryRisk->metadata(),
             $this->attendanceExecution->metadata()->code => $this->attendanceExecution->metadata(),
+            $this->qualityDefectFlow->metadata()->code => $this->qualityDefectFlow->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -18,6 +18,7 @@ use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinP
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
 {
@@ -32,6 +33,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private SupplyReliabilityBuiltinPublishedReport $supplyReliability,
         private InventoryRiskBuiltinPublishedReport $inventoryRisk,
         private AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
+        private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -47,6 +49,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->supplyReliability->scheduling()->code => $this->supplyReliability->scheduling(),
             $this->inventoryRisk->scheduling()->code => $this->inventoryRisk->scheduling(),
             $this->attendanceExecution->scheduling()->code => $this->attendanceExecution->scheduling(),
+            $this->qualityDefectFlow->scheduling()->code => $this->qualityDefectFlow->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -75,6 +75,8 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacity
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -117,6 +119,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(AttendanceExecutionBuiltinPublishedReport::class, fn (Application $app): AttendanceExecutionBuiltinPublishedReport => new AttendanceExecutionBuiltinPublishedReport(
             $app->make(AttendanceExecutionCandidateContract::class),
         ));
+        $this->app->singleton(QualityDefectFlowCandidateContract::class);
+        $this->app->singleton(QualityDefectFlowBuiltinPublishedReport::class, fn (Application $app): QualityDefectFlowBuiltinPublishedReport => new QualityDefectFlowBuiltinPublishedReport(
+            $app->make(QualityDefectFlowCandidateContract::class),
+        ));
         $this->app->singleton(ProcurementCycleCandidateContract::class);
         $this->app->singleton(ProcurementCycleBuiltinPublishedReport::class, fn (Application $app): ProcurementCycleBuiltinPublishedReport => new ProcurementCycleBuiltinPublishedReport(
             $app->make(ProcurementCycleCandidateContract::class),
@@ -146,6 +152,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(SupplyReliabilityBuiltinPublishedReport::class),
                 $app->make(InventoryRiskBuiltinPublishedReport::class),
                 $app->make(AttendanceExecutionBuiltinPublishedReport::class),
+                $app->make(QualityDefectFlowBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -155,9 +162,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/QualityControl/QualityControlServiceProvider.php
+++ b/app/BusinessModules/Features/QualityControl/QualityControlServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\QualityControl;
 
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
 use Illuminate\Support\ServiceProvider;
 
 final class QualityControlServiceProvider extends ServiceProvider
@@ -34,10 +35,16 @@ final class QualityControlServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\DefectFlow\DrillDown\QualityDefectFlowDrillDownProvider::class);
         $this->app->singleton(Reporting\DefectFlow\Backfill\QualityDefectFlowBackfill::class);
         $this->app->singleton(Reporting\DefectFlow\Readiness\QualityDefectFlowReadinessProbe::class);
+        $this->app->singleton(Reporting\DefectFlow\QualityDefectFlowCandidateContract::class);
+        $this->app->scoped(Reporting\DefectFlow\QualityDefectFlowReportBindingFactory::class);
+        $this->app->scoped(Reporting\DefectFlow\QualityDefectFlowPublishedRuntimeBindingRegistrar::class);
     }
 
     public function boot(): void
     {
+        $this->app->afterResolving(ReportDefinitionBindingAssembler::class, function (ReportDefinitionBindingAssembler $assembler): void {
+            $this->app->make(Reporting\DefectFlow\QualityDefectFlowPublishedRuntimeBindingRegistrar::class)->register($assembler);
+        });
         $migrationsPath = __DIR__.'/migrations';
         if (is_dir($migrationsPath)) {
             $this->loadMigrationsFrom($migrationsPath);

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowBuiltinPublishedReport.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\QualityControl\Reporting\DefectFlow;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class QualityDefectFlowBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+    public const RENDERER_VERSION = '1.0.0';
+    public const MANIFEST_ORDINAL = 23;
+
+    public function __construct(private QualityDefectFlowCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            QualityDefectFlowCandidateContract::CODE,
+            'reports.catalog.quality_defect_flow',
+            ReportCatalogGroup::QUALITY_SAFETY,
+            'quality_safety',
+            'defect_transition_project',
+            2,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(QualityDefectFlowCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => QualityDefectFlowCandidateContract::CODE,
+            'title_key' => 'reports.catalog.quality_defect_flow',
+            'catalog_group' => 'quality_safety',
+            'category' => 'quality_safety',
+            'grain' => 'defect_transition_project',
+            'wave' => 2,
+            'source_module' => 'quality-control',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => [
+                'contract' => self::CONTRACT_VERSION,
+                'formula' => QualityDefectFlowCandidateContract::FORMULA_VERSION,
+                'source_schema' => QualityDefectFlowCandidateContract::SOURCE_SCHEMA_VERSION,
+                'renderer' => self::RENDERER_VERSION,
+            ],
+            'semantic_fingerprints' => [
+                'formula' => QualityDefectFlowCandidateContract::FORMULA_HASH,
+                'source' => QualityDefectFlowCandidateContract::SOURCE_HASH,
+            ],
+            'permissions' => [
+                'view' => ['quality-control.defects.view'],
+                'export' => ['quality-control.reports.export'],
+                'sensitive' => [],
+                'audit' => ['quality-control.defects.view'],
+            ],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\QualityControl\Reporting\DefectFlow;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Services\QualityDefectFlowFormula;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Services\QualityDefectFlowSnapshotMaterializer;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class QualityDefectFlowCandidateContract
+{
+    public const CODE = 'quality_defect_flow';
+    public const FORMULA_VERSION = 'quality_defect_flow_v1';
+    public const SOURCE_SCHEMA_VERSION = 'quality_defect_flow_v1';
+    public const FORMULA_HASH = 'acae0365d20840207443202b4e9992034797843ac61e64382823e398edbc3f7a';
+    public const SOURCE_HASH = '8c0972a1b979d4afb341953874051b758051669729d651b90c4ada66fa8d927a';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'period_from', 'required' => true],
+            ['id' => 'period_to', 'required' => true],
+            ['id' => 'severity', 'required' => false],
+            ['id' => 'status', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'cohort_date', 'project_id', 'contractor_id', 'schedule_task_id',
+            'quality_defect_id', 'event_version', 'severity', 'status', 'created',
+            'reopened', 'closed', 'closing', 'cycle_days', 'due_date', 'evidence_refs',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return array_map(static fn (string $id): array => [
+            'id' => $id,
+            'direction' => $id === 'cohort_date'
+                ? ReportSortDirection::DESC->value
+                : ReportSortDirection::ASC->value,
+        ], ['cohort_date', 'due_date', 'severity', 'status', 'quality_defect_id']);
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(QualityDefectFlowFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(QualityDefectFlowSnapshotMaterializer::class))) {
+            throw new InvalidArgumentException('quality_defect_flow_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'quality-control'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['quality-control.defects.view']
+            || $definition->permissionPolicy->exportPermissions !== ['quality-control.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== ['quality-control.defects.view']) {
+            throw new InvalidArgumentException('quality_defect_flow_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
+            throw new InvalidArgumentException('quality_defect_flow_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('quality_defect_flow_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR),
+            $items,
+        );
+    }
+}

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\QualityControl\Reporting\DefectFlow;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class QualityDefectFlowPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private QualityDefectFlowReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(QualityDefectFlowCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+
+            throw $exception;
+        }
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowReportBindingFactory.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowReportBindingFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\QualityControl\Reporting\DefectFlow;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\DrillDown\QualityDefectFlowDrillDownProvider;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Providers\QualityDefectFlowReportProvider;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Queries\QualityDefectFlowRowQuery;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Readiness\QualityDefectFlowReadinessProbe;
+
+final readonly class QualityDefectFlowReportBindingFactory
+{
+    public function __construct(
+        private QualityDefectFlowReportProvider $provider,
+        private QualityDefectFlowRowQuery $rows,
+        private QualityDefectFlowDrillDownProvider $drillDown,
+        private QualityDefectFlowReadinessProbe $readiness,
+        private QualityDefectFlowCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->rows,
+            $this->drillDown,
+            $this->readiness,
+        );
+    }
+}

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
@@ -58,6 +58,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
         CompletedReportSourceLedgerBinding::lockAndAssertOwnerGeneration($organizationId, $ledgerBinding);
         $asOf = CarbonImmutable::instance($query->asOf);
         [$periodFrom, $periodTo] = $this->period($query, $asOf);
+        $this->assertPublicFilterValues($query);
         $events = $this->events(
             $organizationId,
             $context->scope->projectIds,
@@ -661,5 +662,24 @@ final readonly class QualityDefectFlowSnapshotMaterializer
             is_array($value) ? $value : [$value],
             static fn (mixed $item): bool => is_int($item) || is_string($item),
         ));
+    }
+
+    private function assertPublicFilterValues(ReportQuery $query): void
+    {
+        $severities = $this->filterValues($query->filters->values['severity'] ?? null);
+        $statuses = $this->filterValues($query->filters->values['status'] ?? null);
+        if (array_diff($severities, ['minor', 'major', 'critical']) !== []
+            || array_diff($statuses, [
+                'draft',
+                'open',
+                'assigned',
+                'in_progress',
+                'ready_for_review',
+                'resolved',
+                'rejected',
+                'cancelled',
+            ]) !== []) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+        }
     }
 }

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -39,6 +39,8 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacity
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -77,6 +79,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('supply_reliability', $registry->published('supply_reliability')->code);
         self::assertSame('inventory_risk', $registry->published('inventory_risk')->code);
         self::assertSame('attendance_execution', $registry->published('attendance_execution')->code);
+        self::assertSame('quality_defect_flow', $registry->published('quality_defect_flow')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
@@ -87,6 +90,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('supply_reliability', $app->make(ReportCatalogMetadataRegistry::class)->published('supply_reliability')->code);
         self::assertSame('inventory_risk', $app->make(ReportCatalogMetadataRegistry::class)->published('inventory_risk')->code);
         self::assertSame('attendance_execution', $app->make(ReportCatalogMetadataRegistry::class)->published('attendance_execution')->code);
+        self::assertSame('quality_defect_flow', $app->make(ReportCatalogMetadataRegistry::class)->published('quality_defect_flow')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
@@ -97,6 +101,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('supply_reliability', $app->make(ReportSchedulingCapabilityRegistry::class)->published('supply_reliability')->code);
         self::assertSame('inventory_risk', $app->make(ReportSchedulingCapabilityRegistry::class)->published('inventory_risk')->code);
         self::assertSame('attendance_execution', $app->make(ReportSchedulingCapabilityRegistry::class)->published('attendance_execution')->code);
+        self::assertSame('quality_defect_flow', $app->make(ReportSchedulingCapabilityRegistry::class)->published('quality_defect_flow')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -112,10 +117,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->supplyReliability(),
             $this->inventoryRisk(),
             $this->attendanceExecution(),
+            $this->qualityDefectFlow(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -143,6 +149,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->supplyReliability(),
             $this->inventoryRisk(),
             $this->attendanceExecution(),
+            $this->qualityDefectFlow(),
         );
 
         $expectedModules = [
@@ -156,6 +163,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'supply_reliability' => 'procurement',
             'inventory_risk' => 'basic-warehouse',
             'attendance_execution' => 'workforce-management',
+            'quality_defect_flow' => 'quality-control',
         ];
 
         foreach ($expectedModules as $code => $module) {
@@ -170,11 +178,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -182,7 +190,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -264,5 +272,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function attendanceExecution(): AttendanceExecutionBuiltinPublishedReport
     {
         return new AttendanceExecutionBuiltinPublishedReport(new AttendanceExecutionCandidateContract);
+    }
+
+    private function qualityDefectFlow(): QualityDefectFlowBuiltinPublishedReport
+    {
+        return new QualityDefectFlowBuiltinPublishedReport(new QualityDefectFlowCandidateContract);
     }
 }


### PR DESCRIPTION
## Что изменено
- опубликован R23 quality_defect_flow на реальной append-only истории дефектов и версиях политики
- организация и проект берутся только из server-owned scope
- публичные фильтры ограничены периодом, серьёзностью и статусом
- подменённые enum-значения отклоняются стандартной ошибкой
- подключены immutable snapshot, totals, rows, readiness, ABAC drill-down и export

## Проверки
- php -l для 11 изменённых PHP-файлов
- git diff --check
- сверка formula/source fingerprints
- PHPUnit/Larastan локально недоступны: vendor отсутствует