### PR TITLE
feat: опубликован отчёт допуска персонала

### DIFF
--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -77,6 +77,8 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecuti
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -123,6 +125,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(QualityDefectFlowBuiltinPublishedReport::class, fn (Application $app): QualityDefectFlowBuiltinPublishedReport => new QualityDefectFlowBuiltinPublishedReport(
             $app->make(QualityDefectFlowCandidateContract::class),
         ));
+        $this->app->singleton(WorkforceAdmissionCandidateContract::class);
+        $this->app->singleton(WorkforceAdmissionBuiltinPublishedReport::class, fn (Application $app): WorkforceAdmissionBuiltinPublishedReport => new WorkforceAdmissionBuiltinPublishedReport(
+            $app->make(WorkforceAdmissionCandidateContract::class),
+        ));
         $this->app->singleton(ProcurementCycleCandidateContract::class);
         $this->app->singleton(ProcurementCycleBuiltinPublishedReport::class, fn (Application $app): ProcurementCycleBuiltinPublishedReport => new ProcurementCycleBuiltinPublishedReport(
             $app->make(ProcurementCycleCandidateContract::class),
@@ -153,6 +159,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(InventoryRiskBuiltinPublishedReport::class),
                 $app->make(AttendanceExecutionBuiltinPublishedReport::class),
                 $app->make(QualityDefectFlowBuiltinPublishedReport::class),
+                $app->make(WorkforceAdmissionBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -162,9 +169,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionBuiltinPublishedReport.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\Admission;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class WorkforceAdmissionBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+    public const RENDERER_VERSION = '1.0.0';
+    public const MANIFEST_ORDINAL = 25;
+
+    public function __construct(private WorkforceAdmissionCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            WorkforceAdmissionCandidateContract::CODE,
+            'reports.catalog.workforce_admission',
+            ReportCatalogGroup::QUALITY_SAFETY,
+            'quality_safety',
+            'person_site_requirement_day',
+            2,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(WorkforceAdmissionCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => WorkforceAdmissionCandidateContract::CODE,
+            'title_key' => 'reports.catalog.workforce_admission',
+            'catalog_group' => 'quality_safety',
+            'category' => 'quality_safety',
+            'grain' => 'person_site_requirement_day',
+            'wave' => 2,
+            'source_module' => 'safety-management',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => [
+                'contract' => self::CONTRACT_VERSION,
+                'formula' => WorkforceAdmissionCandidateContract::FORMULA_VERSION,
+                'source_schema' => WorkforceAdmissionCandidateContract::SOURCE_SCHEMA_VERSION,
+                'renderer' => self::RENDERER_VERSION,
+            ],
+            'semantic_fingerprints' => [
+                'formula' => WorkforceAdmissionCandidateContract::FORMULA_HASH,
+                'source' => WorkforceAdmissionCandidateContract::SOURCE_HASH,
+            ],
+            'permissions' => [
+                'view' => ['safety-management.view'],
+                'export' => ['safety-management.reports.export'],
+                'sensitive' => ['safety-management.medical.view'],
+                'audit' => ['safety-management.view'],
+            ],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\Admission;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Services\WorkforceAdmissionFormula;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Services\WorkforceAdmissionSnapshotMaterializer;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class WorkforceAdmissionCandidateContract
+{
+    public const CODE = 'workforce_admission';
+    public const FORMULA_VERSION = 'workforce_admission_v1';
+    public const SOURCE_SCHEMA_VERSION = 'workforce_admission_v1';
+    public const FORMULA_HASH = '4df1641fb5a5c69fffbc38b3a7ad11abe2d81869d15f46ce47be44384e43f106';
+    public const SOURCE_HASH = 'd9831fb19829c9acc43efe244f708d69f73ac312a1a20adc28a90d639c7970e9';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'status', 'required' => false],
+            ['id' => 'mandatory', 'required' => false],
+            ['id' => 'blocked', 'required' => false],
+            ['id' => 'verified', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'snapshot_date', 'project_id', 'safety_site_id', 'workforce_assignment_id',
+            'employee_id', 'requirement_code', 'requirement_type', 'status', 'mandatory',
+            'blocked', 'verified', 'valid_until', 'evidence_id', 'medical_details',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return array_map(static fn (string $id): array => [
+            'id' => $id,
+            'direction' => $id === 'snapshot_date' ? ReportSortDirection::DESC->value : ReportSortDirection::ASC->value,
+        ], ['snapshot_date', 'status', 'valid_until', 'employee_id', 'row_key']);
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(WorkforceAdmissionFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(WorkforceAdmissionSnapshotMaterializer::class))) {
+            throw new InvalidArgumentException('workforce_admission_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'safety-management'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['safety-management.view']
+            || $definition->permissionPolicy->exportPermissions !== ['safety-management.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== ['safety-management.medical.view']
+            || $definition->permissionPolicy->auditPermissions !== ['safety-management.view']) {
+            throw new InvalidArgumentException('workforce_admission_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
+            throw new InvalidArgumentException('workforce_admission_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('workforce_admission_candidate_source_unreadable');
+        }
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR),
+            $items,
+        );
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\Admission;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class WorkforceAdmissionPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private WorkforceAdmissionReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(WorkforceAdmissionCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+            throw $exception;
+        }
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionReportBindingFactory.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionReportBindingFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\Admission;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\DrillDown\WorkforceAdmissionDrillDownProvider;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Providers\WorkforceAdmissionReportProvider;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Queries\WorkforceAdmissionRowQuery;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Readiness\WorkforceAdmissionReadinessProbe;
+
+final readonly class WorkforceAdmissionReportBindingFactory
+{
+    public function __construct(
+        private WorkforceAdmissionReportProvider $provider,
+        private WorkforceAdmissionRowQuery $rows,
+        private WorkforceAdmissionDrillDownProvider $drillDown,
+        private WorkforceAdmissionReadinessProbe $readiness,
+        private WorkforceAdmissionCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->rows,
+            $this->drillDown,
+            $this->readiness,
+        );
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/SafetyManagementServiceProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/SafetyManagementServiceProvider.php
@@ -32,6 +32,9 @@ final class SafetyManagementServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\Admission\DrillDown\WorkforceAdmissionDrillDownProvider::class);
         $this->app->singleton(Reporting\Admission\Backfill\WorkforceAdmissionBackfill::class);
         $this->app->singleton(Reporting\Admission\Readiness\WorkforceAdmissionReadinessProbe::class);
+        $this->app->singleton(Reporting\Admission\WorkforceAdmissionCandidateContract::class);
+        $this->app->scoped(Reporting\Admission\WorkforceAdmissionReportBindingFactory::class);
+        $this->app->scoped(Reporting\Admission\WorkforceAdmissionPublishedRuntimeBindingRegistrar::class);
     }
 
     public function boot(): void
@@ -49,6 +52,14 @@ final class SafetyManagementServiceProvider extends ServiceProvider
         $this->app['router']->aliasMiddleware(
             'safety-management.active',
             Http\Middleware\EnsureSafetyManagementActive::class
+        );
+
+        $this->app->resolving(
+            \App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler::class,
+            function ($assembler): void {
+                $this->app->make(Reporting\Admission\WorkforceAdmissionPublishedRuntimeBindingRegistrar::class)
+                    ->register($assembler);
+            },
         );
     }
 }

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -41,6 +41,8 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecuti
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -80,6 +82,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('inventory_risk', $registry->published('inventory_risk')->code);
         self::assertSame('attendance_execution', $registry->published('attendance_execution')->code);
         self::assertSame('quality_defect_flow', $registry->published('quality_defect_flow')->code);
+        self::assertSame('workforce_admission', $registry->published('workforce_admission')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
@@ -91,6 +94,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('inventory_risk', $app->make(ReportCatalogMetadataRegistry::class)->published('inventory_risk')->code);
         self::assertSame('attendance_execution', $app->make(ReportCatalogMetadataRegistry::class)->published('attendance_execution')->code);
         self::assertSame('quality_defect_flow', $app->make(ReportCatalogMetadataRegistry::class)->published('quality_defect_flow')->code);
+        self::assertSame('workforce_admission', $app->make(ReportCatalogMetadataRegistry::class)->published('workforce_admission')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
@@ -102,6 +106,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('inventory_risk', $app->make(ReportSchedulingCapabilityRegistry::class)->published('inventory_risk')->code);
         self::assertSame('attendance_execution', $app->make(ReportSchedulingCapabilityRegistry::class)->published('attendance_execution')->code);
         self::assertSame('quality_defect_flow', $app->make(ReportSchedulingCapabilityRegistry::class)->published('quality_defect_flow')->code);
+        self::assertSame('workforce_admission', $app->make(ReportSchedulingCapabilityRegistry::class)->published('workforce_admission')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -118,10 +123,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->inventoryRisk(),
             $this->attendanceExecution(),
             $this->qualityDefectFlow(),
+            $this->workforceAdmission(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -150,6 +156,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->inventoryRisk(),
             $this->attendanceExecution(),
             $this->qualityDefectFlow(),
+            $this->workforceAdmission(),
         );
 
         $expectedModules = [
@@ -164,6 +171,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'inventory_risk' => 'basic-warehouse',
             'attendance_execution' => 'workforce-management',
             'quality_defect_flow' => 'quality-control',
+            'workforce_admission' => 'safety-management',
         ];
 
         foreach ($expectedModules as $code => $module) {
@@ -178,11 +186,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->workforceAdmission()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -190,7 +198,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->workforceAdmission()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -277,5 +285,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function qualityDefectFlow(): QualityDefectFlowBuiltinPublishedReport
     {
         return new QualityDefectFlowBuiltinPublishedReport(new QualityDefectFlowCandidateContract);
+    }
+
+    private function workforceAdmission(): WorkforceAdmissionBuiltinPublishedReport
+    {
+        return new WorkforceAdmissionBuiltinPublishedReport(new WorkforceAdmissionCandidateContract);
     }
 }


### PR DESCRIPTION
Публикует R25 как canonical отчёт МОСТ с server-owned контекстом, безопасными бизнес-фильтрами, медицинской редактировкой и полным runtime binding.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced WorkforceAdmission report to the reporting catalog.</li>
<li>Created WorkforceAdmissionBuiltinPublishedReport and WorkforceAdmissionCandidateContract classes.</li>
<li>Registered the new report in ReportingCatalogServiceProvider and SafetyManagementServiceProvider.</li>
<li>Added unit tests for the new report definition registry.</li>
</ul></div>