### PR TITLE
feat: опубликован отчёт по инцидентам безопасности

### DIFF
--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -79,6 +79,8 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionCandidateContract;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -129,6 +131,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(WorkforceAdmissionBuiltinPublishedReport::class, fn (Application $app): WorkforceAdmissionBuiltinPublishedReport => new WorkforceAdmissionBuiltinPublishedReport(
             $app->make(WorkforceAdmissionCandidateContract::class),
         ));
+        $this->app->singleton(SafetyIncidentActionsCandidateContract::class);
+        $this->app->singleton(SafetyIncidentActionsBuiltinPublishedReport::class, fn (Application $app): SafetyIncidentActionsBuiltinPublishedReport => new SafetyIncidentActionsBuiltinPublishedReport(
+            $app->make(SafetyIncidentActionsCandidateContract::class),
+        ));
         $this->app->singleton(ProcurementCycleCandidateContract::class);
         $this->app->singleton(ProcurementCycleBuiltinPublishedReport::class, fn (Application $app): ProcurementCycleBuiltinPublishedReport => new ProcurementCycleBuiltinPublishedReport(
             $app->make(ProcurementCycleCandidateContract::class),
@@ -159,6 +165,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(InventoryRiskBuiltinPublishedReport::class),
                 $app->make(AttendanceExecutionBuiltinPublishedReport::class),
                 $app->make(QualityDefectFlowBuiltinPublishedReport::class),
+                $app->make(SafetyIncidentActionsBuiltinPublishedReport::class),
                 $app->make(WorkforceAdmissionBuiltinPublishedReport::class),
             ),
         );
@@ -169,9 +176,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsBuiltinPublishedReport.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class SafetyIncidentActionsBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+    public const RENDERER_VERSION = '1.0.0';
+    public const MANIFEST_ORDINAL = 24;
+
+    public function __construct(private SafetyIncidentActionsCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            SafetyIncidentActionsCandidateContract::CODE,
+            'reports.catalog.safety_incident_actions',
+            ReportCatalogGroup::QUALITY_SAFETY,
+            'quality_safety',
+            'incident_action_site_day',
+            2,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(SafetyIncidentActionsCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => SafetyIncidentActionsCandidateContract::CODE,
+            'title_key' => 'reports.catalog.safety_incident_actions',
+            'catalog_group' => 'quality_safety',
+            'category' => 'quality_safety',
+            'grain' => 'incident_action_site_day',
+            'wave' => 2,
+            'source_module' => 'safety-management',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => SafetyIncidentActionsCandidateContract::FORMULA_VERSION, 'source_schema' => SafetyIncidentActionsCandidateContract::SOURCE_SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION],
+            'semantic_fingerprints' => ['formula' => SafetyIncidentActionsCandidateContract::FORMULA_HASH, 'source' => SafetyIncidentActionsCandidateContract::SOURCE_HASH],
+            'permissions' => ['view' => ['safety-management.view'], 'export' => ['safety-management.reports.export'], 'sensitive' => [], 'audit' => ['safety-management.view']],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Services\SafetyIncidentFormula;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Services\SafetyIncidentSnapshotMaterializer;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class SafetyIncidentActionsCandidateContract
+{
+    public const CODE = 'safety_incident_actions';
+    public const FORMULA_VERSION = 'safety_incident_actions_v1';
+    public const SOURCE_SCHEMA_VERSION = 'safety_incident_actions_v1';
+    public const FORMULA_HASH = 'f0e98a08eb88ece897c5e552142134cf8b3247fcd8e19a873760b7fad399c790';
+    public const SOURCE_HASH = 'f762593825f2523ef2c4c109023779fec762dd0fc28bdbf61e506328b55b30c6';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'period_from', 'required' => true],
+            ['id' => 'period_to', 'required' => true],
+            ['id' => 'subject_type', 'required' => false],
+            ['id' => 'severity', 'required' => false],
+            ['id' => 'status', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'event_date', 'project_id', 'safety_site_id', 'contractor_id',
+            'subject_type', 'subject_id', 'event_version', 'category', 'severity',
+            'status', 'owner_user_id', 'due_date', 'created', 'reopened', 'closed',
+            'closure_verified', 'closure_days', 'evidence_id',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return array_map(static fn (string $id): array => [
+            'id' => $id,
+            'direction' => $id === 'event_date' ? ReportSortDirection::DESC->value : ReportSortDirection::ASC->value,
+        ], ['event_date', 'due_date', 'severity', 'status', 'row_key']);
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(SafetyIncidentFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(SafetyIncidentSnapshotMaterializer::class))) {
+            throw new InvalidArgumentException('safety_incident_actions_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'safety-management'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['safety-management.view']
+            || $definition->permissionPolicy->exportPermissions !== ['safety-management.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== ['safety-management.view']) {
+            throw new InvalidArgumentException('safety_incident_actions_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
+            throw new InvalidArgumentException('safety_incident_actions_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('safety_incident_actions_candidate_source_unreadable');
+        }
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR),
+            $items,
+        );
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class SafetyIncidentActionsPublishedRuntimeBindingRegistrar
+{
+    public function __construct(private ReportDefinitionRegistry $definitions, private SafetyIncidentActionsReportBindingFactory $bindings) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(SafetyIncidentActionsCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+            throw $exception;
+        }
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsReportBindingFactory.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsReportBindingFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\DrillDown\SafetyIncidentDrillDownProvider;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Providers\SafetyIncidentActionsReportProvider;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Queries\SafetyIncidentRowQuery;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Readiness\SafetyIncidentReadinessProbe;
+
+final readonly class SafetyIncidentActionsReportBindingFactory
+{
+    public function __construct(
+        private SafetyIncidentActionsReportProvider $provider,
+        private SafetyIncidentRowQuery $rows,
+        private SafetyIncidentDrillDownProvider $drillDown,
+        private SafetyIncidentReadinessProbe $readiness,
+        private SafetyIncidentActionsCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+        return new ReportDefinitionBinding($definition->code, $definition->definitionHash, $definition->contractVersion, $this->provider, $this->rows, $this->drillDown, $this->readiness);
+    }
+}

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
@@ -63,6 +63,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
         array $ledgerBinding,
     ): SafetyIncidentSnapshot {
         $organizationId = $context->scope->organizationId;
+        $this->assertPublicFilterValues($query);
         CompletedReportSourceLedgerBinding::lockAndAssertOwnerGeneration($organizationId, $ledgerBinding);
         $asOf = CarbonImmutable::instance($query->asOf);
         [$periodFrom, $periodTo] = $this->period($query, $asOf);
@@ -937,5 +938,27 @@ final readonly class SafetyIncidentSnapshotMaterializer
             is_array($value) ? $value : [$value],
             static fn (mixed $item): bool => is_int($item) || is_string($item),
         ));
+    }
+
+    private function assertPublicFilterValues(ReportQuery $query): void
+    {
+        $subjectTypes = $this->filterValues($query->filters->values['subject_type'] ?? null);
+        $severities = $this->filterValues($query->filters->values['severity'] ?? null);
+        $statuses = $this->filterValues($query->filters->values['status'] ?? null);
+        if (array_diff($subjectTypes, ['incident', 'violation', 'corrective_action']) !== []
+            || array_diff($severities, ['minor', 'major', 'high', 'critical']) !== []
+            || array_diff($statuses, [
+                'reported',
+                'triage',
+                'investigation',
+                'corrective_actions',
+                'open',
+                'resolved',
+                'verified',
+                'closed',
+                'cancelled',
+            ]) !== []) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+        }
     }
 }

--- a/app/BusinessModules/Features/SafetyManagement/SafetyManagementServiceProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/SafetyManagementServiceProvider.php
@@ -24,6 +24,9 @@ final class SafetyManagementServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\IncidentActions\Backfill\SafetyIncidentBackfill::class);
         $this->app->singleton(Reporting\IncidentActions\Backfill\SafetyExposureBackfill::class);
         $this->app->singleton(Reporting\IncidentActions\Readiness\SafetyIncidentReadinessProbe::class);
+        $this->app->singleton(Reporting\IncidentActions\SafetyIncidentActionsCandidateContract::class);
+        $this->app->scoped(Reporting\IncidentActions\SafetyIncidentActionsReportBindingFactory::class);
+        $this->app->scoped(Reporting\IncidentActions\SafetyIncidentActionsPublishedRuntimeBindingRegistrar::class);
         $this->app->singleton(Reporting\Admission\Services\SafetySiteAssignmentService::class);
         $this->app->singleton(Reporting\Admission\Services\WorkforceAdmissionFormula::class);
         $this->app->singleton(Reporting\Admission\Services\WorkforceAdmissionSnapshotMaterializer::class);
@@ -57,6 +60,8 @@ final class SafetyManagementServiceProvider extends ServiceProvider
         $this->app->resolving(
             \App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler::class,
             function ($assembler): void {
+                $this->app->make(Reporting\IncidentActions\SafetyIncidentActionsPublishedRuntimeBindingRegistrar::class)
+                    ->register($assembler);
                 $this->app->make(Reporting\Admission\WorkforceAdmissionPublishedRuntimeBindingRegistrar::class)
                     ->register($assembler);
             },

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -43,6 +43,8 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionCandidateContract;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -83,6 +85,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('attendance_execution', $registry->published('attendance_execution')->code);
         self::assertSame('quality_defect_flow', $registry->published('quality_defect_flow')->code);
         self::assertSame('workforce_admission', $registry->published('workforce_admission')->code);
+        self::assertSame('safety_incident_actions', $registry->published('safety_incident_actions')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
@@ -95,6 +98,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('attendance_execution', $app->make(ReportCatalogMetadataRegistry::class)->published('attendance_execution')->code);
         self::assertSame('quality_defect_flow', $app->make(ReportCatalogMetadataRegistry::class)->published('quality_defect_flow')->code);
         self::assertSame('workforce_admission', $app->make(ReportCatalogMetadataRegistry::class)->published('workforce_admission')->code);
+        self::assertSame('safety_incident_actions', $app->make(ReportCatalogMetadataRegistry::class)->published('safety_incident_actions')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
@@ -107,6 +111,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('attendance_execution', $app->make(ReportSchedulingCapabilityRegistry::class)->published('attendance_execution')->code);
         self::assertSame('quality_defect_flow', $app->make(ReportSchedulingCapabilityRegistry::class)->published('quality_defect_flow')->code);
         self::assertSame('workforce_admission', $app->make(ReportSchedulingCapabilityRegistry::class)->published('workforce_admission')->code);
+        self::assertSame('safety_incident_actions', $app->make(ReportSchedulingCapabilityRegistry::class)->published('safety_incident_actions')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -123,11 +128,12 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->inventoryRisk(),
             $this->attendanceExecution(),
             $this->qualityDefectFlow(),
+            $this->safetyIncidentActions(),
             $this->workforceAdmission(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -156,6 +162,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->inventoryRisk(),
             $this->attendanceExecution(),
             $this->qualityDefectFlow(),
+            $this->safetyIncidentActions(),
             $this->workforceAdmission(),
         );
 
@@ -171,6 +178,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'inventory_risk' => 'basic-warehouse',
             'attendance_execution' => 'workforce-management',
             'quality_defect_flow' => 'quality-control',
+            'safety_incident_actions' => 'safety-management',
             'workforce_admission' => 'safety-management',
         ];
 
@@ -186,11 +194,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->workforceAdmission()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -198,7 +206,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->workforceAdmission()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -290,5 +298,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function workforceAdmission(): WorkforceAdmissionBuiltinPublishedReport
     {
         return new WorkforceAdmissionBuiltinPublishedReport(new WorkforceAdmissionCandidateContract);
+    }
+
+    private function safetyIncidentActions(): SafetyIncidentActionsBuiltinPublishedReport
+    {
+        return new SafetyIncidentActionsBuiltinPublishedReport(new SafetyIncidentActionsCandidateContract);
     }
 }


### PR DESCRIPTION
Публикует R24 МОСТ на реальных safety transitions и экспозиции: server-owned контекст, строгие фильтры, backlog, сроки, частота, drill-down и экспорт.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a new 'Safety Incident Actions' report to the reporting catalog.</li>
<li>Implemented the 'SafetyIncidentActionsBuiltinPublishedReport' class to define report metadata, scheduling, and document structure.</li>
<li>Created 'SafetyIncidentActionsCandidateContract' to manage report schema, filters, columns, and runtime validation.</li>
<li>Registered the new report in 'ReportingCatalogServiceProvider' and 'SafetyManagementServiceProvider'.</li>
<li>Added unit tests for the new report definition registry.</li>
</ul></div>