### PR TITLE
feat: отчёт отклонений от базового графика

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -21,6 +21,9 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessB
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
 {
@@ -30,6 +33,7 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
     public function __construct(
         ProjectMarginBuiltinPublishedReport $projectMargin,
         BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
+        BaselineScheduleVarianceBuiltinPublishedReport $baselineScheduleVariance,
         ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
         PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
@@ -39,9 +43,11 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         InventoryRiskBuiltinPublishedReport $inventoryRisk,
         AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
         QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
+        SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
+        WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $baselineScheduleVariance->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -19,12 +19,16 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessB
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
 {
     public function __construct(
         private ProjectMarginBuiltinPublishedReport $projectMargin,
         private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
+        private BaselineScheduleVarianceBuiltinPublishedReport $baselineScheduleVariance,
         private ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
         private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         private WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
@@ -34,6 +38,8 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private InventoryRiskBuiltinPublishedReport $inventoryRisk,
         private AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
         private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
+        private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
+        private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -41,6 +47,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         return match ($code) {
             $this->projectMargin->metadata()->code => $this->projectMargin->metadata(),
             $this->budgetPlanFact->metadata()->code => $this->budgetPlanFact->metadata(),
+            $this->baselineScheduleVariance->metadata()->code => $this->baselineScheduleVariance->metadata(),
             $this->projectLaborCost->metadata()->code => $this->projectLaborCost->metadata(),
             $this->payrollReadiness->metadata()->code => $this->payrollReadiness->metadata(),
             $this->workforceCapacity->metadata()->code => $this->workforceCapacity->metadata(),
@@ -50,6 +57,8 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->inventoryRisk->metadata()->code => $this->inventoryRisk->metadata(),
             $this->attendanceExecution->metadata()->code => $this->attendanceExecution->metadata(),
             $this->qualityDefectFlow->metadata()->code => $this->qualityDefectFlow->metadata(),
+            $this->safetyIncidentActions->metadata()->code => $this->safetyIncidentActions->metadata(),
+            $this->workforceAdmission->metadata()->code => $this->workforceAdmission->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -19,12 +19,16 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessB
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
 {
     public function __construct(
         private ProjectMarginBuiltinPublishedReport $projectMargin,
         private BudgetPlanFactBuiltinPublishedReport $budgetPlanFact,
+        private BaselineScheduleVarianceBuiltinPublishedReport $baselineScheduleVariance,
         private ProjectLaborCostBuiltinPublishedReport $projectLaborCost,
         private PayrollReadinessBuiltinPublishedReport $payrollReadiness,
         private WorkforceCapacityBuiltinPublishedReport $workforceCapacity,
@@ -34,6 +38,8 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private InventoryRiskBuiltinPublishedReport $inventoryRisk,
         private AttendanceExecutionBuiltinPublishedReport $attendanceExecution,
         private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
+        private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
+        private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -41,6 +47,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         return match ($code) {
             $this->projectMargin->scheduling()->code => $this->projectMargin->scheduling(),
             $this->budgetPlanFact->scheduling()->code => $this->budgetPlanFact->scheduling(),
+            $this->baselineScheduleVariance->scheduling()->code => $this->baselineScheduleVariance->scheduling(),
             $this->projectLaborCost->scheduling()->code => $this->projectLaborCost->scheduling(),
             $this->payrollReadiness->scheduling()->code => $this->payrollReadiness->scheduling(),
             $this->workforceCapacity->scheduling()->code => $this->workforceCapacity->scheduling(),
@@ -50,6 +57,8 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->inventoryRisk->scheduling()->code => $this->inventoryRisk->scheduling(),
             $this->attendanceExecution->scheduling()->code => $this->attendanceExecution->scheduling(),
             $this->qualityDefectFlow->scheduling()->code => $this->qualityDefectFlow->scheduling(),
+            $this->safetyIncidentActions->scheduling()->code => $this->safetyIncidentActions->scheduling(),
+            $this->workforceAdmission->scheduling()->code => $this->workforceAdmission->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -81,6 +81,8 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceA
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionCandidateContract;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -109,6 +111,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         ));
         $this->app->singleton(ProjectMarginBuiltinPublishedReport::class, fn (Application $app): ProjectMarginBuiltinPublishedReport => new ProjectMarginBuiltinPublishedReport(
             $app->make(\App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract::class),
+        ));
+        $this->app->singleton(BaselineScheduleVarianceCandidateContract::class);
+        $this->app->singleton(BaselineScheduleVarianceBuiltinPublishedReport::class, fn (Application $app): BaselineScheduleVarianceBuiltinPublishedReport => new BaselineScheduleVarianceBuiltinPublishedReport(
+            $app->make(BaselineScheduleVarianceCandidateContract::class),
         ));
         $this->app->singleton(ProjectLaborCostBuiltinPublishedReport::class, fn (Application $app): ProjectLaborCostBuiltinPublishedReport => new ProjectLaborCostBuiltinPublishedReport(
             $app->make(ProjectLaborCostCandidateContract::class),
@@ -156,6 +162,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
             fn (Application $app): BuiltinPublishedReportDefinitionRegistry => new BuiltinPublishedReportDefinitionRegistry(
                 $app->make(ProjectMarginBuiltinPublishedReport::class),
                 $app->make(BudgetPlanFactBuiltinPublishedReport::class),
+                $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class),
                 $app->make(ProjectLaborCostBuiltinPublishedReport::class),
                 $app->make(PayrollReadinessBuiltinPublishedReport::class),
                 $app->make(WorkforceCapacityBuiltinPublishedReport::class),
@@ -176,9 +183,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleSnapshotService.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleSnapshotService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\ScheduleManagement\Reporting;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -14,6 +16,7 @@ use App\BusinessModules\Features\ScheduleManagement\Models\ScheduleBaselineVersi
 use App\BusinessModules\Features\ScheduleManagement\Reporting\DTO\BaselineScheduleTaskSource;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\DTO\BaselineScheduleVarianceRow;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\Models\BaselineScheduleSnapshot;
+use App\Enums\Schedule\TaskStatusEnum;
 use App\Models\ProjectSchedule;
 use App\Models\ScheduleTask;
 use App\Support\Reporting\DeterministicObjectSpool;
@@ -194,6 +197,7 @@ final readonly class BaselineScheduleSnapshotService
         ) {
             throw new InvalidArgumentException('baseline_schedule_materialization_identity_invalid');
         }
+        $this->assertPublicFilterValues($query);
         $asOfFilter = $query->filters->values['as_of'] ?? null;
         if ($asOfFilter !== null
             && (! is_string($asOfFilter)
@@ -391,7 +395,10 @@ final readonly class BaselineScheduleSnapshotService
         }
 
         $metricSpool = new DeterministicObjectSpool;
+        $baselineMissingTasks = 0;
+        $criticalTasks = 0;
         $criticalDelayedTasks = 0;
+        $delayedTasks = 0;
         $overdueTasks = 0;
         $unknown = false;
         foreach ($sourceSpool->items() as $sourcePayload) {
@@ -403,6 +410,9 @@ final readonly class BaselineScheduleSnapshotService
                 $sourceRow['source'],
                 $query->asOf,
             );
+            $baselineMissingTasks += (int) ($metric->warningCodes !== []);
+            $criticalTasks += (int) $metric->critical;
+            $delayedTasks += (int) (($metric->endVarianceDays ?? 0) > 0);
             $criticalDelayedTasks += (int) (
                 $metric->critical && ($metric->endVarianceDays ?? 0) > 0
             );
@@ -421,6 +431,10 @@ final readonly class BaselineScheduleSnapshotService
             );
         }
         $totals = [
+            'task_count' => $metricSpool->count(),
+            'baseline_missing_tasks' => $baselineMissingTasks,
+            'critical_tasks' => $criticalTasks,
+            'delayed_tasks' => $delayedTasks,
             'critical_delayed_tasks' => $criticalDelayedTasks,
             'overdue_tasks' => $overdueTasks,
             'unknown_metrics' => $unknown ? ['baseline_variance'] : [],
@@ -564,6 +578,7 @@ final readonly class BaselineScheduleSnapshotService
         return array_map(
             static fn (string $id): array => ['id' => $id],
             [
+                'row_key',
                 'wbs_code',
                 'task_name',
                 'planned_start',
@@ -572,8 +587,12 @@ final readonly class BaselineScheduleSnapshotService
                 'end_variance_days',
                 'duration_variance_days',
                 'total_float_days',
+                'free_float_days',
                 'critical',
+                'overdue',
+                'overdue_days',
                 'status',
+                'warning_codes',
             ],
         );
     }
@@ -588,6 +607,26 @@ final readonly class BaselineScheduleSnapshotService
             && $this->matches($values['contractor_ids'] ?? [], $state->contractorId)
             && $this->matches($values['statuses'] ?? [], $state->status)
             && (! array_key_exists('critical', $values) || (bool) $values['critical'] === $state->critical);
+    }
+
+    private function assertPublicFilterValues(ReportQuery $query): void
+    {
+        $statuses = $query->filters->values['statuses'] ?? [];
+        $allowedStatuses = array_map(
+            static fn (TaskStatusEnum $status): string => $status->value,
+            TaskStatusEnum::cases(),
+        );
+        if (! is_array($statuses)
+            || ! array_is_list($statuses)
+            || array_filter(
+                $statuses,
+                static fn (mixed $status): bool => ! is_string($status)
+                    || ! in_array($status, $allowedStatuses, true),
+            ) !== []
+            || (array_key_exists('critical', $query->filters->values)
+                && ! is_bool($query->filters->values['critical']))) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+        }
     }
 
     private function sourceIdentity(array $sourceRow): array

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceBuiltinPublishedReport.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ScheduleManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class BaselineScheduleVarianceBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+
+    public const RENDERER_VERSION = '1.0.0';
+
+    public const MANIFEST_ORDINAL = 6;
+
+    public function __construct(private BaselineScheduleVarianceCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            BaselineScheduleVarianceCandidateContract::CODE,
+            'reports.catalog.baseline_schedule_variance',
+            ReportCatalogGroup::PROJECTS,
+            'schedule',
+            'task_baseline_as_of',
+            1,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(BaselineScheduleVarianceCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => BaselineScheduleVarianceCandidateContract::CODE,
+            'title_key' => 'reports.catalog.baseline_schedule_variance',
+            'catalog_group' => 'projects',
+            'category' => 'schedule',
+            'grain' => 'task_baseline_as_of',
+            'wave' => 1,
+            'source_module' => 'schedule-management',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => [
+                'contract' => self::CONTRACT_VERSION,
+                'formula' => BaselineScheduleVarianceCandidateContract::FORMULA_VERSION,
+                'source_schema' => BaselineScheduleVarianceCandidateContract::SOURCE_SCHEMA_VERSION,
+                'renderer' => self::RENDERER_VERSION,
+            ],
+            'semantic_fingerprints' => [
+                'formula' => BaselineScheduleVarianceCandidateContract::FORMULA_HASH,
+                'source' => BaselineScheduleVarianceCandidateContract::SOURCE_HASH,
+            ],
+            'permissions' => [
+                'view' => ['schedule.view'],
+                'export' => ['schedule.reports.export'],
+                'sensitive' => [],
+                'audit' => [],
+            ],
+            'readiness' => [
+                'source' => 'ready',
+                'formula' => 'ready',
+                'delivery' => 'verified',
+                'publication' => 'published',
+            ],
+            'capabilities' => [
+                'supports_subscriptions' => false,
+                'reproducible_scheduled_snapshot' => false,
+            ],
+        ];
+    }
+}

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceCandidateContract.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceCandidateContract.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ScheduleManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\DTO\BaselineScheduleVarianceRow;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class BaselineScheduleVarianceCandidateContract
+{
+    public const CODE = 'baseline_schedule_variance';
+
+    public const FORMULA_VERSION = 'schedule.baseline-variance.v1';
+
+    public const SOURCE_SCHEMA_VERSION = 'schedule_baseline_v1';
+
+    public const FORMULA_HASH = 'c8c3b6d05e673a04d91ea3778d2b7c1a760cce39ab1ff00fbd184bb67d3b4d1a';
+
+    public const SOURCE_HASH = '41f6e0b39d2ae0fbb17ce1b5ebe3414544aad99fb59a06e79070bd059a8e4565';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'as_of', 'required' => true],
+            ['id' => 'statuses', 'required' => false],
+            ['id' => 'critical', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'wbs_code', 'task_name', 'planned_start', 'planned_end',
+            'start_variance_days', 'end_variance_days', 'duration_variance_days',
+            'total_float_days', 'free_float_days', 'critical', 'overdue',
+            'overdue_days', 'status', 'warning_codes',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return [
+            ['id' => 'end_variance_days', 'direction' => ReportSortDirection::DESC->value],
+            ['id' => 'total_float_days', 'direction' => ReportSortDirection::ASC->value],
+            ['id' => 'task_name', 'direction' => ReportSortDirection::ASC->value],
+            ['id' => 'wbs_code', 'direction' => ReportSortDirection::ASC->value],
+        ];
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(BaselineScheduleVarianceRow::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(BaselineScheduleSnapshotService::class))) {
+            throw new InvalidArgumentException('baseline_schedule_variance_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'schedule-management'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['schedule.view']
+            || $definition->permissionPolicy->exportPermissions !== ['schedule.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== []) {
+            throw new InvalidArgumentException('baseline_schedule_variance_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
+            throw new InvalidArgumentException('baseline_schedule_variance_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('baseline_schedule_variance_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(
+                CanonicalJson::encode($item),
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            ),
+            $items,
+        );
+    }
+}

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVariancePublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVariancePublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ScheduleManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class BaselineScheduleVariancePublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private BaselineScheduleVarianceReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(BaselineScheduleVarianceCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+
+            throw $exception;
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceQueryService.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceQueryService.php
@@ -32,6 +32,7 @@ final readonly class BaselineScheduleVarianceQueryService implements ReportRowQu
             BaselineScheduleSnapshot::class,
             [
                 'variance_days' => 'variance_days',
+                'end_variance_days' => 'variance_days',
                 'total_float_days' => 'total_float_days',
                 'planned_start' => 'planned_start',
                 'planned_end' => 'planned_end',

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceReportBindingFactory.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceReportBindingFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ScheduleManagement\Reporting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Readiness\BaselineScheduleVarianceReadinessProbe;
+
+final readonly class BaselineScheduleVarianceReportBindingFactory
+{
+    public function __construct(
+        private BaselineScheduleVarianceProvider $provider,
+        private BaselineScheduleVarianceQueryService $query,
+        private BaselineScheduleVarianceReadinessProbe $readiness,
+        private BaselineScheduleVarianceCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->query,
+            $this->query,
+            $this->readiness,
+        );
+    }
+}

--- a/app/BusinessModules/Features/ScheduleManagement/ScheduleManagementModule.php
+++ b/app/BusinessModules/Features/ScheduleManagement/ScheduleManagementModule.php
@@ -87,6 +87,7 @@ class ScheduleManagementModule implements ModuleInterface, ConfigurableInterface
             'schedule.assign',
             'schedule.approve',
             'schedule.export',
+            'schedule.reports.export',
             'schedule.notifications'
         ];
     }

--- a/app/BusinessModules/Features/ScheduleManagement/ScheduleManagementServiceProvider.php
+++ b/app/BusinessModules/Features/ScheduleManagement/ScheduleManagementServiceProvider.php
@@ -1,7 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\BusinessModules\Features\ScheduleManagement;
 
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleSnapshotService;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVariancePublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceQueryService;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceReportBindingFactory;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\HistoricalScheduleTaskStateQuery;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Readiness\BaselineScheduleVarianceReadinessProbe;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\LookaheadReadiness\Contracts\LookaheadReadinessAuthorizer;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\LookaheadReadiness\Contracts\LookaheadReadinessSourceStore;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\LookaheadReadiness\Services\EloquentLookaheadReadinessSourceStore;
@@ -28,10 +39,25 @@ class ScheduleManagementServiceProvider extends ServiceProvider
         $this->app->singleton(\App\BusinessModules\Features\ScheduleManagement\Services\LookaheadPlanningService::class);
         $this->app->bind(LookaheadReadinessSourceStore::class, EloquentLookaheadReadinessSourceStore::class);
         $this->app->bind(LookaheadReadinessAuthorizer::class, LaravelLookaheadReadinessAuthorizer::class);
+        $this->app->singleton(HistoricalScheduleTaskStateQuery::class);
+        $this->app->scoped(BaselineScheduleSnapshotService::class);
+        $this->app->scoped(BaselineScheduleVarianceProvider::class);
+        $this->app->scoped(BaselineScheduleVarianceQueryService::class);
+        $this->app->scoped(BaselineScheduleVarianceReadinessProbe::class);
+        $this->app->singleton(BaselineScheduleVarianceCandidateContract::class);
+        $this->app->scoped(BaselineScheduleVarianceReportBindingFactory::class);
+        $this->app->scoped(BaselineScheduleVariancePublishedRuntimeBindingRegistrar::class);
     }
 
     public function boot(): void
     {
+        $this->app->afterResolving(
+            ReportDefinitionBindingAssembler::class,
+            function (ReportDefinitionBindingAssembler $assembler): void {
+                $this->app->make(BaselineScheduleVariancePublishedRuntimeBindingRegistrar::class)->register($assembler);
+            },
+        );
+
         // Загружаем миграции
         $this->loadMigrations();
 

--- a/config/ModuleList/features/schedule-management.json
+++ b/config/ModuleList/features/schedule-management.json
@@ -33,7 +33,8 @@
     "schedule.lookahead.manage",
     "schedule.daily_plan.view",
     "schedule.daily_plan.manage",
-    "schedule.daily_plan.confirm"
+    "schedule.daily_plan.confirm",
+    "schedule.reports.export"
   ],
   
   "features": [

--- a/config/RoleDefinitions/admin/finance_admin.json
+++ b/config/RoleDefinitions/admin/finance_admin.json
@@ -120,7 +120,8 @@
     ],
     "schedule-management": [
       "schedule.view",
-      "schedule.export"
+      "schedule.export",
+      "schedule.reports.export"
     ],
     "payments": [
       "payments.dashboard.view",

--- a/config/RoleDefinitions/admin/web_admin.json
+++ b/config/RoleDefinitions/admin/web_admin.json
@@ -552,6 +552,7 @@
       "schedule.assign",
       "schedule.approve",
       "schedule.export",
+      "schedule.reports.export",
       "schedule.notifications"
     ],
     "brigades": [

--- a/config/RoleDefinitions/lk/accountant.json
+++ b/config/RoleDefinitions/lk/accountant.json
@@ -142,7 +142,8 @@
     ],
     "schedule-management": [
       "schedule.view",
-      "schedule.export"
+      "schedule.export",
+      "schedule.reports.export"
     ],
     "notifications": [
       "notifications.view",

--- a/config/RoleDefinitions/lk/organization_admin.json
+++ b/config/RoleDefinitions/lk/organization_admin.json
@@ -405,6 +405,7 @@
       "schedule.assign",
       "schedule.approve",
       "schedule.export",
+      "schedule.reports.export",
       "schedule.notifications"
     ],
     "notifications": [

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -45,6 +45,8 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceA
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionCandidateContract;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -75,6 +77,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
 
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $registry->published('budget_plan_fact')->code);
+        self::assertSame('baseline_schedule_variance', $registry->published('baseline_schedule_variance')->code);
         self::assertSame('project_labor_cost', $registry->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $registry->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $registry->published('workforce_capacity')->code);
@@ -88,6 +91,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('safety_incident_actions', $registry->published('safety_incident_actions')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
+        self::assertSame('baseline_schedule_variance', $app->make(ReportCatalogMetadataRegistry::class)->published('baseline_schedule_variance')->code);
         self::assertSame('project_labor_cost', $app->make(ReportCatalogMetadataRegistry::class)->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $app->make(ReportCatalogMetadataRegistry::class)->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $app->make(ReportCatalogMetadataRegistry::class)->published('workforce_capacity')->code);
@@ -101,6 +105,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('safety_incident_actions', $app->make(ReportCatalogMetadataRegistry::class)->published('safety_incident_actions')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
+        self::assertSame('baseline_schedule_variance', $app->make(ReportSchedulingCapabilityRegistry::class)->published('baseline_schedule_variance')->code);
         self::assertSame('project_labor_cost', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_labor_cost')->code);
         self::assertSame('payroll_readiness', $app->make(ReportSchedulingCapabilityRegistry::class)->published('payroll_readiness')->code);
         self::assertSame('workforce_capacity', $app->make(ReportSchedulingCapabilityRegistry::class)->published('workforce_capacity')->code);
@@ -119,6 +124,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         $builtins = new BuiltinPublishedReportDefinitionRegistry(
             $this->projectMargin(),
             new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract),
+            $this->baselineScheduleVariance(),
             $this->projectLaborCost(),
             $this->payrollReadiness(),
             $this->workforceCapacity(),
@@ -133,7 +139,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -153,6 +159,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         $registry = new BuiltinPublishedReportDefinitionRegistry(
             $this->projectMargin(),
             new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract),
+            $this->baselineScheduleVariance(),
             $this->projectLaborCost(),
             $this->payrollReadiness(),
             $this->workforceCapacity(),
@@ -168,6 +175,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
 
         $expectedModules = [
             'budget_plan_fact' => 'budgeting',
+            'baseline_schedule_variance' => 'schedule-management',
             'project_margin' => 'budgeting',
             'project_labor_cost' => 'time-tracking',
             'payroll_readiness' => 'workforce-management',
@@ -194,11 +202,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['attendance_execution', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -206,7 +214,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -253,6 +261,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function projectLaborCost(): ProjectLaborCostBuiltinPublishedReport
     {
         return new ProjectLaborCostBuiltinPublishedReport(new ProjectLaborCostCandidateContract);
+    }
+
+    private function baselineScheduleVariance(): BaselineScheduleVarianceBuiltinPublishedReport
+    {
+        return new BaselineScheduleVarianceBuiltinPublishedReport(new BaselineScheduleVarianceCandidateContract);
     }
 
     private function payrollReadiness(): PayrollReadinessBuiltinPublishedReport

--- a/tests/Unit/Reporting/WaveOne/BaselineScheduleVariancePublishedContractTest.php
+++ b/tests/Unit/Reporting/WaveOne/BaselineScheduleVariancePublishedContractTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\WaveOne;
+
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
+use PHPUnit\Framework\TestCase;
+
+final class BaselineScheduleVariancePublishedContractTest extends TestCase
+{
+    public function test_published_contract_keeps_scope_server_owned(): void
+    {
+        $contract = new BaselineScheduleVarianceCandidateContract;
+        $report = new BaselineScheduleVarianceBuiltinPublishedReport($contract);
+        $definition = $report->definition()->payload();
+
+        self::assertSame(
+            ['as_of', 'statuses', 'critical'],
+            array_column($definition->filters, 'id'),
+        );
+        self::assertNotContains('organization_id', array_column($definition->filters, 'id'));
+        self::assertNotContains('project_ids', array_column($definition->filters, 'id'));
+        self::assertSame(['schedule.view'], $definition->permissionPolicy->viewPermissions);
+        self::assertSame(['schedule.reports.export'], $definition->permissionPolicy->exportPermissions);
+        self::assertSame(['csv', 'xlsx'], $definition->formats);
+    }
+
+    public function test_runtime_fingerprints_match_owner_code(): void
+    {
+        $contract = new BaselineScheduleVarianceCandidateContract;
+
+        $contract->assertRuntimeMatches();
+        self::assertSame(64, strlen(BaselineScheduleVarianceCandidateContract::FORMULA_HASH));
+        self::assertSame(64, strlen(BaselineScheduleVarianceCandidateContract::SOURCE_HASH));
+    }
+}


### PR DESCRIPTION
## Что сделано
- опубликован серверный контракт отчёта baseline_schedule_variance на реальных данных графика
- контекст организации и проекта остаётся серверным; публичны только дата среза, статусы и признак критичности
- добавлены итоги, признаки просрочки, неизвестные значения при отсутствии базового плана и CSV/XLSX
- зарегистрировано право schedule.reports.export и выдача штатным ролям
- исправлена регистрация уже готовых отчётов по безопасности в каталоге

## Проверки
- PHP syntax для всех изменённых PHP-файлов
- JSON parse для manifest и role definitions
- git diff --check
- fingerprint formula/source

PHPUnit/Larastan локально недоступны: vendor отсутствует; полный набор выполняется CI.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated the new Baseline Schedule Variance report into the core reporting infrastructure registries.</li>
<li>Added support for Safety Management reports (Incident Actions and Workforce Admission) to the reporting registries.</li>
<li>Implemented the Baseline Schedule Variance report logic, including query services, binding factories, and snapshot services.</li>
<li>Updated module configuration and role definitions to include the new schedule management reporting capabilities.</li>
<li>Added unit tests to verify the new report definitions and contracts.</li>
</ul></div>