### PR TITLE
feat: отчёт SLA заказчиков

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -24,6 +24,7 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
 {
@@ -45,9 +46,10 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
         SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
+        CustomerSlaBuiltinPublishedReport $customerSla,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $baselineScheduleVariance->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $baselineScheduleVariance->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $customerSla->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
 {
@@ -40,6 +41,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
         private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
+        private CustomerSlaBuiltinPublishedReport $customerSla,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -59,6 +61,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->qualityDefectFlow->metadata()->code => $this->qualityDefectFlow->metadata(),
             $this->safetyIncidentActions->metadata()->code => $this->safetyIncidentActions->metadata(),
             $this->workforceAdmission->metadata()->code => $this->workforceAdmission->metadata(),
+            $this->customerSla->metadata()->code => $this->customerSla->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
 {
@@ -40,6 +41,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
         private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
+        private CustomerSlaBuiltinPublishedReport $customerSla,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -59,6 +61,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->qualityDefectFlow->scheduling()->code => $this->qualityDefectFlow->scheduling(),
             $this->safetyIncidentActions->scheduling()->code => $this->safetyIncidentActions->scheduling(),
             $this->workforceAdmission->scheduling()->code => $this->workforceAdmission->scheduling(),
+            $this->customerSla->scheduling()->code => $this->customerSla->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };
     }

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -83,6 +83,8 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Safe
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -115,6 +117,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(BaselineScheduleVarianceCandidateContract::class);
         $this->app->singleton(BaselineScheduleVarianceBuiltinPublishedReport::class, fn (Application $app): BaselineScheduleVarianceBuiltinPublishedReport => new BaselineScheduleVarianceBuiltinPublishedReport(
             $app->make(BaselineScheduleVarianceCandidateContract::class),
+        ));
+        $this->app->singleton(CustomerSlaCandidateContract::class);
+        $this->app->singleton(CustomerSlaBuiltinPublishedReport::class, fn (Application $app): CustomerSlaBuiltinPublishedReport => new CustomerSlaBuiltinPublishedReport(
+            $app->make(CustomerSlaCandidateContract::class),
         ));
         $this->app->singleton(ProjectLaborCostBuiltinPublishedReport::class, fn (Application $app): ProjectLaborCostBuiltinPublishedReport => new ProjectLaborCostBuiltinPublishedReport(
             $app->make(ProjectLaborCostCandidateContract::class),
@@ -174,6 +180,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(QualityDefectFlowBuiltinPublishedReport::class),
                 $app->make(SafetyIncidentActionsBuiltinPublishedReport::class),
                 $app->make(WorkforceAdmissionBuiltinPublishedReport::class),
+                $app->make(CustomerSlaBuiltinPublishedReport::class),
             ),
         );
         $this->app->singleton(
@@ -183,9 +190,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/Providers/CustomerReportingServiceProvider.php
+++ b/app/Providers/CustomerReportingServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
+use App\Services\Customer\Reporting\Sla\CustomerSlaPublishedRuntimeBindingRegistrar;
+use App\Services\Customer\Reporting\Sla\CustomerSlaReportBindingFactory;
+use App\Services\Customer\Reporting\Sla\DrillDown\CustomerSlaDrillDownProvider;
+use App\Services\Customer\Reporting\Sla\Providers\CustomerSlaReportProvider;
+use App\Services\Customer\Reporting\Sla\Queries\CustomerSlaRowQuery;
+use App\Services\Customer\Reporting\Sla\Readiness\CustomerSlaReadinessProbe;
+use App\Services\Customer\Reporting\Sla\Services\CustomerSlaClock;
+use App\Services\Customer\Reporting\Sla\Services\CustomerSlaFormula;
+use App\Services\Customer\Reporting\Sla\Services\CustomerSlaSnapshotMaterializer;
+use Illuminate\Support\ServiceProvider;
+
+final class CustomerReportingServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(CustomerSlaClock::class);
+        $this->app->singleton(CustomerSlaFormula::class);
+        $this->app->scoped(CustomerSlaSnapshotMaterializer::class);
+        $this->app->scoped(CustomerSlaReportProvider::class);
+        $this->app->scoped(CustomerSlaRowQuery::class);
+        $this->app->scoped(CustomerSlaDrillDownProvider::class);
+        $this->app->scoped(CustomerSlaReadinessProbe::class);
+        $this->app->singleton(CustomerSlaCandidateContract::class);
+        $this->app->scoped(CustomerSlaReportBindingFactory::class);
+        $this->app->scoped(CustomerSlaPublishedRuntimeBindingRegistrar::class);
+    }
+
+    public function boot(): void
+    {
+        $this->app->resolving(
+            ReportDefinitionBindingAssembler::class,
+            function (ReportDefinitionBindingAssembler $assembler): void {
+                $this->app->make(CustomerSlaPublishedRuntimeBindingRegistrar::class)->register($assembler);
+            },
+        );
+    }
+}

--- a/app/Services/Customer/Reporting/Sla/CustomerSlaBuiltinPublishedReport.php
+++ b/app/Services/Customer/Reporting/Sla/CustomerSlaBuiltinPublishedReport.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Customer\Reporting\Sla;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class CustomerSlaBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+    public const RENDERER_VERSION = '1.0.0';
+    public const MANIFEST_ORDINAL = 28;
+
+    public function __construct(private CustomerSlaCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(self::code(), 'reports.catalog.customer_sla', ReportCatalogGroup::PARTNERS_CUSTOMERS, 'customers', 'request_event_customer', 3, self::MANIFEST_ORDINAL);
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(self::code(), false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => self::code(), 'title_key' => 'reports.catalog.customer_sla',
+            'catalog_group' => 'partners_customers', 'category' => 'customers',
+            'grain' => 'request_event_customer', 'wave' => 3, 'source_module' => 'reports',
+            'core_access_mode' => 'reporting_workspace', 'filters' => $this->contract->filters(),
+            'columns' => $this->contract->columns(), 'sorts' => $this->contract->sorts(),
+            'formats' => $this->contract->formats(),
+            'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => CustomerSlaCandidateContract::FORMULA_VERSION, 'source_schema' => CustomerSlaCandidateContract::SOURCE_SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION],
+            'semantic_fingerprints' => ['formula' => CustomerSlaCandidateContract::FORMULA_HASH, 'source' => CustomerSlaCandidateContract::SOURCE_HASH],
+            'permissions' => ['view' => ['customer.sla_report.view'], 'export' => ['customer.sla_report.export'], 'sensitive' => [], 'audit' => []],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+
+    private static function code(): string
+    {
+        return CustomerSlaCandidateContract::CODE;
+    }
+}

--- a/app/Services/Customer/Reporting/Sla/CustomerSlaCandidateContract.php
+++ b/app/Services/Customer/Reporting/Sla/CustomerSlaCandidateContract.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Customer\Reporting\Sla;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\Services\Customer\Reporting\Sla\Services\CustomerSlaFormula;
+use App\Services\Customer\Reporting\Sla\Services\CustomerSlaSnapshotMaterializer;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class CustomerSlaCandidateContract
+{
+    public const CODE = 'customer_sla';
+    public const FORMULA_VERSION = 'customer-sla.v1';
+    public const SOURCE_SCHEMA_VERSION = 'customer-sla.v1';
+    public const FORMULA_HASH = '63e1999fa8411abbdb0ea38b5012a61e587a11ca7150bde8c3245f3ebed9319';
+    public const SOURCE_HASH = '2647891111121878bf6fdffec2df91c1b0c6595167d421a6edeb042fe3a0aa42';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'period_from', 'required' => true],
+            ['id' => 'period_to', 'required' => true],
+            ['id' => 'workflow_types', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'project_id', 'customer_organization_id', 'workflow_type',
+            'workflow_id', 'priority', 'status', 'opened_at', 'first_response_seconds',
+            'resolution_seconds', 'open_aging_seconds', 'first_response_breached',
+            'resolution_breached', 'actor_side_complete',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return array_map(static fn (string $id): array => [
+            'id' => $id,
+            'direction' => $id === 'opened_at' ? ReportSortDirection::DESC->value : ReportSortDirection::ASC->value,
+        ], ['opened_at', 'project_id', 'customer_organization_id', 'workflow_type', 'workflow_id', 'row_key']);
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(CustomerSlaFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(CustomerSlaSnapshotMaterializer::class))) {
+            throw new InvalidArgumentException('customer_sla_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'reports'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::REPORTING_WORKSPACE
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['customer.sla_report.view']
+            || $definition->permissionPolicy->exportPermissions !== ['customer.sla_report.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== []) {
+            throw new InvalidArgumentException('customer_sla_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
+            throw new InvalidArgumentException('customer_sla_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('customer_sla_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR),
+            $items,
+        );
+    }
+}

--- a/app/Services/Customer/Reporting/Sla/CustomerSlaPublishedRuntimeBindingRegistrar.php
+++ b/app/Services/Customer/Reporting/Sla/CustomerSlaPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Customer\Reporting\Sla;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class CustomerSlaPublishedRuntimeBindingRegistrar
+{
+    public function __construct(private ReportDefinitionRegistry $definitions, private CustomerSlaReportBindingFactory $bindings) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(CustomerSlaCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+            throw $exception;
+        }
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/Services/Customer/Reporting/Sla/CustomerSlaReportBindingFactory.php
+++ b/app/Services/Customer/Reporting/Sla/CustomerSlaReportBindingFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Customer\Reporting\Sla;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\Services\Customer\Reporting\Sla\DrillDown\CustomerSlaDrillDownProvider;
+use App\Services\Customer\Reporting\Sla\Providers\CustomerSlaReportProvider;
+use App\Services\Customer\Reporting\Sla\Queries\CustomerSlaRowQuery;
+use App\Services\Customer\Reporting\Sla\Readiness\CustomerSlaReadinessProbe;
+
+final readonly class CustomerSlaReportBindingFactory
+{
+    public function __construct(private CustomerSlaReportProvider $provider, private CustomerSlaRowQuery $query, private CustomerSlaDrillDownProvider $drillDown, private CustomerSlaReadinessProbe $readiness, private CustomerSlaCandidateContract $contract) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding($definition->code, $definition->definitionHash, $definition->contractVersion, $this->provider, $this->query, $this->drillDown, $this->readiness);
+    }
+}

--- a/app/Services/Customer/Reporting/Sla/Providers/CustomerSlaReportProvider.php
+++ b/app/Services/Customer/Reporting/Sla/Providers/CustomerSlaReportProvider.php
@@ -62,6 +62,10 @@ final readonly class CustomerSlaReportProvider implements ReportDataProvider
         $overdue = (clone $rows)->where(static function ($builder): void {
             $builder->where('first_response_breached', true)->orWhere('resolution_breached', true);
         })->count();
+        $firstResponseBreached = (clone $rows)->where('first_response_breached', true)->count();
+        $resolutionBreached = (clone $rows)->where('resolution_breached', true)->count();
+        $firstResponseKnown = (clone $rows)->whereNotNull('first_response_seconds')->count();
+        $resolutionKnown = (clone $rows)->whereNotNull('resolution_seconds')->count();
         $qualityStatus = $knownActorSides === $rowCount
             ? ReportQualityStatus::COMPLETE
             : ReportQualityStatus::PARTIAL;
@@ -73,7 +77,15 @@ final readonly class CustomerSlaReportProvider implements ReportDataProvider
                 DateTimeImmutable::createFromInterface($record->generated_at),
                 $record->stale_at === null ? null : DateTimeImmutable::createFromInterface($record->stale_at),
             ),
-            ['workflow_count' => $rowCount, 'overdue_count' => $overdue],
+            [
+                'workflow_count' => $rowCount,
+                'overdue_count' => $overdue,
+                'first_response_breached_count' => $firstResponseBreached,
+                'resolution_breached_count' => $resolutionBreached,
+                'first_response_known_count' => $firstResponseKnown,
+                'resolution_known_count' => $resolutionKnown,
+                'actor_side_unknown_count' => $rowCount - $knownActorSides,
+            ],
             $snapshot->staleAt !== null && $snapshot->staleAt <= new DateTimeImmutable()
                 ? ReportFreshnessStatus::STALE
                 : ReportFreshnessStatus::FRESH,
@@ -107,13 +119,20 @@ final readonly class CustomerSlaReportProvider implements ReportDataProvider
                 null,
             ),
             [
-                ['id' => 'opened_at', 'type' => 'datetime'],
+                ['id' => 'row_key', 'type' => 'string'],
+                ['id' => 'project_id', 'type' => 'integer'],
+                ['id' => 'customer_organization_id', 'type' => 'integer'],
                 ['id' => 'workflow_type', 'type' => 'string'],
+                ['id' => 'workflow_id', 'type' => 'integer'],
+                ['id' => 'priority', 'type' => 'string'],
+                ['id' => 'status', 'type' => 'string'],
+                ['id' => 'opened_at', 'type' => 'datetime'],
                 ['id' => 'first_response_seconds', 'type' => 'integer'],
                 ['id' => 'resolution_seconds', 'type' => 'integer'],
                 ['id' => 'open_aging_seconds', 'type' => 'integer'],
                 ['id' => 'first_response_breached', 'type' => 'boolean'],
                 ['id' => 'resolution_breached', 'type' => 'boolean'],
+                ['id' => 'actor_side_complete', 'type' => 'boolean'],
             ],
             ['admin_only' => true, 'drill_down' => true, 'export_formats' => ['csv', 'xlsx']],
         );

--- a/app/Services/Customer/Reporting/Sla/Readiness/CustomerSlaReadinessProbe.php
+++ b/app/Services/Customer/Reporting/Sla/Readiness/CustomerSlaReadinessProbe.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Customer\Reporting\Sla\Readiness;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceReadinessProbe;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -32,9 +34,11 @@ final readonly class CustomerSlaReadinessProbe implements ReportSourceReadinessP
         ReportExecutionContext $context,
         ReportQuery $query,
     ): ReportSourceReadiness {
-        $issues = DB::table('customer_issues')
+        [$periodFrom, $periodTo, $workflowTypes] = $this->filters($query);
+        $issues = ! in_array('issue', $workflowTypes, true) ? collect() : DB::table('customer_issues')
             ->where('organization_id', $context->scope->organizationId)
             ->where('created_at', '<=', $query->asOf)
+            ->whereBetween('created_at', [$periodFrom, $periodTo])
             ->when(
                 $query->scope->projectIds !== [],
                 fn ($builder) => $builder->whereIn('project_id', $query->scope->projectIds),
@@ -47,9 +51,10 @@ final readonly class CustomerSlaReadinessProbe implements ReportSourceReadinessP
                 'created_at' => (string) $row->created_at,
                 'updated_at' => (string) $row->updated_at,
             ]);
-        $requests = DB::table('customer_requests')
+        $requests = ! in_array('request', $workflowTypes, true) ? collect() : DB::table('customer_requests')
             ->where('organization_id', $context->scope->organizationId)
             ->where('created_at', '<=', $query->asOf)
+            ->whereBetween('created_at', [$periodFrom, $periodTo])
             ->when(
                 $query->scope->projectIds !== [],
                 fn ($builder) => $builder->whereIn('project_id', $query->scope->projectIds),
@@ -137,6 +142,34 @@ final readonly class CustomerSlaReadinessProbe implements ReportSourceReadinessP
             hash('sha256', CanonicalJson::encode($output)),
             $ready ? CarbonImmutable::now('UTC') : null,
         );
+    }
+
+    private function filters(ReportQuery $query): array
+    {
+        $from = $query->filters->values['period_from'] ?? null;
+        $to = $query->filters->values['period_to'] ?? null;
+        $types = $query->filters->values['workflow_types'] ?? ['issue', 'request'];
+        if (! is_string($from)
+            || ! is_string($to)
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/D', $from) !== 1
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/D', $to) !== 1
+            || ! is_array($types)
+            || ! array_is_list($types)
+            || $types === []
+            || array_filter($types, static fn (mixed $type): bool => ! is_string($type)
+                || ! in_array($type, ['issue', 'request'], true)) !== []) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+        }
+        $periodFrom = CarbonImmutable::createFromFormat('!Y-m-d', $from, 'UTC');
+        $periodTo = CarbonImmutable::createFromFormat('!Y-m-d', $to, 'UTC')?->endOfDay();
+        if (! $periodFrom instanceof CarbonImmutable
+            || ! $periodTo instanceof CarbonImmutable
+            || $periodFrom->greaterThan($periodTo)
+            || $periodTo->toDateString() > CarbonImmutable::instance($query->asOf)->toDateString()) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+        }
+
+        return [$periodFrom, $periodTo, array_values(array_unique($types))];
     }
 
     private function selectPolicy(\Illuminate\Support\Collection $policies, object $event): ?object

--- a/app/Services/Customer/Reporting/Sla/Services/CustomerSlaSnapshotMaterializer.php
+++ b/app/Services/Customer/Reporting/Sla/Services/CustomerSlaSnapshotMaterializer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Customer\Reporting\Sla\Services;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -39,6 +41,12 @@ final readonly class CustomerSlaSnapshotMaterializer
         ) {
             throw new InvalidArgumentException('customer_sla_context_invalid');
         }
+        [$periodFrom, $periodTo, $workflowTypes] = $this->filters($query);
+        $normalizedFilters = [
+            'period_from' => $periodFrom->toDateString(),
+            'period_to' => $periodTo->toDateString(),
+            'workflow_types' => $workflowTypes,
+        ];
         $events = CustomerWorkflowEvent::query()
             ->where('organization_id', $query->scope->organizationId)
             ->where('occurred_at', '<=', $query->asOf)
@@ -51,21 +59,15 @@ final readonly class CustomerSlaSnapshotMaterializer
             ->orderBy('occurred_at')
             ->orderBy('id')
             ->get();
-        if ($events->isEmpty()) {
-            throw new InvalidArgumentException('customer_sla_event_source_unavailable');
-        }
         $policies = CustomerSlaPolicyVersion::query()
             ->where('organization_id', $query->scope->organizationId)
             ->where('effective_from', '<=', $query->asOf)
             ->orderBy('effective_from')
             ->orderBy('id')
             ->get();
-        if ($policies->isEmpty()) {
-            throw new InvalidArgumentException('customer_sla_policy_unavailable');
-        }
-
         $sourceHash = hash('sha256', CanonicalJson::encode([
             'as_of' => $query->asOf->format(DATE_ATOM),
+            'filters' => $normalizedFilters,
             'event_hashes' => $events->pluck('evidence_hash')->all(),
             'policy_versions' => $policies->map(static fn (CustomerSlaPolicyVersion $policy): array => [
                 'id' => (int) $policy->id,
@@ -76,7 +78,24 @@ final readonly class CustomerSlaSnapshotMaterializer
         ]));
         $generatedAt = CarbonImmutable::now('UTC');
         $snapshotId = (string) Str::ulid();
-        $groups = $events->groupBy(static fn (CustomerWorkflowEvent $event): string => $event->workflow_type.':'.$event->workflow_id);
+        $groups = $events
+            ->groupBy(static fn (CustomerWorkflowEvent $event): string => $event->workflow_type.':'.$event->workflow_id)
+            ->filter(static function (Collection $workflowEvents) use ($periodFrom, $periodTo, $workflowTypes): bool {
+                $opened = $workflowEvents->first(
+                    static fn (CustomerWorkflowEvent $event): bool => $event->event_type === CustomerWorkflowEventType::OPENED,
+                );
+
+                if (! $opened instanceof CustomerWorkflowEvent
+                    || ! in_array($opened->workflow_type, $workflowTypes, true)) {
+                    return false;
+                }
+                $openedAt = CarbonImmutable::instance($opened->occurred_at);
+
+                return ! $openedAt->lessThan($periodFrom) && ! $openedAt->greaterThan($periodTo);
+            });
+        if ($groups->isNotEmpty() && $policies->isEmpty()) {
+            throw new InvalidArgumentException('customer_sla_policy_unavailable');
+        }
 
         DB::transaction(function () use (
             $query,
@@ -86,6 +105,7 @@ final readonly class CustomerSlaSnapshotMaterializer
             $generatedAt,
             $snapshotId,
             $groups,
+            $normalizedFilters,
         ): void {
             DB::table('organizations')
                 ->where('id', $query->scope->organizationId)
@@ -107,7 +127,7 @@ final readonly class CustomerSlaSnapshotMaterializer
                 'source_hash' => $sourceHash,
                 'formula_version' => self::FORMULA_VERSION,
                 'scope_identity' => $query->scope->canonicalIdentity(),
-                'filters' => $query->filters->values,
+                'filters' => $normalizedFilters,
                 'as_of' => $query->asOf,
                 'generated_at' => $generatedAt,
                 'stale_at' => $generatedAt->addMinutes(15),
@@ -200,6 +220,37 @@ final readonly class CustomerSlaSnapshotMaterializer
             ReportSnapshotClassification::OPERATIONAL,
             null,
         );
+    }
+
+    private function filters(ReportQuery $query): array
+    {
+        $from = $query->filters->values['period_from'] ?? null;
+        $to = $query->filters->values['period_to'] ?? null;
+        $types = $query->filters->values['workflow_types'] ?? ['issue', 'request'];
+        if (! is_string($from)
+            || ! is_string($to)
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/D', $from) !== 1
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/D', $to) !== 1
+            || ! is_array($types)
+            || ! array_is_list($types)
+            || $types === []
+            || array_filter($types, static fn (mixed $type): bool => ! is_string($type)
+                || ! in_array($type, ['issue', 'request'], true)) !== []) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+        }
+        $periodFrom = CarbonImmutable::createFromFormat('!Y-m-d', $from, 'UTC');
+        $periodTo = CarbonImmutable::createFromFormat('!Y-m-d', $to, 'UTC')?->endOfDay();
+        if (! $periodFrom instanceof CarbonImmutable
+            || ! $periodTo instanceof CarbonImmutable
+            || $periodFrom->greaterThan($periodTo)
+            || $periodTo->toDateString() > CarbonImmutable::instance($query->asOf)->toDateString()) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+        }
+
+        $types = array_values(array_unique($types));
+        sort($types, SORT_STRING);
+
+        return [$periodFrom, $periodTo, $types];
     }
 
     private function selectPolicy(Collection $policies, CustomerWorkflowEvent $event): CustomerSlaPolicyVersion

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,6 +2,7 @@
 
 return [
     App\Providers\EstimateGenerationIntegrationServiceProvider::class,
+    App\Providers\CustomerReportingServiceProvider::class,
     App\BusinessModules\Addons\EstimateGeneration\EstimateGenerationServiceProvider::class,
     App\BusinessModules\Core\Mdm\MdmServiceProvider::class,
     App\BusinessModules\Core\Payments\PaymentsServiceProvider::class,

--- a/config/RoleDefinitions/admin/web_admin.json
+++ b/config/RoleDefinitions/admin/web_admin.json
@@ -22,6 +22,8 @@
     "admin.contracts.edit",
     "admin.reports.view",
     "admin.reports.export",
+    "customer.sla_report.view",
+    "customer.sla_report.export",
     "admin.catalogs.manage",
     "mdm.view",
     "mdm.manage",

--- a/config/RoleDefinitions/lk/organization_admin.json
+++ b/config/RoleDefinitions/lk/organization_admin.json
@@ -20,6 +20,8 @@
     "profile.edit",
     "admin.access",
     "admin.dashboard.view",
+    "customer.sla_report.view",
+    "customer.sla_report.export",
     "admin.projects.view",
     "admin.users.view",
     "admin.users.create",

--- a/config/RoleDefinitions/lk/organization_owner.json
+++ b/config/RoleDefinitions/lk/organization_owner.json
@@ -31,6 +31,8 @@
     "erp_controls.sod_conflicts.view",
     "erp_controls.sod_conflicts.resolve",
     "admin.*",
+    "customer.sla_report.view",
+    "customer.sla_report.export",
     "legal_archive.view",
     "legal_archive.create",
     "legal_archive.update",

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -47,6 +47,8 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Safe
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -89,6 +91,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('quality_defect_flow', $registry->published('quality_defect_flow')->code);
         self::assertSame('workforce_admission', $registry->published('workforce_admission')->code);
         self::assertSame('safety_incident_actions', $registry->published('safety_incident_actions')->code);
+        self::assertSame('customer_sla', $registry->published('customer_sla')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('baseline_schedule_variance', $app->make(ReportCatalogMetadataRegistry::class)->published('baseline_schedule_variance')->code);
@@ -103,6 +106,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('quality_defect_flow', $app->make(ReportCatalogMetadataRegistry::class)->published('quality_defect_flow')->code);
         self::assertSame('workforce_admission', $app->make(ReportCatalogMetadataRegistry::class)->published('workforce_admission')->code);
         self::assertSame('safety_incident_actions', $app->make(ReportCatalogMetadataRegistry::class)->published('safety_incident_actions')->code);
+        self::assertSame('customer_sla', $app->make(ReportCatalogMetadataRegistry::class)->published('customer_sla')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('baseline_schedule_variance', $app->make(ReportSchedulingCapabilityRegistry::class)->published('baseline_schedule_variance')->code);
@@ -117,6 +121,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('quality_defect_flow', $app->make(ReportSchedulingCapabilityRegistry::class)->published('quality_defect_flow')->code);
         self::assertSame('workforce_admission', $app->make(ReportSchedulingCapabilityRegistry::class)->published('workforce_admission')->code);
         self::assertSame('safety_incident_actions', $app->make(ReportSchedulingCapabilityRegistry::class)->published('safety_incident_actions')->code);
+        self::assertSame('customer_sla', $app->make(ReportSchedulingCapabilityRegistry::class)->published('customer_sla')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -136,10 +141,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->qualityDefectFlow(),
             $this->safetyIncidentActions(),
             $this->workforceAdmission(),
+            $this->customerSla(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -171,6 +177,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->qualityDefectFlow(),
             $this->safetyIncidentActions(),
             $this->workforceAdmission(),
+            $this->customerSla(),
         );
 
         $expectedModules = [
@@ -188,13 +195,17 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'quality_defect_flow' => 'quality-control',
             'safety_incident_actions' => 'safety-management',
             'workforce_admission' => 'safety-management',
+            'customer_sla' => 'reports',
         ];
 
         foreach ($expectedModules as $code => $module) {
             $definition = $registry->published($code)->payload();
 
             self::assertSame($module, $definition->sourceModule);
-            self::assertSame(ReportCoreAccessMode::SOURCE_MODULE_REPORT, $definition->coreAccessMode);
+            self::assertSame(
+                $code === 'customer_sla' ? ReportCoreAccessMode::REPORTING_WORKSPACE : ReportCoreAccessMode::SOURCE_MODULE_REPORT,
+                $definition->coreAccessMode,
+            );
         }
     }
 
@@ -202,11 +213,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->customerSla()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -214,7 +225,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->customerSla()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -316,5 +327,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function safetyIncidentActions(): SafetyIncidentActionsBuiltinPublishedReport
     {
         return new SafetyIncidentActionsBuiltinPublishedReport(new SafetyIncidentActionsCandidateContract);
+    }
+
+    private function customerSla(): CustomerSlaBuiltinPublishedReport
+    {
+        return new CustomerSlaBuiltinPublishedReport(new CustomerSlaCandidateContract);
     }
 }

--- a/tests/Unit/Reporting/Waves23/CustomerSlaPublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/CustomerSlaPublishedContractTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
+use PHPUnit\Framework\TestCase;
+
+final class CustomerSlaPublishedContractTest extends TestCase
+{
+    public function test_contract_exposes_only_business_filters(): void
+    {
+        $contract = new CustomerSlaCandidateContract;
+        $definition = (new CustomerSlaBuiltinPublishedReport($contract))->definition()->payload();
+
+        self::assertSame(['period_from', 'period_to', 'workflow_types'], array_column($definition->filters, 'id'));
+        self::assertNotContains('organization_id', array_column($definition->filters, 'id'));
+        self::assertNotContains('project_id', array_column($definition->filters, 'id'));
+        self::assertNotContains('customer_organization_id', array_column($definition->filters, 'id'));
+        self::assertSame(ReportCoreAccessMode::REPORTING_WORKSPACE, $definition->coreAccessMode);
+        self::assertSame(['customer.sla_report.view'], $definition->permissionPolicy->viewPermissions);
+        self::assertSame(['customer.sla_report.export'], $definition->permissionPolicy->exportPermissions);
+        self::assertSame(['csv', 'xlsx'], $definition->formats);
+    }
+
+    public function test_runtime_fingerprints_match_owner_code(): void
+    {
+        $contract = new CustomerSlaCandidateContract;
+
+        $contract->assertRuntimeMatches();
+        self::assertSame(64, strlen(CustomerSlaCandidateContract::FORMULA_HASH));
+        self::assertSame(64, strlen(CustomerSlaCandidateContract::SOURCE_HASH));
+    }
+}


### PR DESCRIPTION
## Что сделано
- опубликован R28 customer_sla на реальных событиях проблем и запросов заказчика
- период и тип обращения строго валидируются и входят в immutable snapshot identity
- организация и проект остаются server-owned; customer/project IDs не принимаются как фильтры
- SLA учитывает versioned policy, рабочий календарь и паузы
- добавлены итоги по первому ответу, решению, просрочке и полноте actor side
- пустой период возвращает пустой снимок, а не техническую ошибку
- drill-down повторяет owner ABAC и редактирует недоступные события
- доступ остаётся только через Admin reporting workspace; CustomerResponse/клиентские routes не добавлялись

## Проверки
- PHP syntax всех изменённых PHP-файлов
- JSON parse затронутых role definitions
- formula/source fingerprints
- git diff --check

PHPUnit/Larastan локально недоступны: vendor отсутствует; полный runtime gate выполняется CI/deploy.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated a new Customer SLA report into the reporting infrastructure.</li>
<li>Registered CustomerSlaBuiltinPublishedReport and CustomerSlaCandidateContract in the ReportingCatalogServiceProvider.</li>
<li>Updated registry classes (Definition, Metadata, Scheduling) to include the new Customer SLA report.</li>
<li>Added new service classes for Customer SLA reporting, including snapshot materialization and readiness probes.</li>
<li>Updated role definitions to include access for the new report.</li>
</ul></div>