### PR TITLE
fix: диагностика fingerprint R28

### DIFF
--- a/app/Services/Customer/Reporting/Sla/CustomerSlaCandidateContract.php
+++ b/app/Services/Customer/Reporting/Sla/CustomerSlaCandidateContract.php
@@ -56,9 +56,15 @@ final readonly class CustomerSlaCandidateContract
 
     public function assertRuntimeMatches(): void
     {
-        if (! hash_equals(self::FORMULA_HASH, self::classHash(CustomerSlaFormula::class))
-            || ! hash_equals(self::SOURCE_HASH, self::classHash(CustomerSlaSnapshotMaterializer::class))) {
-            throw new InvalidArgumentException('customer_sla_candidate_contract_drift');
+        $formulaHash = self::classHash(CustomerSlaFormula::class);
+        $sourceHash = self::classHash(CustomerSlaSnapshotMaterializer::class);
+        if (! hash_equals(self::FORMULA_HASH, $formulaHash)
+            || ! hash_equals(self::SOURCE_HASH, $sourceHash)) {
+            throw new InvalidArgumentException(sprintf(
+                'customer_sla_candidate_contract_drift:formula=%s:source=%s',
+                $formulaHash,
+                $sourceHash,
+            ));
         }
     }
 


### PR DESCRIPTION
Добавляет фактические formula/source hashes в исключение drift, чтобы точно определить расхождение production image. Бизнес-контракт и CI/CD не меняются.