### PR TITLE
feat: отчёт готовности к передаче объекта

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -24,6 +24,7 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
@@ -46,10 +47,11 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
         SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
+        HandoverReadinessBuiltinPublishedReport $handoverReadiness,
         CustomerSlaBuiltinPublishedReport $customerSla,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $baselineScheduleVariance->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $customerSla->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $baselineScheduleVariance->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $handoverReadiness->definition(), $customerSla->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
@@ -41,6 +42,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
         private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
+        private HandoverReadinessBuiltinPublishedReport $handoverReadiness,
         private CustomerSlaBuiltinPublishedReport $customerSla,
     ) {}
 
@@ -61,6 +63,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->qualityDefectFlow->metadata()->code => $this->qualityDefectFlow->metadata(),
             $this->safetyIncidentActions->metadata()->code => $this->safetyIncidentActions->metadata(),
             $this->workforceAdmission->metadata()->code => $this->workforceAdmission->metadata(),
+            $this->handoverReadiness->metadata()->code => $this->handoverReadiness->metadata(),
             $this->customerSla->metadata()->code => $this->customerSla->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefe
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
@@ -41,6 +42,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private QualityDefectFlowBuiltinPublishedReport $qualityDefectFlow,
         private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
+        private HandoverReadinessBuiltinPublishedReport $handoverReadiness,
         private CustomerSlaBuiltinPublishedReport $customerSla,
     ) {}
 
@@ -61,6 +63,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->qualityDefectFlow->scheduling()->code => $this->qualityDefectFlow->scheduling(),
             $this->safetyIncidentActions->scheduling()->code => $this->safetyIncidentActions->scheduling(),
             $this->workforceAdmission->scheduling()->code => $this->workforceAdmission->scheduling(),
+            $this->handoverReadiness->scheduling()->code => $this->handoverReadiness->scheduling(),
             $this->customerSla->scheduling()->code => $this->customerSla->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -85,6 +85,8 @@ use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVa
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -121,6 +123,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(CustomerSlaCandidateContract::class);
         $this->app->singleton(CustomerSlaBuiltinPublishedReport::class, fn (Application $app): CustomerSlaBuiltinPublishedReport => new CustomerSlaBuiltinPublishedReport(
             $app->make(CustomerSlaCandidateContract::class),
+        ));
+        $this->app->singleton(HandoverReadinessCandidateContract::class);
+        $this->app->singleton(HandoverReadinessBuiltinPublishedReport::class, fn (Application $app): HandoverReadinessBuiltinPublishedReport => new HandoverReadinessBuiltinPublishedReport(
+            $app->make(HandoverReadinessCandidateContract::class),
         ));
         $this->app->singleton(ProjectLaborCostBuiltinPublishedReport::class, fn (Application $app): ProjectLaborCostBuiltinPublishedReport => new ProjectLaborCostBuiltinPublishedReport(
             $app->make(ProjectLaborCostCandidateContract::class),
@@ -180,6 +186,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(QualityDefectFlowBuiltinPublishedReport::class),
                 $app->make(SafetyIncidentActionsBuiltinPublishedReport::class),
                 $app->make(WorkforceAdmissionBuiltinPublishedReport::class),
+                $app->make(HandoverReadinessBuiltinPublishedReport::class),
                 $app->make(CustomerSlaBuiltinPublishedReport::class),
             ),
         );
@@ -190,9 +197,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(HandoverReadinessBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(HandoverReadinessBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/app/BusinessModules/Features/HandoverAcceptance/HandoverAcceptanceServiceProvider.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/HandoverAcceptanceServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\HandoverAcceptance;
 
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
 use Illuminate\Support\ServiceProvider;
 
 final class HandoverAcceptanceServiceProvider extends ServiceProvider
@@ -21,10 +22,21 @@ final class HandoverAcceptanceServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\Readiness\DrillDown\HandoverReadinessDrillDownProvider::class);
         $this->app->singleton(Reporting\Readiness\Readiness\HandoverReadinessProbe::class);
         $this->app->singleton(Reporting\Readiness\Backfill\HandoverReadinessBackfill::class);
+        $this->app->singleton(Reporting\Readiness\HandoverReadinessCandidateContract::class);
+        $this->app->scoped(Reporting\Readiness\HandoverReadinessReportBindingFactory::class);
+        $this->app->scoped(Reporting\Readiness\HandoverReadinessPublishedRuntimeBindingRegistrar::class);
     }
 
     public function boot(): void
     {
+        $this->app->resolving(
+            ReportDefinitionBindingAssembler::class,
+            function (ReportDefinitionBindingAssembler $assembler): void {
+                $this->app->make(Reporting\Readiness\HandoverReadinessPublishedRuntimeBindingRegistrar::class)
+                    ->register($assembler);
+            },
+        );
+
         $migrationsPath = __DIR__.'/migrations';
         if (is_dir($migrationsPath)) {
             $this->loadMigrationsFrom($migrationsPath);

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/DrillDown/HandoverReadinessDrillDownProvider.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/DrillDown/HandoverReadinessDrillDownProvider.php
@@ -7,6 +7,7 @@ namespace App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Dr
 use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceObjectAuthorizer;
 use App\BusinessModules\Core\Reporting\Application\Rows\StableDrillDownPage;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -15,9 +16,14 @@ use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Models\H
 use InvalidArgumentException;
 use JsonException;
 
-final readonly class HandoverReadinessDrillDownProvider implements ReportDrillDownProvider
+final readonly class HandoverReadinessDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
     public function __construct(private ReportSourceObjectAuthorizer $sources) {}
+
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
 
     public function drillDown(
         ReportExecutionContext $context,

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessBuiltinPublishedReport.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class HandoverReadinessBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0'; public const RENDERER_VERSION = '1.0.0'; public const MANIFEST_ORDINAL = 26;
+    public function __construct(private HandoverReadinessCandidateContract $contract) {}
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches(); $definition = (new ReportDefinitionFactory)->fromManifest($this->document()); $this->contract->assertDefinition($definition); return new PublishedReportDefinition($definition);
+    }
+    public function metadata(): ReportCatalogMetadata { return new ReportCatalogMetadata(self::code(), 'reports.catalog.handover_readiness', ReportCatalogGroup::PROJECTS, 'handover', 'gate_location_package', 3, self::MANIFEST_ORDINAL); }
+    public function scheduling(): ReportSchedulingCapability { return new ReportSchedulingCapability(self::code(), false, false); }
+    public function document(): array
+    {
+        return ['code' => self::code(), 'title_key' => 'reports.catalog.handover_readiness', 'catalog_group' => 'projects', 'category' => 'handover', 'grain' => 'gate_location_package', 'wave' => 3, 'source_module' => 'reports', 'core_access_mode' => 'reporting_workspace', 'filters' => $this->contract->filters(), 'columns' => $this->contract->columns(), 'sorts' => $this->contract->sorts(), 'formats' => $this->contract->formats(), 'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => HandoverReadinessCandidateContract::FORMULA_VERSION, 'source_schema' => HandoverReadinessCandidateContract::SOURCE_SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION], 'semantic_fingerprints' => ['formula' => HandoverReadinessCandidateContract::FORMULA_HASH, 'source' => HandoverReadinessCandidateContract::SOURCE_HASH], 'permissions' => ['view' => ['reports.project_readiness.view'], 'export' => ['reports.project_readiness.export'], 'sensitive' => [], 'audit' => []], 'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'], 'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false]];
+    }
+    private static function code(): string { return HandoverReadinessCandidateContract::CODE; }
+}

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessCandidateContract.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessCandidateContract.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Services\HandoverReadinessFormula;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Services\HandoverReadinessSnapshotMaterializer;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class HandoverReadinessCandidateContract
+{
+    public const CODE = 'handover_readiness';
+    public const FORMULA_VERSION = 'handover.v1';
+    public const SOURCE_SCHEMA_VERSION = 'handover-readiness.v1';
+    public const FORMULA_HASH = '480796625d579f1b2887bc92674efe7dff6e178da9272f34d3da830dca9bb8c5';
+    public const SOURCE_HASH = 'd452ed1af702aa8a42400ba0fed5e0aa9b4d93263ce23695a02ae751c1dc542d';
+
+    public function filters(): array { return []; }
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'project_id', 'acceptance_scope_id', 'location_id', 'package_id', 'gate_code', 'due_on',
+            'mandatory_completeness', 'document_completeness', 'open_hard_blocker_count', 'attempt_count',
+            'successful_result_count', 'ready', 'drill',
+        ]);
+    }
+    public function sorts(): array
+    {
+        return array_map(
+            static fn (string $id): array => ['id' => $id, 'direction' => ReportSortDirection::ASC->value],
+            ['due_on', 'project_id', 'location_id', 'package_id', 'gate_code', 'row_key'],
+        );
+    }
+    public function formats(): array { return ['csv', 'xlsx']; }
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, self::classHash(HandoverReadinessFormula::class)) || ! hash_equals(self::SOURCE_HASH, self::classHash(HandoverReadinessSnapshotMaterializer::class))) {
+            throw new InvalidArgumentException('handover_readiness_candidate_contract_drift');
+        }
+    }
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE || $definition->sourceModule !== 'reports' || $definition->coreAccessMode !== ReportCoreAccessMode::REPORTING_WORKSPACE || $definition->formulaVersion !== self::FORMULA_VERSION || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION || $definition->filters !== self::canonicalItems($this->filters()) || $definition->columns !== self::canonicalItems($this->columns()) || $definition->sorts !== self::canonicalItems($this->sorts()) || $definition->formats !== $this->formats() || $definition->permissionPolicy->viewPermissions !== ['reports.project_readiness.view'] || $definition->permissionPolicy->exportPermissions !== ['reports.project_readiness.export'] || $definition->permissionPolicy->sensitivePermissions !== [] || $definition->permissionPolicy->auditPermissions !== []) {
+            throw new InvalidArgumentException('handover_readiness_candidate_definition_invalid');
+        }
+    }
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) throw new InvalidArgumentException('handover_readiness_candidate_sort_invalid');
+    }
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName(); $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) throw new InvalidArgumentException('handover_readiness_candidate_source_unreadable');
+        return $hash;
+    }
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR), $items);
+    }
+}

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class HandoverReadinessPublishedRuntimeBindingRegistrar
+{
+    public function __construct(private ReportDefinitionRegistry $definitions, private HandoverReadinessReportBindingFactory $bindings) {}
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try { $definition = $this->definitions->published(HandoverReadinessCandidateContract::CODE); } catch (ReportContractException $exception) { if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) return; throw $exception; }
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessReportBindingFactory.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessReportBindingFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\DrillDown\HandoverReadinessDrillDownProvider;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Providers\HandoverReadinessReportProvider;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Queries\HandoverReadinessRowQuery;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Readiness\HandoverReadinessProbe;
+
+final readonly class HandoverReadinessReportBindingFactory
+{
+    public function __construct(private HandoverReadinessReportProvider $provider, private HandoverReadinessRowQuery $query, private HandoverReadinessDrillDownProvider $drillDown, private HandoverReadinessProbe $readiness, private HandoverReadinessCandidateContract $contract) {}
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches(); $this->contract->assertDefinition($definition); return new ReportDefinitionBinding($definition->code, $definition->definitionHash, $definition->contractVersion, $this->provider, $this->query, $this->drillDown, $this->readiness);
+    }
+}

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/HandoverReadinessReportProvider.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/HandoverReadinessReportProvider.php
@@ -54,11 +54,16 @@ final readonly class HandoverReadinessReportProvider implements ReportDataProvid
             ->where('organization_id', $context->scope->organizationId)
             ->whereKey($snapshot->id)
             ->firstOrFail();
-        $ready = HandoverReadinessRow::query()
+        $totals = HandoverReadinessRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
-            ->where('ready', true)
-            ->count();
+            ->selectRaw('COUNT(*) AS gate_count')
+            ->selectRaw('SUM(CASE WHEN ready THEN 1 ELSE 0 END) AS ready_gate_count')
+            ->selectRaw('SUM(open_hard_blocker_count) AS open_hard_blocker_count')
+            ->selectRaw('SUM(attempt_count) AS attempt_count')
+            ->selectRaw('SUM(successful_result_count) AS successful_result_count')
+            ->first();
+        $ready = (int) ($totals?->ready_gate_count ?? 0);
         $rowCount = (int) $record->row_count;
         $quality = new ReportQuality(
             ReportQualityStatus::COMPLETE,
@@ -77,7 +82,14 @@ final readonly class HandoverReadinessReportProvider implements ReportDataProvid
                 DateTimeImmutable::createFromInterface($record->generated_at),
                 $record->stale_at === null ? null : DateTimeImmutable::createFromInterface($record->stale_at),
             ),
-            ['gate_count' => $rowCount, 'ready_gate_count' => $ready],
+            [
+                'gate_count' => $rowCount,
+                'ready_gate_count' => $ready,
+                'not_ready_gate_count' => max(0, $rowCount - $ready),
+                'open_hard_blocker_count' => (int) ($totals?->open_hard_blocker_count ?? 0),
+                'attempt_count' => (int) ($totals?->attempt_count ?? 0),
+                'successful_result_count' => (int) ($totals?->successful_result_count ?? 0),
+            ],
             $snapshot->staleAt !== null && $snapshot->staleAt <= new DateTimeImmutable()
                 ? ReportFreshnessStatus::STALE
                 : ReportFreshnessStatus::FRESH,
@@ -97,12 +109,12 @@ final readonly class HandoverReadinessReportProvider implements ReportDataProvid
                 null,
             ),
             [
-                ['id' => 'project_id', 'type' => 'integer'],
-                ['id' => 'gate_code', 'type' => 'string'],
-                ['id' => 'mandatory_completeness', 'type' => 'decimal'],
-                ['id' => 'document_completeness', 'type' => 'decimal'],
-                ['id' => 'open_hard_blocker_count', 'type' => 'integer'],
-                ['id' => 'ready', 'type' => 'boolean'],
+                ['id' => 'project_id', 'type' => 'integer'], ['id' => 'acceptance_scope_id', 'type' => 'integer'],
+                ['id' => 'location_id', 'type' => 'integer'], ['id' => 'package_id', 'type' => 'integer'],
+                ['id' => 'gate_code', 'type' => 'string'], ['id' => 'due_on', 'type' => 'date'],
+                ['id' => 'mandatory_completeness', 'type' => 'decimal'], ['id' => 'document_completeness', 'type' => 'decimal'],
+                ['id' => 'open_hard_blocker_count', 'type' => 'integer'], ['id' => 'attempt_count', 'type' => 'integer'],
+                ['id' => 'successful_result_count', 'type' => 'integer'], ['id' => 'ready', 'type' => 'boolean'],
             ],
             ['drill_down' => true, 'export_formats' => ['csv', 'xlsx']],
         );

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Services/HandoverReadinessSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Services/HandoverReadinessSnapshotMaterializer.php
@@ -50,10 +50,6 @@ final readonly class HandoverReadinessSnapshotMaterializer
             ->unique(static fn (HandoverGateVersion $gate): string => $gate->acceptance_scope_id.':'.$gate->gate_code)
             ->values();
 
-        if ($gates->isEmpty()) {
-            throw new InvalidArgumentException('handover_gate_policy_unavailable');
-        }
-
         $events = HandoverEvidenceEvent::query()
             ->where('organization_id', $query->scope->organizationId)
             ->whereIn('acceptance_scope_id', $gates->pluck('acceptance_scope_id')->all())

--- a/config/RoleDefinitions/admin/web_admin.json
+++ b/config/RoleDefinitions/admin/web_admin.json
@@ -24,6 +24,8 @@
     "admin.reports.export",
     "customer.sla_report.view",
     "customer.sla_report.export",
+    "reports.project_readiness.view",
+    "reports.project_readiness.export",
     "admin.catalogs.manage",
     "mdm.view",
     "mdm.manage",

--- a/config/RoleDefinitions/lk/organization_admin.json
+++ b/config/RoleDefinitions/lk/organization_admin.json
@@ -22,6 +22,8 @@
     "admin.dashboard.view",
     "customer.sla_report.view",
     "customer.sla_report.export",
+    "reports.project_readiness.view",
+    "reports.project_readiness.export",
     "admin.projects.view",
     "admin.users.view",
     "admin.users.create",

--- a/config/RoleDefinitions/lk/organization_owner.json
+++ b/config/RoleDefinitions/lk/organization_owner.json
@@ -33,6 +33,8 @@
     "admin.*",
     "customer.sla_report.view",
     "customer.sla_report.export",
+    "reports.project_readiness.view",
+    "reports.project_readiness.export",
     "legal_archive.view",
     "legal_archive.create",
     "legal_archive.update",

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -47,6 +47,8 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Safe
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessCandidateContract;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
 use Illuminate\Foundation\Application;
@@ -92,6 +94,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('workforce_admission', $registry->published('workforce_admission')->code);
         self::assertSame('safety_incident_actions', $registry->published('safety_incident_actions')->code);
         self::assertSame('customer_sla', $registry->published('customer_sla')->code);
+        self::assertSame('handover_readiness', $registry->published('handover_readiness')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('baseline_schedule_variance', $app->make(ReportCatalogMetadataRegistry::class)->published('baseline_schedule_variance')->code);
@@ -141,11 +144,12 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->qualityDefectFlow(),
             $this->safetyIncidentActions(),
             $this->workforceAdmission(),
+            $this->handoverReadiness(),
             $this->customerSla(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'handover_readiness', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -177,6 +181,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->qualityDefectFlow(),
             $this->safetyIncidentActions(),
             $this->workforceAdmission(),
+            $this->handoverReadiness(),
             $this->customerSla(),
         );
 
@@ -213,11 +218,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->customerSla()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->customerSla()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'handover_readiness', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -225,7 +230,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->customerSla()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->customerSla()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -332,5 +337,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function customerSla(): CustomerSlaBuiltinPublishedReport
     {
         return new CustomerSlaBuiltinPublishedReport(new CustomerSlaCandidateContract);
+    }
+
+    private function handoverReadiness(): HandoverReadinessBuiltinPublishedReport
+    {
+        return new HandoverReadinessBuiltinPublishedReport(new HandoverReadinessCandidateContract);
     }
 }

--- a/tests/Unit/Reporting/Waves23/HandoverReadinessPublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/HandoverReadinessPublishedContractTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessCandidateContract;
+use PHPUnit\Framework\TestCase;
+
+final class HandoverReadinessPublishedContractTest extends TestCase
+{
+    public function test_contract_has_no_client_owned_context_filters(): void
+    {
+        $contract = new HandoverReadinessCandidateContract;
+        $definition = (new HandoverReadinessBuiltinPublishedReport($contract))->definition()->payload();
+
+        self::assertSame([], $definition->filters);
+        self::assertSame(ReportCoreAccessMode::REPORTING_WORKSPACE, $definition->coreAccessMode);
+        self::assertSame(['reports.project_readiness.view'], $definition->permissionPolicy->viewPermissions);
+        self::assertSame(['reports.project_readiness.export'], $definition->permissionPolicy->exportPermissions);
+        self::assertSame(['csv', 'xlsx'], $definition->formats);
+        self::assertContains('ready', array_column($definition->columns, 'id'));
+        self::assertContains('open_hard_blocker_count', array_column($definition->columns, 'id'));
+    }
+
+    public function test_runtime_fingerprints_match_owner_code(): void
+    {
+        $contract = new HandoverReadinessCandidateContract;
+        $contract->assertRuntimeMatches();
+
+        self::assertSame(64, strlen(HandoverReadinessCandidateContract::FORMULA_HASH));
+        self::assertSame(64, strlen(HandoverReadinessCandidateContract::SOURCE_HASH));
+    }
+}


### PR DESCRIPTION
Публикует R26 на реальных версиях ворот и событиях evidence: server-owned organization/project context, честное empty-состояние, итоги, ABAC drill-down с подписанным токеном, CSV/XLSX и права. Локально: PHP syntax для изменённых файлов, JSON role definitions, diff check; vendor отсутствует, поэтому PHPUnit/Larastan выполняются в CI.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated the new HandoverReadiness report into the core reporting infrastructure registries.</li>
<li>Registered HandoverReadinessBuiltinPublishedReport and HandoverReadinessCandidateContract in the ReportingCatalogServiceProvider.</li>
<li>Implemented the HandoverReadiness reporting feature, including drill-down providers, snapshot materialization, and binding factories.</li>
<li>Updated administrative role definitions to include access for the new handover readiness reporting.</li>
<li>Added unit tests to verify the HandoverReadiness report contract and registry integration.</li>
</ul></div>