### PR TITLE
fix: дата среза R26

### DIFF
--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessCandidateContract.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessCandidateContract.php
@@ -20,9 +20,12 @@ final readonly class HandoverReadinessCandidateContract
     public const FORMULA_VERSION = 'handover.v1';
     public const SOURCE_SCHEMA_VERSION = 'handover-readiness.v1';
     public const FORMULA_HASH = '480796625d579f1b2887bc92674efe7dff6e178da9272f34d3da830dca9bb8c5';
-    public const SOURCE_HASH = 'd452ed1af702aa8a42400ba0fed5e0aa9b4d93263ce23695a02ae751c1dc542d';
+    public const SOURCE_HASH = 'abf160e4af08783cd7f1ad8c08103590efa3334ff84a60a14d66b1f5a781ed21';
 
-    public function filters(): array { return []; }
+    public function filters(): array
+    {
+        return [['id' => 'as_of', 'required' => true]];
+    }
     public function columns(): array
     {
         return array_map(static fn (string $id): array => ['id' => $id], [

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Services/HandoverReadinessSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Services/HandoverReadinessSnapshotMaterializer.php
@@ -204,9 +204,13 @@ final readonly class HandoverReadinessSnapshotMaterializer
 
     private function assertContext(ReportExecutionContext $context, ReportQuery $query): void
     {
+        $asOf = $query->filters->values['as_of'] ?? null;
         if (
             $query->definition->code !== 'handover_readiness'
             || $context->scope->canonicalIdentity() !== $query->scope->canonicalIdentity()
+            || ! is_string($asOf)
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/D', $asOf) !== 1
+            || $asOf !== $query->asOf->format('Y-m-d')
         ) {
             throw new InvalidArgumentException('handover_readiness_context_invalid');
         }

--- a/tests/Unit/Reporting/Waves23/HandoverReadinessPublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/HandoverReadinessPublishedContractTest.php
@@ -16,7 +16,9 @@ final class HandoverReadinessPublishedContractTest extends TestCase
         $contract = new HandoverReadinessCandidateContract;
         $definition = (new HandoverReadinessBuiltinPublishedReport($contract))->definition()->payload();
 
-        self::assertSame([], $definition->filters);
+        self::assertSame(['as_of'], array_column($definition->filters, 'id'));
+        self::assertNotContains('organization_id', array_column($definition->filters, 'id'));
+        self::assertNotContains('project_id', array_column($definition->filters, 'id'));
         self::assertSame(ReportCoreAccessMode::REPORTING_WORKSPACE, $definition->coreAccessMode);
         self::assertSame(['reports.project_readiness.view'], $definition->permissionPolicy->viewPermissions);
         self::assertSame(['reports.project_readiness.export'], $definition->permissionPolicy->exportPermissions);


### PR DESCRIPTION
Добавляет обязательную дату среза в canonical-контракт и отклоняет её расхождение с server-owned as_of. Исправляет package:discover без ослабления контракта.