### PR TITLE
fix: подписанная детализация опубликованных отчётов

### DIFF
--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/DrillDown/InventoryRiskDrillDownProvider.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/DrillDown/InventoryRiskDrillDownProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\DrillDown;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -20,8 +21,13 @@ use DomainException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
-final readonly class InventoryRiskDrillDownProvider implements ReportDrillDownProvider
+final readonly class InventoryRiskDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
+
     public function __construct(
         private EloquentOwnerDrillDown $drillDown,
         private OwnerReportTokenPayload $tokens,

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskCandidateContract.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/InventoryRiskCandidateContract.php
@@ -36,7 +36,7 @@ final readonly class InventoryRiskCandidateContract
             'row_key', 'balance_date', 'warehouse_id', 'project_id', 'material_id', 'risk_status',
             'closing_on_hand', 'reserved_quantity', 'available_quantity', 'consumption_quantity',
             'turnover', 'cost_turnover', 'days_on_hand', 'stockout_at', 'consumption_value_minor',
-            'on_hand_value_minor', 'currency', 'recommended_order_quantity', 'quality_warnings',
+            'on_hand_value_minor', 'currency', 'recommended_order_quantity', 'quality_warnings', 'drill',
         ]);
     }
 

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/Queries/SupplierAwardRowQuery.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/Queries/SupplierAwardRowQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Procurement\Reporting\Award\Queries;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCursor;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
@@ -19,8 +20,13 @@ use App\BusinessModules\Features\Procurement\Reporting\Award\Models\SupplierAwar
 use App\Support\Reporting\EloquentOwnerDrillDown;
 use App\Support\Reporting\EloquentOwnerReportRows;
 
-final readonly class SupplierAwardRowQuery implements ReportDrillDownProvider, ReportRowQuery
+final readonly class SupplierAwardRowQuery implements ReportDrillDownProvider, ReportDrillDownTokenColumns, ReportRowQuery
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'decision_evidence'];
+    }
+
     private const SORT_FIELDS = [
         'selected_at',
         'decision_id',

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardCandidateContract.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/SupplierAwardCandidateContract.php
@@ -33,7 +33,7 @@ final readonly class SupplierAwardCandidateContract
             'row_key', 'selected_at', 'decision_id', 'decision_version', 'proposal_version_id',
             'supplier_party_id', 'material_ids', 'currency', 'selected_amount_minor',
             'cheapest_amount_minor', 'premium_minor', 'premium_ratio', 'participation_ratio',
-            'quality_warnings',
+            'quality_warnings', 'drill',
         ]);
     }
 

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleCandidateContract.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleCandidateContract.php
@@ -18,7 +18,7 @@ final readonly class ProcurementCycleCandidateContract
 
     public const FORMULA_HASH = '7fa0c79e701d081930247ed67ebe233b5318b16127341898b586600a43463d71';
 
-    public const SOURCE_HASH = '38036ba2c63d19ae8b570ba94244e282f59488577a8b96d33a8487e12f940156';
+    public const SOURCE_HASH = '4e123c67b13aac917751deab7c6e8be050d07043a70ba810f9219ebbe5993308';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Queries/ProcurementCycleRowQuery.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Queries/ProcurementCycleRowQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Procurement\Reporting\Cycle\Queries;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCursor;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
@@ -19,8 +20,13 @@ use App\BusinessModules\Features\Procurement\Reporting\Cycle\Models\ProcurementP
 use App\Support\Reporting\EloquentOwnerDrillDown;
 use App\Support\Reporting\EloquentOwnerReportRows;
 
-final readonly class ProcurementCycleRowQuery implements ReportDrillDownProvider, ReportRowQuery
+final readonly class ProcurementCycleRowQuery implements ReportDrillDownProvider, ReportDrillDownTokenColumns, ReportRowQuery
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['stage_breakdown' => 'stage_events', 'audit_timeline' => 'audit_events'];
+    }
+
     private const SORT_FIELDS = [
         'cohort_date',
         'purchase_request_line_id',

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleReportAdapter.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleReportAdapter.php
@@ -9,6 +9,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStore;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCoverage;
@@ -39,8 +40,13 @@ use App\BusinessModules\Core\Reporting\Domain\Enums\ReportWarningSeverity;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Contracts\ProcurementCycleSourceSnapshotWriter;
 
-final readonly class ProcurementCycleReportAdapter implements ReportDataProvider, ReportDrillDownProvider, ReportRowQuery
+final readonly class ProcurementCycleReportAdapter implements ReportDataProvider, ReportDrillDownProvider, ReportDrillDownTokenColumns, ReportRowQuery
 {
+    public function drillDownTokenColumns(): array
+    {
+        return [self::STAGE_DRILL_COLUMN => 'stage_events', self::AUDIT_DRILL_COLUMN => 'audit_events'];
+    }
+
     public const REPORT_CODE = 'procurement_cycle';
 
     public const SOURCE_KIND = 'procurement.cycle';

--- a/app/BusinessModules/Features/Procurement/Reporting/Supply/DrillDown/SupplyReliabilityDrillDownProvider.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Supply/DrillDown/SupplyReliabilityDrillDownProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Procurement\Reporting\Supply\DrillDown;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -13,8 +14,13 @@ use App\BusinessModules\Features\Procurement\Reporting\Supply\Models\SupplyLifec
 use App\BusinessModules\Features\Procurement\Reporting\Supply\Models\SupplyReliabilityRow;
 use App\Support\Reporting\EloquentOwnerDrillDown;
 
-final readonly class SupplyReliabilityDrillDownProvider implements ReportDrillDownProvider
+final readonly class SupplyReliabilityDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
+
     public function __construct(private EloquentOwnerDrillDown $drillDown) {}
 
     public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownRequest $request): ReportDrillDownResult

--- a/app/BusinessModules/Features/Procurement/Reporting/Supply/SupplyReliabilityCandidateContract.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Supply/SupplyReliabilityCandidateContract.php
@@ -31,7 +31,7 @@ final readonly class SupplyReliabilityCandidateContract
             'supplier_id', 'ordered_quantity', 'net_received_quantity', 'delay_bucket', 'eligible',
             'on_time', 'in_full', 'stable_in_full', 'mature', 'otif', 'quantity_otif_numerator',
             'quantity_otif_denominator', 'value_otif_numerator_minor', 'value_otif_denominator_minor',
-            'value_currency', 'value_basis', 'quality_warnings',
+            'value_currency', 'value_basis', 'quality_warnings', 'drill',
         ]);
     }
 

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/DrillDown/QualityDefectFlowDrillDownProvider.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/DrillDown/QualityDefectFlowDrillDownProvider.php
@@ -7,6 +7,7 @@ namespace App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Drill
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -16,8 +17,13 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Support\ScopedReportSourceGuard;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Models\QualityDefectFlowRow;
 
-final readonly class QualityDefectFlowDrillDownProvider implements ReportDrillDownProvider
+final readonly class QualityDefectFlowDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
+
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
@@ -37,7 +37,7 @@ final readonly class QualityDefectFlowCandidateContract
         return array_map(static fn (string $id): array => ['id' => $id], [
             'row_key', 'cohort_date', 'project_id', 'contractor_id', 'schedule_task_id',
             'quality_defect_id', 'event_version', 'severity', 'status', 'created',
-            'reopened', 'closed', 'closing', 'cycle_days', 'due_date', 'evidence_refs',
+            'reopened', 'closed', 'closing', 'cycle_days', 'due_date', 'evidence_refs', 'drill',
         ]);
     }
 

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/DrillDown/WorkforceAdmissionDrillDownProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/DrillDown/WorkforceAdmissionDrillDownProvider.php
@@ -7,6 +7,7 @@ namespace App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Dril
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -16,8 +17,13 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Support\ScopedReportSourceGuard;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Models\SafetyAdmissionRow;
 
-final readonly class WorkforceAdmissionDrillDownProvider implements ReportDrillDownProvider
+final readonly class WorkforceAdmissionDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
+
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
@@ -37,7 +37,7 @@ final readonly class WorkforceAdmissionCandidateContract
         return array_map(static fn (string $id): array => ['id' => $id], [
             'row_key', 'snapshot_date', 'project_id', 'safety_site_id', 'workforce_assignment_id',
             'employee_id', 'requirement_code', 'requirement_type', 'status', 'mandatory',
-            'blocked', 'verified', 'valid_until', 'evidence_id', 'medical_details',
+            'blocked', 'verified', 'valid_until', 'evidence_id', 'medical_details', 'drill',
         ]);
     }
 

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/DrillDown/SafetyIncidentDrillDownProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/DrillDown/SafetyIncidentDrillDownProvider.php
@@ -7,6 +7,7 @@ namespace App\BusinessModules\Features\SafetyManagement\Reporting\IncidentAction
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -16,8 +17,13 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Support\ScopedReportSourceGuard;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Models\SafetyIncidentRow;
 
-final readonly class SafetyIncidentDrillDownProvider implements ReportDrillDownProvider
+final readonly class SafetyIncidentDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
+
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
@@ -39,7 +39,7 @@ final readonly class SafetyIncidentActionsCandidateContract
             'row_key', 'event_date', 'project_id', 'safety_site_id', 'contractor_id',
             'subject_type', 'subject_id', 'event_version', 'category', 'severity',
             'status', 'owner_user_id', 'due_date', 'created', 'reopened', 'closed',
-            'closure_verified', 'closure_days', 'evidence_id',
+            'closure_verified', 'closure_days', 'evidence_id', 'drill',
         ]);
     }
 

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceCandidateContract.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceCandidateContract.php
@@ -40,7 +40,7 @@ final readonly class BaselineScheduleVarianceCandidateContract
             'row_key', 'wbs_code', 'task_name', 'planned_start', 'planned_end',
             'start_variance_days', 'end_variance_days', 'duration_variance_days',
             'total_float_days', 'free_float_days', 'critical', 'overdue',
-            'overdue_days', 'status', 'warning_codes',
+            'overdue_days', 'status', 'warning_codes', 'drill',
         ]);
     }
 

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceQueryService.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceQueryService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\ScheduleManagement\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCursor;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
@@ -18,8 +19,13 @@ use App\BusinessModules\Features\ScheduleManagement\Reporting\Models\BaselineSch
 use App\Support\Reporting\ImmutableOwnerProjectionReader;
 use App\Support\Reporting\ReportSourceObjectAccessAuthorizer;
 
-final readonly class BaselineScheduleVarianceQueryService implements ReportRowQuery, ReportDrillDownProvider
+final readonly class BaselineScheduleVarianceQueryService implements ReportRowQuery, ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
+
     private ImmutableOwnerProjectionReader $reader;
 
     private ReportSourceObjectAccessAuthorizer $sourceAccess;

--- a/app/Services/Customer/Reporting/Sla/CustomerSlaCandidateContract.php
+++ b/app/Services/Customer/Reporting/Sla/CustomerSlaCandidateContract.php
@@ -37,7 +37,7 @@ final readonly class CustomerSlaCandidateContract
             'row_key', 'project_id', 'customer_organization_id', 'workflow_type',
             'workflow_id', 'priority', 'status', 'opened_at', 'first_response_seconds',
             'resolution_seconds', 'open_aging_seconds', 'first_response_breached',
-            'resolution_breached', 'actor_side_complete',
+            'resolution_breached', 'actor_side_complete', 'drill',
         ]);
     }
 

--- a/app/Services/Customer/Reporting/Sla/DrillDown/CustomerSlaDrillDownProvider.php
+++ b/app/Services/Customer/Reporting/Sla/DrillDown/CustomerSlaDrillDownProvider.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportEvidenceRedactor
 use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceObjectAuthorizer;
 use App\BusinessModules\Core\Reporting\Application\Rows\StableDrillDownPage;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -16,8 +17,13 @@ use App\Services\Customer\Reporting\Sla\Models\CustomerSlaRow;
 use InvalidArgumentException;
 use JsonException;
 
-final readonly class CustomerSlaDrillDownProvider implements ReportDrillDownProvider
+final readonly class CustomerSlaDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'event_refs'];
+    }
+
     public function __construct(
         private ReportSourceObjectAuthorizer $sources,
         private ReportEvidenceRedactor $redactor,

--- a/tests/Unit/Reporting/Catalog/PublishedDrillDownContractTest.php
+++ b/tests/Unit/Reporting/Catalog/PublishedDrillDownContractTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Catalog;
+
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\DrillDown\InventoryRiskDrillDownProvider;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskCandidateContract;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Queries\SupplierAwardRowQuery;
+use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardCandidateContract;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Services\ProcurementCycleReportAdapter;
+use App\BusinessModules\Features\Procurement\Reporting\Supply\DrillDown\SupplyReliabilityDrillDownProvider;
+use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityCandidateContract;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\DrillDown\QualityDefectFlowDrillDownProvider;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\DrillDown\WorkforceAdmissionDrillDownProvider;
+use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionCandidateContract;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\DrillDown\SafetyIncidentDrillDownProvider;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceQueryService;
+use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
+use App\Services\Customer\Reporting\Sla\DrillDown\CustomerSlaDrillDownProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PublishedDrillDownContractTest extends TestCase
+{
+    #[DataProvider('simpleReports')]
+    public function test_published_drill_down_has_signed_token_column(string $provider, object $contract): void
+    {
+        self::assertTrue(is_subclass_of($provider, ReportDrillDownTokenColumns::class));
+        self::assertContains('drill', array_column($contract->columns(), 'id'));
+    }
+
+    public function test_procurement_cycle_declares_both_signed_token_columns(): void
+    {
+        self::assertTrue(is_subclass_of(ProcurementCycleReportAdapter::class, ReportDrillDownTokenColumns::class));
+        $columns = array_column((new ProcurementCycleCandidateContract)->columns(), 'id');
+        self::assertContains('stage_breakdown', $columns);
+        self::assertContains('audit_timeline', $columns);
+    }
+
+    public static function simpleReports(): iterable
+    {
+        yield [BaselineScheduleVarianceQueryService::class, new BaselineScheduleVarianceCandidateContract];
+        yield [CustomerSlaDrillDownProvider::class, new CustomerSlaCandidateContract];
+        yield [SupplierAwardRowQuery::class, new SupplierAwardCandidateContract];
+        yield [SupplyReliabilityDrillDownProvider::class, new SupplyReliabilityCandidateContract];
+        yield [InventoryRiskDrillDownProvider::class, new InventoryRiskCandidateContract];
+        yield [QualityDefectFlowDrillDownProvider::class, new QualityDefectFlowCandidateContract];
+        yield [SafetyIncidentDrillDownProvider::class, new SafetyIncidentActionsCandidateContract];
+        yield [WorkforceAdmissionDrillDownProvider::class, new WorkforceAdmissionCandidateContract];
+    }
+}


### PR DESCRIPTION
Восстанавливает canonical drill-down tokens для R06, R17, R18, R20, R23–R25 и R28. UI больше не должен получать строки без promised drill token; сырые source id не используются как токены. Добавлен единый контрактный тест. Проверено: PHP syntax изменённых файлов, diff check; vendor отсутствует, PHPUnit выполняется в CI.