### PR TITLE
refactor: canonical owner-проекция R27

### DIFF
--- a/app/BusinessModules/ContractorMarketplace/ContractorMarketplaceServiceProvider.php
+++ b/app/BusinessModules/ContractorMarketplace/ContractorMarketplaceServiceProvider.php
@@ -37,10 +37,10 @@ class ContractorMarketplaceServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\Scorecard\Services\ContractorMembershipEvidenceResolver::class);
         $this->app->singleton(Reporting\Scorecard\Services\ContractorReviewEventProjector::class);
         $this->app->singleton(Reporting\Scorecard\Services\ContractorReviewSnapshotResolver::class);
-        $this->app->singleton(Reporting\Scorecard\Services\ContractorScorecardSourceResolver::class);
+        $this->app->scoped(Reporting\Scorecard\Services\ContractorScorecardSourceResolver::class);
         $this->app->singleton(Reporting\Scorecard\Services\ContractorScorecardObservationReader::class);
         $this->app->singleton(Reporting\Scorecard\Services\ContractorScorecardPolicyWriter::class);
-        $this->app->singleton(Reporting\Scorecard\Services\ContractorScorecardSnapshotMaterializer::class);
+        $this->app->scoped(Reporting\Scorecard\Services\ContractorScorecardSnapshotMaterializer::class);
         $this->app->singleton(Reporting\Scorecard\Providers\ContractorScorecardReportProvider::class);
         $this->app->singleton(Reporting\Scorecard\Queries\ContractorScorecardRowQuery::class);
         $this->app->singleton(Reporting\Scorecard\DrillDown\ContractorScorecardDrillDownProvider::class);

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
@@ -11,6 +11,7 @@ use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Models\Contrac
 use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Models\ContractorScorecardRow;
 use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Models\ContractorScorecardSnapshot;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
@@ -49,7 +50,6 @@ final readonly class ContractorScorecardSnapshotMaterializer
         ) {
             throw new InvalidArgumentException('contractor_scorecard_context_invalid');
         }
-        $tuple = $this->sources->resolve($context, $query);
         $policy = ContractorScorecardPolicyVersion::query()
             ->where('organization_id', $query->scope->organizationId)
             ->where('effective_from', '<=', $query->asOf)
@@ -66,6 +66,24 @@ final readonly class ContractorScorecardSnapshotMaterializer
         if (! in_array($cohortPeriod, ['month', 'quarter', 'year'], true)) {
             throw new InvalidArgumentException('contractor_scorecard_cohort_invalid');
         }
+        $cohortKey = $query->filters->values['cohort'] ?? $this->cohortKey(
+            CarbonImmutable::instance($query->asOf),
+            $cohortPeriod,
+            $cohortKey,
+        );
+        if (! is_string($cohortKey)) {
+            throw new InvalidArgumentException('contractor_scorecard_cohort_invalid');
+        }
+        $query = new ReportQuery(
+            $query->definition,
+            $query->scope,
+            new ReportFilterSet([...$query->filters->values, 'cohort' => $cohortKey]),
+            $query->comparison,
+            $query->asOf,
+            $query->locale,
+        );
+        [$periodFrom, $periodTo] = $this->cohortBounds($cohortKey, $cohortPeriod);
+        $tuple = $this->sources->resolve($context, $query, $periodFrom, $periodTo);
         $components = $this->components($policy);
         $this->assertPinnedSources($tuple, $components);
         $objectiveObservations = $this->observations->load($tuple);
@@ -80,14 +98,14 @@ final readonly class ContractorScorecardSnapshotMaterializer
             ->filter(fn (object $review): bool => $this->matchesRequestedCohort(
                 CarbonImmutable::parse($review->created_at),
                 $policy,
-                $query->filters->values['cohort'] ?? null,
+                $cohortKey,
             ));
         $groups = $this->groups(
             $reviews,
             $objectiveObservations,
             $policy,
             $query->asOf,
-            $query->filters->values['cohort'] ?? null,
+            $cohortKey,
         );
         $sourceHash = hash('sha256', CanonicalJson::encode([
             'filters' => $query->filters->values,
@@ -149,7 +167,7 @@ final readonly class ContractorScorecardSnapshotMaterializer
                 'stale_at' => $staleAt,
                 'watermarks' => [
                     'as_of' => $query->asOf->format(DATE_ATOM),
-                    'cohort_key' => $query->filters->values['cohort'] ?? null,
+                    'cohort_key' => $cohortKey,
                     'filters_hash' => hash('sha256', CanonicalJson::encode($query->filters->values)),
                     'source_schema_version' => 'contractor-scorecard.v1',
                     'source_tuple_hash' => $tuple->hash(),
@@ -443,6 +461,27 @@ final readonly class ContractorScorecardSnapshotMaterializer
             'quarter' => $date->year.'-Q'.$date->quarter,
             'year' => $date->format('Y'),
         };
+    }
+
+    private function cohortBounds(string $cohortKey, string $period): array
+    {
+        if ($period === 'month' && preg_match('/^(\d{4})-(0[1-9]|1[0-2])$/D', $cohortKey, $parts) === 1) {
+            $start = CarbonImmutable::create((int) $parts[1], (int) $parts[2], 1, 0, 0, 0, 'UTC');
+
+            return [$start->toDateString(), $start->endOfMonth()->toDateString()];
+        }
+        if ($period === 'quarter' && preg_match('/^(\d{4})-Q([1-4])$/D', $cohortKey, $parts) === 1) {
+            $start = CarbonImmutable::create((int) $parts[1], ((int) $parts[2] - 1) * 3 + 1, 1, 0, 0, 0, 'UTC');
+
+            return [$start->toDateString(), $start->endOfQuarter()->toDateString()];
+        }
+        if ($period === 'year' && preg_match('/^(\d{4})$/D', $cohortKey, $parts) === 1) {
+            $start = CarbonImmutable::create((int) $parts[1], 1, 1, 0, 0, 0, 'UTC');
+
+            return [$start->toDateString(), $start->endOfYear()->toDateString()];
+        }
+
+        throw new InvalidArgumentException('contractor_scorecard_cohort_invalid');
     }
 
     private function watermark(array $watermarks): string

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSourceResolver.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSourceResolver.php
@@ -7,16 +7,18 @@ namespace App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Services
 use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\DTO\ContractorScorecardSourceTuple;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
-use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
-use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
-use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\Models\ReportRunRecord;
-use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
-use Carbon\CarbonImmutable;
-use DateTimeImmutable;
-use Illuminate\Support\Facades\DB;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportQualityStatus;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportReconciliationStatus;
+use App\BusinessModules\Features\Procurement\Reporting\Supply\Providers\SupplyReliabilityReportProvider;
+use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Providers\QualityDefectFlowReportProvider;
+use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Providers\SafetyIncidentActionsReportProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceProvider;
 use Throwable;
 
 final readonly class ContractorScorecardSourceResolver
@@ -30,16 +32,29 @@ final readonly class ContractorScorecardSourceResolver
 
     public function __construct(
         private ContractorReviewSnapshotResolver $reviews,
+        private ReportDefinitionRegistry $definitions,
+        private BaselineScheduleVarianceProvider $baseline,
+        private SupplyReliabilityReportProvider $supply,
+        private QualityDefectFlowReportProvider $quality,
+        private SafetyIncidentActionsReportProvider $safety,
     ) {}
 
     public function resolve(
         ReportExecutionContext $context,
         ReportQuery $query,
+        string $periodFrom,
+        string $periodTo,
     ): ContractorScorecardSourceTuple {
         try {
             $refs = [];
             foreach (self::REPORT_CODES as $code) {
-                $refs[$code] = $this->reportSnapshot($context, $query, $code);
+                $refs[$code] = $this->materializeOwner(
+                    $context,
+                    $query,
+                    $code,
+                    $periodFrom,
+                    $periodTo,
+                );
             }
             $tuple = new ContractorScorecardSourceTuple(
                 $refs['baseline_schedule_variance'],
@@ -62,122 +77,85 @@ final readonly class ContractorScorecardSourceResolver
         }
     }
 
-    private function reportSnapshot(
+    private function materializeOwner(
         ReportExecutionContext $context,
-        ReportQuery $query,
+        ReportQuery $scorecardQuery,
         string $code,
+        string $periodFrom,
+        string $periodTo,
     ): ReportSnapshotRef {
-        $candidates = ReportRunRecord::query()
-            ->where('organization_id', $context->scope->organizationId)
-            ->where('report_code', $code)
-            ->where('status', 'ready')
-            ->where('as_of', $query->asOf)
-            ->whereRaw(
-                'scope_project_ids = ?::jsonb',
-                [CanonicalJson::encode($query->scope->projectIds)],
-            )
-            ->whereRaw(
-                'scope_holding_organization_ids = ?::jsonb',
-                [CanonicalJson::encode($query->scope->holdingOrganizationIds)],
-            )
-            ->whereRaw(
-                'scope_resources = ?::jsonb',
-                [CanonicalJson::encode(array_map(
-                    static fn ($resource): array => $resource->canonicalIdentity(),
-                    $query->scope->resources,
-                ))],
-            )
-            ->where('scope_timezone', $query->scope->timezone->getName())
-            ->whereRaw(
-                'filters = ?::jsonb',
-                [CanonicalJson::encode($query->filters->values)],
-            )
-            ->whereNotNull('snapshot_id')
-            ->whereNotNull('source_hash')
-            ->orderByDesc('as_of')
-            ->orderByDesc('ready_at')
-            ->first();
-        $record = $candidates;
-        if (
-            ! $record instanceof ReportRunRecord
-            || $record->snapshot_stale_at === null
-            || $record->snapshot_generated_at === null
+        $definition = $this->definitions->published($code)->payload();
+        $ownerQuery = new ReportQuery(
+            $definition,
+            $scorecardQuery->scope,
+            new ReportFilterSet($this->ownerFilters($code, $scorecardQuery, $periodFrom, $periodTo)),
+            [],
+            $scorecardQuery->asOf,
+            $scorecardQuery->locale,
+        );
+        $provider = $this->provider($code);
+        $snapshot = $provider->materialize(
+            $context,
+            $ownerQuery,
+            new ReportProgress(0),
+        );
+        $quality = $provider->result($context, $snapshot)->quality;
+        if ($quality->status !== ReportQualityStatus::COMPLETE
+            || $quality->unmatchedCount !== 0
+            || $quality->reconciliation === ReportReconciliationStatus::MISMATCH
+            || $quality->unknownMetrics !== []
         ) {
             throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
         }
-        $this->assertOwnerSnapshotReady($record, $code, $query);
+        if ($snapshot->scope->canonicalIdentity() !== $scorecardQuery->scope->canonicalIdentity()) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+        }
 
         return new ReportSnapshotRef(
-            $code,
-            (string) $record->snapshot_id,
-            $query->scope,
-            new Sha256Hash((string) $record->definition_hash),
-            (string) $record->formula_version,
-            new Sha256Hash((string) $record->source_hash),
-            DateTimeImmutable::createFromInterface($record->snapshot_generated_at),
-            DateTimeImmutable::createFromInterface($record->snapshot_stale_at),
-            array_merge($record->snapshot_watermarks ?? [], [
-                'source_schema_version' => (string) $record->source_schema_version,
-                'as_of' => $record->as_of->format(DATE_ATOM),
-                'cohort_key' => ($record->filters ?? [])['cohort'] ?? null,
-                'project_ids' => $query->scope->projectIds,
+            $snapshot->kind,
+            $snapshot->id,
+            $snapshot->scope,
+            $snapshot->definitionHash,
+            $snapshot->formulaVersion,
+            $snapshot->sourceHash,
+            $snapshot->generatedAt,
+            $snapshot->staleAt,
+            array_merge($snapshot->watermarks, [
+                'as_of' => $scorecardQuery->asOf->format(DATE_ATOM),
+                'cohort_key' => $scorecardQuery->filters->values['cohort'],
+                'project_ids' => $scorecardQuery->scope->projectIds,
             ]),
-            ReportSnapshotClassification::OPERATIONAL,
-            null,
+            $snapshot->classification,
+            $snapshot->seal,
+            $snapshot->materializedSourceHash,
         );
     }
 
-    private function assertOwnerSnapshotReady(
-        ReportRunRecord $record,
+    private function provider(string $code): \App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider
+    {
+        return match ($code) {
+            'baseline_schedule_variance' => $this->baseline,
+            'supply_reliability' => $this->supply,
+            'quality_defect_flow' => $this->quality,
+            'safety_incident_actions' => $this->safety,
+            default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE),
+        };
+    }
+
+    private function ownerFilters(
         string $code,
         ReportQuery $query,
-    ): void {
-        $snapshot = match ($code) {
-            'baseline_schedule_variance' => DB::table('baseline_schedule_variance_snapshots')
-                ->where('id', $record->snapshot_id)
-                ->where('organization_id', $record->organization_id)
-                ->first(),
-            'supply_reliability' => DB::table('supply_reliability_snapshots')
-                ->where('id', $record->snapshot_id)
-                ->where('organization_id', $record->organization_id)
-                ->where('quality_status', 'complete')
-                ->where('reconciliation_status', 'matched')
-                ->where('gap_count', 0)
-                ->first(),
-            'quality_defect_flow' => DB::table('quality_defect_flow_snapshots')
-                ->where('id', $record->snapshot_id)
-                ->where('organization_id', $record->organization_id)
-                ->where('gap_count', 0)
-                ->where('unknown_count', 0)
-                ->whereColumn('eligible_count', 'projected_count')
-                ->first(),
-            'safety_incident_actions' => DB::table('safety_incident_snapshots')
-                ->where('id', $record->snapshot_id)
-                ->where('organization_id', $record->organization_id)
-                ->where('gap_count', 0)
-                ->where('unknown_count', 0)
-                ->whereColumn('eligible_count', 'projected_count')
-                ->first(),
-            default => null,
+        string $periodFrom,
+        string $periodTo,
+    ): array {
+        return match ($code) {
+            'baseline_schedule_variance' => ['as_of' => $query->asOf->format('Y-m-d')],
+            'supply_reliability' => ['period_start' => $periodFrom, 'period_end' => $periodTo],
+            'quality_defect_flow', 'safety_incident_actions' => [
+                'period_from' => $periodFrom,
+                'period_to' => $periodTo,
+            ],
+            default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE),
         };
-        if (
-            ! is_object($snapshot)
-            || ! hash_equals((string) $snapshot->source_hash, (string) $record->source_hash)
-            || ! hash_equals((string) $snapshot->formula_version, (string) $record->formula_version)
-            || CarbonImmutable::parse((string) $snapshot->generated_at)
-                ->notEqualTo(CarbonImmutable::instance($record->snapshot_generated_at))
-            || $snapshot->stale_at === null
-            || CarbonImmutable::parse((string) $snapshot->stale_at)->lessThanOrEqualTo(CarbonImmutable::now('UTC'))
-        ) {
-            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
-        }
-
-        $snapshotAsOf = CarbonImmutable::parse((string) $snapshot->as_of);
-        $sameAsOf = $code === 'baseline_schedule_variance'
-            ? $snapshotAsOf->toDateString() === CarbonImmutable::instance($query->asOf)->toDateString()
-            : $snapshotAsOf->equalTo(CarbonImmutable::instance($query->asOf));
-        if (! $sameAsOf) {
-            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
-        }
     }
 }

--- a/tests/Unit/Reporting/Waves23/ContractorScorecardOwnerProjectionTest.php
+++ b/tests/Unit/Reporting/Waves23/ContractorScorecardOwnerProjectionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Services\ContractorScorecardSnapshotMaterializer;
+use ReflectionClass;
+use Tests\TestCase;
+
+final class ContractorScorecardOwnerProjectionTest extends TestCase
+{
+    public function test_source_resolver_materializes_each_owner_with_its_own_filter_contract(): void
+    {
+        $source = file_get_contents(base_path('app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSourceResolver.php'));
+
+        self::assertIsString($source);
+        self::assertStringNotContainsString('ReportRunRecord', $source);
+        self::assertStringNotContainsString("'filters = ?::jsonb'", $source);
+        self::assertStringContainsString("'as_of' => \$query->asOf->format('Y-m-d')", $source);
+        self::assertStringContainsString("'period_start' => \$periodFrom", $source);
+        self::assertStringContainsString("'period_from' => \$periodFrom", $source);
+        self::assertStringContainsString('->materialize(', $source);
+    }
+
+    public function test_cohort_bounds_are_strict_and_calendar_aligned(): void
+    {
+        $service = (new ReflectionClass(ContractorScorecardSnapshotMaterializer::class))->newInstanceWithoutConstructor();
+        $method = new \ReflectionMethod($service, 'cohortBounds');
+
+        self::assertSame(['2026-02-01', '2026-02-28'], $method->invoke($service, '2026-02', 'month'));
+        self::assertSame(['2026-04-01', '2026-06-30'], $method->invoke($service, '2026-Q2', 'quarter'));
+        self::assertSame(['2026-01-01', '2026-12-31'], $method->invoke($service, '2026', 'year'));
+    }
+}


### PR DESCRIPTION
Устраняет невозможное требование одинакового filters JSON у четырёх owner-отчётов. R27 теперь материализует каждый опубликованный owner через его реальный provider и валидные фильтры одной когорты, проверяет quality/reconciliation и закрепляет scope/as_of/cohort. Без новых таблиц, CI или publication-инфраструктуры. Локально: PHP syntax, diff check; vendor отсутствует, целевой PHPUnit выполняется в CI.