### PR TITLE
feat[admin]: опубликован отчёт по подрядчикам

### DIFF
--- a/app/BusinessModules/ContractorMarketplace/ContractorMarketplaceServiceProvider.php
+++ b/app/BusinessModules/ContractorMarketplace/ContractorMarketplaceServiceProvider.php
@@ -19,6 +19,7 @@ use App\BusinessModules\ContractorMarketplace\Domain\Services\MarketplaceProfile
 use App\BusinessModules\ContractorMarketplace\Domain\Services\MarketplaceRatingService;
 use App\BusinessModules\ContractorMarketplace\Domain\Services\MarketplaceSearchService;
 use App\BusinessModules\ContractorMarketplace\Domain\Services\MarketplaceWorkCategoryService;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -41,15 +42,26 @@ class ContractorMarketplaceServiceProvider extends ServiceProvider
         $this->app->singleton(Reporting\Scorecard\Services\ContractorScorecardObservationReader::class);
         $this->app->singleton(Reporting\Scorecard\Services\ContractorScorecardPolicyWriter::class);
         $this->app->scoped(Reporting\Scorecard\Services\ContractorScorecardSnapshotMaterializer::class);
-        $this->app->singleton(Reporting\Scorecard\Providers\ContractorScorecardReportProvider::class);
+        $this->app->scoped(Reporting\Scorecard\Providers\ContractorScorecardReportProvider::class);
         $this->app->singleton(Reporting\Scorecard\Queries\ContractorScorecardRowQuery::class);
         $this->app->singleton(Reporting\Scorecard\DrillDown\ContractorScorecardDrillDownProvider::class);
         $this->app->singleton(Reporting\Scorecard\Readiness\ContractorScorecardReadinessProbe::class);
         $this->app->singleton(Reporting\Scorecard\Backfill\ContractorScorecardBackfill::class);
+        $this->app->singleton(Reporting\Scorecard\ContractorScorecardCandidateContract::class);
+        $this->app->scoped(Reporting\Scorecard\ContractorScorecardReportBindingFactory::class);
+        $this->app->scoped(Reporting\Scorecard\ContractorScorecardPublishedRuntimeBindingRegistrar::class);
     }
 
     public function boot(): void
     {
+        $this->app->resolving(
+            ReportDefinitionBindingAssembler::class,
+            function (ReportDefinitionBindingAssembler $assembler): void {
+                $this->app->make(Reporting\Scorecard\ContractorScorecardPublishedRuntimeBindingRegistrar::class)
+                    ->register($assembler);
+            },
+        );
+
         Event::listen(MarketplaceProfilePublished::class, [RecordMarketplaceActivity::class, 'handleProfilePublished']);
         Event::listen(MarketplaceProfilePaused::class, [RecordMarketplaceActivity::class, 'handleProfilePaused']);
         Event::listen(MarketplaceHiringOfferSent::class, [RecordMarketplaceActivity::class, 'handleOfferSent']);

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardBuiltinPublishedReport.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardBuiltinPublishedReport.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\ContractorMarketplace\Reporting\Scorecard;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class ContractorScorecardBuiltinPublishedReport
+{
+    public const CONTRACT_VERSION = '1.0.0';
+    public const RENDERER_VERSION = '1.0.0';
+    public const MANIFEST_ORDINAL = 27;
+
+    public function __construct(private ContractorScorecardCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(self::code(), 'reports.catalog.contractor_scorecard', ReportCatalogGroup::PARTNERS_CUSTOMERS, 'partners', 'contractor_category_cohort', 2, self::MANIFEST_ORDINAL);
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(self::code(), false, false);
+    }
+
+    public function document(): array
+    {
+        return [
+            'code' => self::code(), 'title_key' => 'reports.catalog.contractor_scorecard',
+            'catalog_group' => 'partners_customers', 'category' => 'partners', 'grain' => 'contractor_category_cohort',
+            'wave' => 2, 'source_module' => 'contractor-portal', 'core_access_mode' => 'source_module_report',
+            'filters' => $this->contract->filters(), 'columns' => $this->contract->columns(),
+            'sorts' => $this->contract->sorts(), 'formats' => $this->contract->formats(),
+            'versions' => ['contract' => self::CONTRACT_VERSION, 'formula' => ContractorScorecardCandidateContract::FORMULA_VERSION, 'source_schema' => ContractorScorecardCandidateContract::SOURCE_SCHEMA_VERSION, 'renderer' => self::RENDERER_VERSION],
+            'semantic_fingerprints' => ['formula' => ContractorScorecardCandidateContract::FORMULA_HASH, 'source' => ContractorScorecardCandidateContract::SOURCE_HASH],
+            'permissions' => ['view' => ['contractor_marketplace.profile.view'], 'export' => ['contractor_marketplace.reports.export'], 'sensitive' => [], 'audit' => []],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'published'],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+
+    private static function code(): string
+    {
+        return ContractorScorecardCandidateContract::CODE;
+    }
+}

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardCandidateContract.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardCandidateContract.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\ContractorMarketplace\Reporting\Scorecard;
+
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Services\ContractorScorecardFormula;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Services\ContractorScorecardSnapshotMaterializer;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class ContractorScorecardCandidateContract
+{
+    public const CODE = 'contractor_scorecard';
+    public const FORMULA_VERSION = 'contractor-scorecard.v1';
+    public const SOURCE_SCHEMA_VERSION = 'contractor-scorecard.v1';
+    public const FORMULA_HASH = 'a965552184893020d8da3da25875a0f6fe1ee7af6c8d5c373dd062b16a6d9d18';
+    public const SOURCE_HASH = 'f2f8e82344c4f11521a0bc16cd6fc992f8ac9b4e64a7ccd482416afc478d9e7b';
+
+    public function filters(): array
+    {
+        return [
+            ['id' => 'as_of', 'required' => true],
+            ['id' => 'cohort', 'required' => false],
+        ];
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'profile_id', 'category_id', 'project_id', 'cohort_key', 'component_code',
+            'unit_code', 'component_mean', 'sample_size', 'eligible_count', 'coverage', 'drill',
+        ]);
+    }
+
+    public function sorts(): array
+    {
+        return array_map(
+            static fn (string $id): array => ['id' => $id, 'direction' => ReportSortDirection::ASC->value],
+            ['profile_id', 'category_id', 'cohort_key', 'project_id', 'component_code', 'row_key'],
+        );
+    }
+
+    public function formats(): array
+    {
+        return ['csv', 'xlsx'];
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (
+            ! hash_equals(self::FORMULA_HASH, self::classHash(ContractorScorecardFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, self::classHash(ContractorScorecardSnapshotMaterializer::class))
+        ) {
+            throw new InvalidArgumentException('contractor_scorecard_candidate_contract_drift');
+        }
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if (
+            $definition->code !== self::CODE
+            || $definition->sourceModule !== 'contractor-portal'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || $definition->filters !== self::canonicalItems($this->filters())
+            || $definition->columns !== self::canonicalItems($this->columns())
+            || $definition->sorts !== self::canonicalItems($this->sorts())
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['contractor_marketplace.profile.view']
+            || $definition->permissionPolicy->exportPermissions !== ['contractor_marketplace.reports.export']
+            || $definition->permissionPolicy->sensitivePermissions !== []
+            || $definition->permissionPolicy->auditPermissions !== []
+        ) {
+            throw new InvalidArgumentException('contractor_scorecard_candidate_definition_invalid');
+        }
+    }
+
+    public function assertSort(ReportWindowSort $sort): void
+    {
+        if (! in_array($sort->field, array_column($this->sorts(), 'id'), true)) {
+            throw new InvalidArgumentException('contractor_scorecard_candidate_sort_invalid');
+        }
+    }
+
+    private static function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+        if (! is_string($hash)) {
+            throw new InvalidArgumentException('contractor_scorecard_candidate_source_unreadable');
+        }
+
+        return $hash;
+    }
+
+    private static function canonicalItems(array $items): array
+    {
+        return array_map(
+            static fn (array $item): array => json_decode(CanonicalJson::encode($item), true, 512, JSON_THROW_ON_ERROR),
+            $items,
+        );
+    }
+}

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\ContractorMarketplace\Reporting\Scorecard;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class ContractorScorecardPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private ContractorScorecardReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(ContractorScorecardCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+            throw $exception;
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardReportBindingFactory.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardReportBindingFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\ContractorMarketplace\Reporting\Scorecard;
+
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\DrillDown\ContractorScorecardDrillDownProvider;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Providers\ContractorScorecardReportProvider;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Queries\ContractorScorecardRowQuery;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Readiness\ContractorScorecardReadinessProbe;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+
+final readonly class ContractorScorecardReportBindingFactory
+{
+    public function __construct(
+        private ContractorScorecardReportProvider $provider,
+        private ContractorScorecardRowQuery $query,
+        private ContractorScorecardDrillDownProvider $drillDown,
+        private ContractorScorecardReadinessProbe $readiness,
+        private ContractorScorecardCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding($definition->code, $definition->definitionHash, $definition->contractVersion, $this->provider, $this->query, $this->drillDown, $this->readiness);
+    }
+}

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/DrillDown/ContractorScorecardDrillDownProvider.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/DrillDown/ContractorScorecardDrillDownProvider.php
@@ -9,6 +9,7 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportEvidenceRedactor
 use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceObjectAuthorizer;
 use App\BusinessModules\Core\Reporting\Application\Rows\StableDrillDownPage;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -16,12 +17,17 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use InvalidArgumentException;
 use JsonException;
 
-final readonly class ContractorScorecardDrillDownProvider implements ReportDrillDownProvider
+final readonly class ContractorScorecardDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
     public function __construct(
         private ReportSourceObjectAuthorizer $sources,
         private ReportEvidenceRedactor $redactor,
     ) {}
+
+    public function drillDownTokenColumns(): array
+    {
+        return ['drill' => 'evidence_refs'];
+    }
 
     public function drillDown(
         ReportExecutionContext $context,

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
@@ -44,9 +44,13 @@ final readonly class ContractorScorecardSnapshotMaterializer
 
     public function materialize(ReportExecutionContext $context, ReportQuery $query): ReportSnapshotRef
     {
+        $asOf = $query->filters->values['as_of'] ?? null;
         if (
             $query->definition->code !== 'contractor_scorecard'
             || $context->scope->canonicalIdentity() !== $query->scope->canonicalIdentity()
+            || ! is_string($asOf)
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/D', $asOf) !== 1
+            || $asOf !== $query->asOf->format('Y-m-d')
         ) {
             throw new InvalidArgumentException('contractor_scorecard_context_invalid');
         }
@@ -69,7 +73,6 @@ final readonly class ContractorScorecardSnapshotMaterializer
         $cohortKey = $query->filters->values['cohort'] ?? $this->cohortKey(
             CarbonImmutable::instance($query->asOf),
             $cohortPeriod,
-            $cohortKey,
         );
         if (! is_string($cohortKey)) {
             throw new InvalidArgumentException('contractor_scorecard_cohort_invalid');

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -25,6 +25,7 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceA
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
@@ -48,10 +49,11 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
         HandoverReadinessBuiltinPublishedReport $handoverReadiness,
+        ContractorScorecardBuiltinPublishedReport $contractorScorecard,
         CustomerSlaBuiltinPublishedReport $customerSla,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $baselineScheduleVariance->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $handoverReadiness->definition(), $customerSla->definition()] as $definition) {
+        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $baselineScheduleVariance->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $handoverReadiness->definition(), $contractorScorecard->definition(), $customerSla->definition()] as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -23,6 +23,7 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceA
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
@@ -43,6 +44,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
         private HandoverReadinessBuiltinPublishedReport $handoverReadiness,
+        private ContractorScorecardBuiltinPublishedReport $contractorScorecard,
         private CustomerSlaBuiltinPublishedReport $customerSla,
     ) {}
 
@@ -64,6 +66,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
             $this->safetyIncidentActions->metadata()->code => $this->safetyIncidentActions->metadata(),
             $this->workforceAdmission->metadata()->code => $this->workforceAdmission->metadata(),
             $this->handoverReadiness->metadata()->code => $this->handoverReadiness->metadata(),
+            $this->contractorScorecard->metadata()->code => $this->contractorScorecard->metadata(),
             $this->customerSla->metadata()->code => $this->customerSla->metadata(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -23,6 +23,7 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceA
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
@@ -43,6 +44,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private SafetyIncidentActionsBuiltinPublishedReport $safetyIncidentActions,
         private WorkforceAdmissionBuiltinPublishedReport $workforceAdmission,
         private HandoverReadinessBuiltinPublishedReport $handoverReadiness,
+        private ContractorScorecardBuiltinPublishedReport $contractorScorecard,
         private CustomerSlaBuiltinPublishedReport $customerSla,
     ) {}
 
@@ -64,6 +66,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
             $this->safetyIncidentActions->scheduling()->code => $this->safetyIncidentActions->scheduling(),
             $this->workforceAdmission->scheduling()->code => $this->workforceAdmission->scheduling(),
             $this->handoverReadiness->scheduling()->code => $this->handoverReadiness->scheduling(),
+            $this->contractorScorecard->scheduling()->code => $this->contractorScorecard->scheduling(),
             $this->customerSla->scheduling()->code => $this->customerSla->scheduling(),
             default => throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND),
         };

--- a/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php
@@ -87,6 +87,8 @@ use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessCandidateContract;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardCandidateContract;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
@@ -127,6 +129,10 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
         $this->app->singleton(HandoverReadinessCandidateContract::class);
         $this->app->singleton(HandoverReadinessBuiltinPublishedReport::class, fn (Application $app): HandoverReadinessBuiltinPublishedReport => new HandoverReadinessBuiltinPublishedReport(
             $app->make(HandoverReadinessCandidateContract::class),
+        ));
+        $this->app->singleton(ContractorScorecardCandidateContract::class);
+        $this->app->singleton(ContractorScorecardBuiltinPublishedReport::class, fn (Application $app): ContractorScorecardBuiltinPublishedReport => new ContractorScorecardBuiltinPublishedReport(
+            $app->make(ContractorScorecardCandidateContract::class),
         ));
         $this->app->singleton(ProjectLaborCostBuiltinPublishedReport::class, fn (Application $app): ProjectLaborCostBuiltinPublishedReport => new ProjectLaborCostBuiltinPublishedReport(
             $app->make(ProjectLaborCostCandidateContract::class),
@@ -187,6 +193,7 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(SafetyIncidentActionsBuiltinPublishedReport::class),
                 $app->make(WorkforceAdmissionBuiltinPublishedReport::class),
                 $app->make(HandoverReadinessBuiltinPublishedReport::class),
+                $app->make(ContractorScorecardBuiltinPublishedReport::class),
                 $app->make(CustomerSlaBuiltinPublishedReport::class),
             ),
         );
@@ -197,9 +204,9 @@ final class ReportingCatalogServiceProvider extends ServiceProvider
                 $app->make(DatabasePublishedReportDefinitionRegistry::class),
             ),
         );
-        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(HandoverReadinessBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportCatalogMetadataRegistry::class, fn (Application $app): BuiltinReportCatalogMetadataRegistry => new BuiltinReportCatalogMetadataRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(HandoverReadinessBuiltinPublishedReport::class), $app->make(ContractorScorecardBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
         $this->app->singleton(ReportCatalogMetadataRegistry::class, fn (Application $app): CompositeReportCatalogMetadataRegistry => new CompositeReportCatalogMetadataRegistry($app->make(BuiltinReportCatalogMetadataRegistry::class), $app->make(DatabaseReportCatalogMetadataRegistry::class)));
-        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(HandoverReadinessBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
+        $this->app->singleton(BuiltinReportSchedulingCapabilityRegistry::class, fn (Application $app): BuiltinReportSchedulingCapabilityRegistry => new BuiltinReportSchedulingCapabilityRegistry($app->make(ProjectMarginBuiltinPublishedReport::class), $app->make(BudgetPlanFactBuiltinPublishedReport::class), $app->make(BaselineScheduleVarianceBuiltinPublishedReport::class), $app->make(ProjectLaborCostBuiltinPublishedReport::class), $app->make(PayrollReadinessBuiltinPublishedReport::class), $app->make(WorkforceCapacityBuiltinPublishedReport::class), $app->make(ProcurementCycleBuiltinPublishedReport::class), $app->make(SupplierAwardBuiltinPublishedReport::class), $app->make(SupplyReliabilityBuiltinPublishedReport::class), $app->make(InventoryRiskBuiltinPublishedReport::class), $app->make(AttendanceExecutionBuiltinPublishedReport::class), $app->make(QualityDefectFlowBuiltinPublishedReport::class), $app->make(SafetyIncidentActionsBuiltinPublishedReport::class), $app->make(WorkforceAdmissionBuiltinPublishedReport::class), $app->make(HandoverReadinessBuiltinPublishedReport::class), $app->make(ContractorScorecardBuiltinPublishedReport::class), $app->make(CustomerSlaBuiltinPublishedReport::class)));
         $this->app->singleton(ReportSchedulingCapabilityRegistry::class, fn (Application $app): CompositeReportSchedulingCapabilityRegistry => new CompositeReportSchedulingCapabilityRegistry($app->make(BuiltinReportSchedulingCapabilityRegistry::class), $app->make(DatabaseReportSchedulingCapabilityRegistry::class)));
         $this->app->singleton(GetReportCatalogAction::class, GetReportCatalogHandler::class);
         $this->app->singleton(

--- a/config/RoleDefinitions/admin/web_admin.json
+++ b/config/RoleDefinitions/admin/web_admin.json
@@ -383,7 +383,9 @@
       "organizations.search",
       "organizations.suggestions",
       "organizations.recommendations",
-      "organizations.availability.check"
+      "organizations.availability.check",
+      "contractor_marketplace.profile.view",
+      "contractor_marketplace.reports.export"
     ],
     "crm": [
       "crm.view",

--- a/config/RoleDefinitions/lk/organization_admin.json
+++ b/config/RoleDefinitions/lk/organization_admin.json
@@ -323,6 +323,7 @@
       "contractor_marketplace.categories.view",
       "contractor_marketplace.search.view",
       "contractor_marketplace.profile.view",
+      "contractor_marketplace.reports.export",
       "contractor_marketplace.profile.edit",
       "contractor_marketplace.profile.publish",
       "contractor_marketplace.offers.view",

--- a/config/RoleDefinitions/project/project_manager.json
+++ b/config/RoleDefinitions/project/project_manager.json
@@ -121,6 +121,7 @@
       "contractor_marketplace.categories.view",
       "contractor_marketplace.search.view",
       "contractor_marketplace.profile.view",
+      "contractor_marketplace.reports.export",
       "contractor_marketplace.offers.view",
       "contractor_marketplace.offers.create",
       "contractor_marketplace.offers.cancel",

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -49,6 +49,8 @@ use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVa
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessCandidateContract;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardCandidateContract;
 use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
 use Illuminate\Foundation\Application;
@@ -95,6 +97,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('safety_incident_actions', $registry->published('safety_incident_actions')->code);
         self::assertSame('customer_sla', $registry->published('customer_sla')->code);
         self::assertSame('handover_readiness', $registry->published('handover_readiness')->code);
+        self::assertSame('contractor_scorecard', $registry->published('contractor_scorecard')->code);
         self::assertSame('project_margin', $app->make(ReportCatalogMetadataRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportCatalogMetadataRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('baseline_schedule_variance', $app->make(ReportCatalogMetadataRegistry::class)->published('baseline_schedule_variance')->code);
@@ -110,6 +113,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('workforce_admission', $app->make(ReportCatalogMetadataRegistry::class)->published('workforce_admission')->code);
         self::assertSame('safety_incident_actions', $app->make(ReportCatalogMetadataRegistry::class)->published('safety_incident_actions')->code);
         self::assertSame('customer_sla', $app->make(ReportCatalogMetadataRegistry::class)->published('customer_sla')->code);
+        self::assertSame('contractor_scorecard', $app->make(ReportCatalogMetadataRegistry::class)->published('contractor_scorecard')->code);
         self::assertSame('project_margin', $app->make(ReportSchedulingCapabilityRegistry::class)->published('project_margin')->code);
         self::assertSame('budget_plan_fact', $app->make(ReportSchedulingCapabilityRegistry::class)->published('budget_plan_fact')->code);
         self::assertSame('baseline_schedule_variance', $app->make(ReportSchedulingCapabilityRegistry::class)->published('baseline_schedule_variance')->code);
@@ -125,6 +129,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('workforce_admission', $app->make(ReportSchedulingCapabilityRegistry::class)->published('workforce_admission')->code);
         self::assertSame('safety_incident_actions', $app->make(ReportSchedulingCapabilityRegistry::class)->published('safety_incident_actions')->code);
         self::assertSame('customer_sla', $app->make(ReportSchedulingCapabilityRegistry::class)->published('customer_sla')->code);
+        self::assertSame('contractor_scorecard', $app->make(ReportSchedulingCapabilityRegistry::class)->published('contractor_scorecard')->code);
     }
 
     public function test_budget_plan_fact_is_available_without_database_publication(): void
@@ -145,11 +150,12 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->safetyIncidentActions(),
             $this->workforceAdmission(),
             $this->handoverReadiness(),
+            $this->contractorScorecard(),
             $this->customerSla(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'handover_readiness', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'contractor_scorecard', 'customer_sla', 'handover_readiness', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -182,6 +188,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->safetyIncidentActions(),
             $this->workforceAdmission(),
             $this->handoverReadiness(),
+            $this->contractorScorecard(),
             $this->customerSla(),
         );
 
@@ -201,6 +208,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             'safety_incident_actions' => 'safety-management',
             'workforce_admission' => 'safety-management',
             'customer_sla' => 'reports',
+            'contractor_scorecard' => 'contractor-portal',
         ];
 
         foreach ($expectedModules as $code => $module) {
@@ -218,11 +226,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->customerSla()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->contractorScorecard(), $this->customerSla()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'customer_sla', 'handover_readiness', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'contractor_scorecard', 'customer_sla', 'handover_readiness', 'inventory_risk', 'payroll_readiness', 'procurement_cycle', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -230,7 +238,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->customerSla()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->baselineScheduleVariance(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->contractorScorecard(), $this->customerSla()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -342,5 +350,10 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function handoverReadiness(): HandoverReadinessBuiltinPublishedReport
     {
         return new HandoverReadinessBuiltinPublishedReport(new HandoverReadinessCandidateContract);
+    }
+
+    private function contractorScorecard(): ContractorScorecardBuiltinPublishedReport
+    {
+        return new ContractorScorecardBuiltinPublishedReport(new ContractorScorecardCandidateContract);
     }
 }

--- a/tests/Unit/Reporting/Catalog/PublishedDrillDownContractTest.php
+++ b/tests/Unit/Reporting/Catalog/PublishedDrillDownContractTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Reporting\Catalog;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardCandidateContract;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\DrillDown\ContractorScorecardDrillDownProvider;
 use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\DrillDown\InventoryRiskDrillDownProvider;
 use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Award\Queries\SupplierAwardRowQuery;
@@ -47,6 +49,7 @@ final class PublishedDrillDownContractTest extends TestCase
     {
         yield [BaselineScheduleVarianceQueryService::class, new BaselineScheduleVarianceCandidateContract];
         yield [CustomerSlaDrillDownProvider::class, new CustomerSlaCandidateContract];
+        yield [ContractorScorecardDrillDownProvider::class, new ContractorScorecardCandidateContract];
         yield [SupplierAwardRowQuery::class, new SupplierAwardCandidateContract];
         yield [SupplyReliabilityDrillDownProvider::class, new SupplyReliabilityCandidateContract];
         yield [InventoryRiskDrillDownProvider::class, new InventoryRiskCandidateContract];

--- a/tests/Unit/Reporting/Waves23/ContractorScorecardPublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ContractorScorecardPublishedContractTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardCandidateContract;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use PHPUnit\Framework\TestCase;
+
+final class ContractorScorecardPublishedContractTest extends TestCase
+{
+    public function test_contract_keeps_scope_server_owned_and_exposes_evidence(): void
+    {
+        $contract = new ContractorScorecardCandidateContract;
+        $definition = (new ContractorScorecardBuiltinPublishedReport($contract))->definition()->payload();
+
+        self::assertSame(['as_of', 'cohort'], array_column($definition->filters, 'id'));
+        self::assertNotContains('organization_id', array_column($definition->filters, 'id'));
+        self::assertNotContains('project_id', array_column($definition->filters, 'id'));
+        self::assertSame(ReportCoreAccessMode::SOURCE_MODULE_REPORT, $definition->coreAccessMode);
+        self::assertSame(['contractor_marketplace.profile.view'], $definition->permissionPolicy->viewPermissions);
+        self::assertSame(['contractor_marketplace.reports.export'], $definition->permissionPolicy->exportPermissions);
+        self::assertSame(['csv', 'xlsx'], $definition->formats);
+        self::assertContains('component_mean', array_column($definition->columns, 'id'));
+        self::assertContains('coverage', array_column($definition->columns, 'id'));
+        self::assertContains('drill', array_column($definition->columns, 'id'));
+    }
+
+    public function test_runtime_fingerprints_match_owner_code(): void
+    {
+        $contract = new ContractorScorecardCandidateContract;
+        $contract->assertRuntimeMatches();
+
+        self::assertSame(64, strlen(ContractorScorecardCandidateContract::FORMULA_HASH));
+        self::assertSame(64, strlen(ContractorScorecardCandidateContract::SOURCE_HASH));
+    }
+}


### PR DESCRIPTION
## Что сделано
- опубликован R27 «Карточка подрядчика» на реальных owner-источниках
- организация и проект остаются серверным контекстом
- добавлены итоги, качество, signed drill-down и CSV/XLSX
- исправлено вычисление когорты и назначены права

## Проверки
- PHP syntax для всех изменённых файлов
- JSON role definitions parse
- git diff --check
- PHPUnit/PHPStan локально недоступны: vendor отсутствует; проверка продолжается в CI