### PR TITLE
fix[admin]: восстановлена версионность источников ликвидности

### DIFF
--- a/app/BusinessModules/Core/Payments/Services/PaymentBudgetLimitService.php
+++ b/app/BusinessModules/Core/Payments/Services/PaymentBudgetLimitService.php
@@ -258,15 +258,19 @@ final class PaymentBudgetLimitService
 
     public function release(PaymentDocument $document, string $reason): void
     {
-        BudgetLimitReservation::query()
+        $reservations = BudgetLimitReservation::query()
             ->where('payment_document_id', $document->id)
             ->where('status', BudgetLimitReservation::STATUS_RESERVED)
-            ->update([
+            ->lockForUpdate()
+            ->get();
+
+        foreach ($reservations as $reservation) {
+            $reservation->update([
                 'status' => BudgetLimitReservation::STATUS_RELEASED,
                 'released_at' => now(),
                 'release_reason' => mb_substr($reason, 0, 255),
-                'updated_at' => now(),
             ]);
+        }
     }
 
     public function convertAfterPayment(PaymentDocument $document, ?PaymentTransaction $transaction = null): void

--- a/app/BusinessModules/Core/Payments/Services/PaymentDocumentService.php
+++ b/app/BusinessModules/Core/Payments/Services/PaymentDocumentService.php
@@ -455,10 +455,8 @@ class PaymentDocumentService
                 'value_date' => $paymentData['value_date'] ?? now(),
                 'status' => 'completed',
                 'notes' => $paymentData['notes'] ?? null,
-                'metadata' => json_encode($paymentData['metadata'] ?? []),
+                'metadata' => $paymentData['metadata'] ?? [],
                 'created_by_user_id' => $paymentData['created_by_user_id'] ?? null,
-                'created_at' => now(),
-                'updated_at' => now(),
             ];
 
             Log::info('payment_document.register_payment.checking_invoice_column', [
@@ -478,9 +476,9 @@ class PaymentDocumentService
                 'transaction_data_keys' => array_keys($transactionData),
             ]);
 
-            // Создаем транзакцию платежа
-            $transaction = DB::table('payment_transactions')->insertGetId($transactionData);
-            
+            $transactionModel = PaymentTransaction::query()->create($transactionData);
+            $transaction = (int) $transactionModel->getKey();
+
             Log::info('payment_document.register_payment.transaction_inserted', [
                 'document_id' => $document->id,
                 'transaction_id' => $transaction,
@@ -499,12 +497,9 @@ class PaymentDocumentService
                 'remaining_amount' => $newRemainingAmount,
             ]);
 
-            // Загружаем транзакцию как модель для уведомлений
-            $transactionModel = PaymentTransaction::find($transaction);
-            
             Log::info('payment_document.register_payment.transaction_loaded', [
                 'document_id' => $document->id,
-                'transaction_model_exists' => $transactionModel !== null,
+                'transaction_model_exists' => true,
             ]);
 
             // Отправляем уведомление получателю (если зарегистрирован)

--- a/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
+++ b/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
@@ -10,7 +10,13 @@ use App\BusinessModules\Features\Budgeting\Contracts\BudgetingReportSourceCloseS
 use App\BusinessModules\Features\Budgeting\Contracts\PlanFactSourceSnapshotReport;
 use App\BusinessModules\Features\Budgeting\Contracts\ProjectMarginSourceSnapshotReport;
 use App\BusinessModules\Features\Budgeting\Infrastructure\Persistence\EloquentBudgetingReportSourceCloseStore;
+use App\BusinessModules\Features\Budgeting\Models\BudgetAmount;
+use App\BusinessModules\Features\Budgeting\Models\BudgetLimitReservation;
+use App\BusinessModules\Features\Budgeting\Models\BudgetVersion;
+use App\BusinessModules\Features\Budgeting\Models\CashGapOpeningBalance;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBudgetVersionObserver;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquiditySourceVersionObserver;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\Budgeting\Services\BudgetCatalogService;
 use App\BusinessModules\Features\Budgeting\Services\BudgetImportFileReader;
@@ -95,6 +101,11 @@ final class BudgetingServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        BudgetAmount::observe(PortfolioLiquiditySourceVersionObserver::class);
+        BudgetLimitReservation::observe(PortfolioLiquiditySourceVersionObserver::class);
+        CashGapOpeningBalance::observe(PortfolioLiquiditySourceVersionObserver::class);
+        BudgetVersion::observe(PortfolioLiquidityBudgetVersionObserver::class);
+
         $this->app->afterResolving(
             ReportDefinitionBindingAssembler::class,
             function (ReportDefinitionBindingAssembler $assembler): void {

--- a/app/BusinessModules/Features/Budgeting/Models/BudgetVersion.php
+++ b/app/BusinessModules/Features/Budgeting/Models/BudgetVersion.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 final class BudgetVersion extends Model
@@ -63,6 +64,11 @@ final class BudgetVersion extends Model
     public function lines(): HasMany
     {
         return $this->hasMany(BudgetLine::class, 'budget_version_id');
+    }
+
+    public function amounts(): HasManyThrough
+    {
+        return $this->hasManyThrough(BudgetAmount::class, BudgetLine::class, 'budget_version_id', 'budget_line_id');
     }
 
     public function importBatches(): HasMany

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityAsOfSource.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityAsOfSource.php
@@ -96,6 +96,10 @@ final readonly class PortfolioLiquidityAsOfSource
 
                 continue;
             }
+            if ($version->source_type === 'budget_amount'
+                && ! in_array($payload['status'] ?? null, ['approved', 'active'], true)) {
+                continue;
+            }
             $calendarItems[] = $this->calendarItem($payload);
         }
 

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityBudgetVersionObserver.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityBudgetVersionObserver.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Features\Budgeting\Models\BudgetVersion;
+use DateTimeInterface;
+
+final readonly class PortfolioLiquidityBudgetVersionObserver
+{
+    public function __construct(private PortfolioLiquiditySourceVersionRecorder $recorder) {}
+
+    public function updated(BudgetVersion $version): void
+    {
+        if (! $version->wasChanged('status')) {
+            return;
+        }
+
+        $occurredAt = $version->updated_at instanceof DateTimeInterface ? $version->updated_at : now();
+        $version->amounts()
+            ->with(['line.version', 'line.article'])
+            ->orderBy('budget_amounts.id')
+            ->chunkById(500, function ($amounts) use ($occurredAt): void {
+                foreach ($amounts as $amount) {
+                    $this->recorder->record($amount, $occurredAt);
+                }
+            }, 'budget_amounts.id', 'id');
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquiditySourceVersionRecorder.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquiditySourceVersionRecorder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
 
 use App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem;
+use App\BusinessModules\Core\Payments\Enums\PaymentDocumentStatus;
+use App\BusinessModules\Core\Payments\Enums\PaymentTransactionStatus;
 use App\BusinessModules\Core\Payments\Models\PaymentDocument;
 use App\BusinessModules\Core\Payments\Models\PaymentSchedule;
 use App\BusinessModules\Core\Payments\Models\PaymentTransaction;
@@ -15,6 +17,7 @@ use App\BusinessModules\Features\Budgeting\Models\BudgetLimitReservation;
 use App\BusinessModules\Features\Budgeting\Models\CashGapOpeningBalance;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\Models\PortfolioLiquiditySourceGap;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\Models\PortfolioLiquiditySourceVersion;
+use App\BusinessModules\Features\Budgeting\Services\BudgetWorkflowService;
 use Carbon\CarbonImmutable;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
@@ -37,6 +40,7 @@ final readonly class PortfolioLiquiditySourceVersionRecorder
             return null;
         }
         [$sourceType, $sourceId, $organizationId] = $identity;
+        $tombstone = $tombstone || $this->isInactive($source);
         $item = $tombstone ? null : $this->calendarItem($source);
         if (! $tombstone
             && ! $source instanceof CashGapOpeningBalance
@@ -109,6 +113,48 @@ final readonly class PortfolioLiquiditySourceVersionRecorder
             $source instanceof BudgetAmount => $source->loadMissing(['line.version', 'line.article']),
             default => null,
         };
+    }
+
+    private function isInactive(Model $source): bool
+    {
+        if ($source instanceof PaymentDocument) {
+            $status = $source->status instanceof PaymentDocumentStatus
+                ? $source->status->value
+                : (string) $source->status;
+
+            return ! in_array($status, [
+                PaymentDocumentStatus::SUBMITTED->value,
+                PaymentDocumentStatus::PENDING_APPROVAL->value,
+                PaymentDocumentStatus::APPROVED->value,
+                PaymentDocumentStatus::SCHEDULED->value,
+                PaymentDocumentStatus::PARTIALLY_PAID->value,
+            ], true) || (float) $source->remaining_amount <= 0;
+        }
+        if ($source instanceof PaymentSchedule) {
+            return $source->status !== 'pending'
+                || (float) $source->paid_amount >= (float) $source->amount;
+        }
+        if ($source instanceof PaymentTransaction) {
+            $status = $source->status instanceof PaymentTransactionStatus
+                ? $source->status->value
+                : (string) $source->status;
+
+            return $status !== PaymentTransactionStatus::COMPLETED->value;
+        }
+        if ($source instanceof BudgetLimitReservation) {
+            return $source->status !== BudgetLimitReservation::STATUS_RESERVED;
+        }
+        if ($source instanceof BudgetAmount) {
+            return ! in_array($source->line?->version?->status, [
+                BudgetWorkflowService::STATUS_APPROVED,
+                BudgetWorkflowService::STATUS_ACTIVE,
+            ], true);
+        }
+        if ($source instanceof CashGapOpeningBalance) {
+            return $source->status !== CashGapOpeningBalance::STATUS_APPROVED;
+        }
+
+        return false;
     }
 
     private function calendarItem(Model $source): ?PaymentCalendarItem

--- a/app/BusinessModules/Features/Budgeting/Services/BudgetLineService.php
+++ b/app/BusinessModules/Features/Budgeting/Services/BudgetLineService.php
@@ -106,6 +106,17 @@ final class BudgetLineService
 
         DB::transaction(function () use ($version, $rows, $mode): void {
             if ($mode === 'replace_lines') {
+                BudgetAmount::query()
+                    ->whereHas(
+                        'line',
+                        static fn (Builder $query): Builder => $query->where('budget_version_id', $version->id),
+                    )
+                    ->orderBy('id')
+                    ->chunkById(500, static function ($amounts): void {
+                        foreach ($amounts as $amount) {
+                            $amount->delete();
+                        }
+                    });
                 BudgetLine::query()->where('budget_version_id', $version->id)->delete();
             }
 

--- a/app/BusinessModules/Features/Budgeting/Services/BudgetVersionService.php
+++ b/app/BusinessModules/Features/Budgeting/Services/BudgetVersionService.php
@@ -131,14 +131,19 @@ final class BudgetVersionService
             $toStatus = $this->workflowService->transition($fromStatus, $action, $version->lines()->exists());
 
             if ($action === 'activate') {
-                BudgetVersion::query()
+                $replacedVersions = BudgetVersion::query()
                     ->where('organization_id', $version->organization_id)
                     ->where('budget_period_id', $version->budget_period_id)
                     ->where('scenario_id', $version->scenario_id)
                     ->where('budget_kind', $version->budget_kind)
                     ->where('status', BudgetWorkflowService::STATUS_ACTIVE)
                     ->where('id', '!=', $version->id)
-                    ->update(['status' => BudgetWorkflowService::STATUS_REPLACED]);
+                    ->lockForUpdate()
+                    ->get();
+                foreach ($replacedVersions as $replacedVersion) {
+                    $replacedVersion->status = BudgetWorkflowService::STATUS_REPLACED;
+                    $replacedVersion->save();
+                }
             }
 
             $history = $version->workflow_history ?? [];

--- a/app/BusinessModules/Features/Budgeting/Services/BudgetWorkflowService.php
+++ b/app/BusinessModules/Features/Budgeting/Services/BudgetWorkflowService.php
@@ -111,14 +111,19 @@ final class BudgetWorkflowService
             $to = $this->transition($from, $action, $action !== 'submit' || $version->lines()->exists());
 
             if ($to === self::STATUS_ACTIVE) {
-                BudgetVersion::query()
+                $replacedVersions = BudgetVersion::query()
                     ->where('organization_id', $version->organization_id)
                     ->where('budget_period_id', $version->budget_period_id)
                     ->where('scenario_id', $version->scenario_id)
                     ->where('budget_kind', $version->budget_kind)
                     ->where('id', '!=', $version->id)
                     ->where('status', self::STATUS_ACTIVE)
-                    ->update(['status' => self::STATUS_REPLACED]);
+                    ->lockForUpdate()
+                    ->get();
+                foreach ($replacedVersions as $replacedVersion) {
+                    $replacedVersion->status = self::STATUS_REPLACED;
+                    $replacedVersion->save();
+                }
             }
 
             $history = $version->workflow_history ?? [];

--- a/tests/Feature/BusinessModules/Core/Payments/PaymentBudgetLimitLifecycleTest.php
+++ b/tests/Feature/BusinessModules/Core/Payments/PaymentBudgetLimitLifecycleTest.php
@@ -24,6 +24,7 @@ use App\Models\Module;
 use App\Models\OrganizationModuleActivation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\Support\AdminApiTestContext;
 use Tests\TestCase;
 
@@ -144,6 +145,17 @@ final class PaymentBudgetLimitLifecycleTest extends TestCase
             'status' => BudgetLimitReservation::STATUS_RELEASED,
             'release_reason' => 'Отменено',
         ]);
+        $reservation = BudgetLimitReservation::query()
+            ->where('payment_document_id', $document->id)
+            ->latest('id')
+            ->firstOrFail();
+        $versions = DB::table('budgeting_portfolio_liquidity_source_versions')
+            ->where('source_type', 'budget_limit_reservation')
+            ->where('source_id', (string) $reservation->id)
+            ->orderBy('id')
+            ->get();
+        $this->assertGreaterThanOrEqual(3, $versions->count());
+        $this->assertNull($versions->last()->payload);
 
         $document->forceFill(['status' => PaymentDocumentStatus::APPROVED])->save();
         $this->service()->syncReservation($document->fresh(), $context->user);

--- a/tests/Unit/Reporting/WaveOne/BudgetingPortfolioSourceTest.php
+++ b/tests/Unit/Reporting/WaveOne/BudgetingPortfolioSourceTest.php
@@ -200,6 +200,23 @@ final class BudgetingPortfolioSourceTest extends TestCase
     }
 
     #[Test]
+    public function budgeting_owner_registers_all_non_payment_liquidity_sources_for_versioning(): void
+    {
+        $provider = (string) file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php',
+        );
+
+        foreach ([
+            'BudgetAmount::observe(PortfolioLiquiditySourceVersionObserver::class)',
+            'BudgetLimitReservation::observe(PortfolioLiquiditySourceVersionObserver::class)',
+            'CashGapOpeningBalance::observe(PortfolioLiquiditySourceVersionObserver::class)',
+            'BudgetVersion::observe(PortfolioLiquidityBudgetVersionObserver::class)',
+        ] as $registration) {
+            self::assertStringContainsString($registration, $provider);
+        }
+    }
+
+    #[Test]
     public function production_materializer_requires_all_canonical_owner_sources_and_has_no_prepared_fallback(): void
     {
         $reflection = new ReflectionClass(BudgetingPortfolioProjectionService::class);


### PR DESCRIPTION
## Что изменено
- зарегистрированы владельцы бюджетных источников ликвидности
- статусы версий бюджета синхронизируются с append-only журналом
- освобождение резервов и платежные транзакции больше не обходят model events
- неактивные источники фиксируются tombstone-версиями
- добавлены узкие регрессионные проверки

## Проверки
- php -l для всех изменённых PHP-файлов
- git diff --check
- PHPUnit/PHPStan локально не запускались: vendor в workspace отсутствует; полная проверка выполняется штатным workflow

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored PaymentBudgetLimitService to use row locking when releasing budget reservations.</li>
<li>Updated PaymentDocumentService to use Eloquent models for transaction creation instead of raw DB queries.</li>
<li>Registered new observers in BudgetingServiceProvider for portfolio liquidity tracking.</li>
<li>Added new models and observers to handle budget version and liquidity source updates.</li>
</ul></div>