### PR TITLE
feat[admin]: добавить параметры отчёта ликвидности

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/PortfolioLiquidityReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/PortfolioLiquidityReportOptionsController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\PortfolioLiquidityReportOptionsRequest;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class PortfolioLiquidityReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private PortfolioLiquidityOptionsService $options,
+    ) {}
+
+    public function __invoke(PortfolioLiquidityReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, PortfolioLiquidityCandidateContract::CODE)['context'];
+
+        return AdminResponse::success($this->options->options($context->scope));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -84,7 +84,8 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.project-labor-cost.options',
             'admin.reports.payroll-readiness.options',
             'admin.reports.workforce-capacity.runs.store',
-            'admin.reports.workforce-capacity.options' => $this->targets->createRun(
+            'admin.reports.workforce-capacity.options',
+            'admin.reports.portfolio-liquidity.options' => $this->targets->createRun(
                 $this->routeId($request, 'reportCode'),
             ),
             'admin.reports.runs.show', 'admin.reports.runs.rows' => $this->targets->run(

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/PortfolioLiquidityReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/PortfolioLiquidityReportOptionsRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+final class PortfolioLiquidityReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return $this->forbiddenClientFieldsRules();
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -6,6 +6,7 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMat
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PortfolioLiquidityReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectLaborCostReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectMarginReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportCatalogController;
@@ -88,6 +89,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'workforce_capacity')
             ->middleware(['report.organization-scope', $resourceAccess])
             ->name('workforce-capacity.options');
+        Route::get('/portfolio-liquidity/options', PortfolioLiquidityReportOptionsController::class)
+            ->defaults('reportCode', 'portfolio_liquidity')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('portfolio-liquidity.options');
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityOptionsService.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Features\Budgeting\DTOs\CashGapForecastContext;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\ConnectionInterface;
+
+final readonly class PortfolioLiquidityOptionsService
+{
+    public function __construct(private ConnectionInterface $connection) {}
+
+    public function options(ReportScope $scope): array
+    {
+        $today = CarbonImmutable::today();
+        $projects = $this->connection->table('projects')
+            ->whereIn('id', $scope->projectIds)
+            ->where('status', 'active')
+            ->where('is_archived', false)
+            ->orderBy('name')
+            ->orderBy('id')
+            ->get(['id', 'name'])
+            ->map(static fn (object $project): array => [
+                'id' => (int) $project->id,
+                'name' => (string) $project->name,
+            ])
+            ->values()
+            ->all();
+        $currencies = $this->connection
+            ->table('budgeting_portfolio_liquidity_source_versions')
+            ->where('organization_id', $scope->organizationId)
+            ->whereNotNull('payload')
+            ->selectRaw("UPPER(payload->>'currency') AS currency")
+            ->whereRaw("payload->>'currency' ~ '^[A-Za-z]{3}$'")
+            ->distinct()
+            ->orderBy('currency')
+            ->pluck('currency')
+            ->map(static fn (mixed $currency): array => [
+                'id' => (string) $currency,
+                'name' => (string) $currency,
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'period' => [
+                'default_as_of' => $today->format('Y-m-d'),
+                'default_from' => $today->format('Y-m-d'),
+                'default_to' => $today->addDays(30)->format('Y-m-d'),
+                'max_horizon_days' => 366,
+            ],
+            'projects' => $projects,
+            'currencies' => $currencies,
+            'scenarios' => [
+                ['id' => CashGapForecastContext::SCENARIO_BASE, 'name' => 'Базовый'],
+                ['id' => CashGapForecastContext::SCENARIO_OPTIMISTIC, 'name' => 'Оптимистичный'],
+                ['id' => CashGapForecastContext::SCENARIO_PESSIMISTIC, 'name' => 'Пессимистичный'],
+                ['id' => CashGapForecastContext::SCENARIO_STRESS, 'name' => 'Стрессовый'],
+                ['id' => CashGapForecastContext::SCENARIO_CUSTOM, 'name' => 'Пользовательский'],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Reporting/PortfolioLiquidityOptionsContractTest.php
+++ b/tests/Unit/Reporting/PortfolioLiquidityOptionsContractTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting;
+
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityOptionsService;
+use PHPUnit\Framework\TestCase;
+
+final class PortfolioLiquidityOptionsContractTest extends TestCase
+{
+    public function test_options_route_uses_server_owned_scope_and_authorization(): void
+    {
+        $routes = file_get_contents(base_path('app/BusinessModules/Core/Reporting/routes.php'));
+        $middleware = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php',
+        ));
+        $controller = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Controllers/PortfolioLiquidityReportOptionsController.php',
+        ));
+
+        self::assertIsString($routes);
+        self::assertStringContainsString("Route::get('/portfolio-liquidity/options'", $routes);
+        self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
+        self::assertIsString($middleware);
+        self::assertStringContainsString("'admin.reports.portfolio-liquidity.options'", $middleware);
+        self::assertIsString($controller);
+        self::assertStringContainsString('->createRun($request, PortfolioLiquidityCandidateContract::CODE)', $controller);
+        self::assertStringContainsString('$context->scope', $controller);
+        self::assertStringNotContainsString('organization_id', $controller);
+        self::assertStringNotContainsString('project_id', $controller);
+    }
+
+    public function test_options_are_real_scope_data_and_canonical_scenarios(): void
+    {
+        $source = file_get_contents((new \ReflectionClass(PortfolioLiquidityOptionsService::class))->getFileName());
+
+        self::assertIsString($source);
+        self::assertStringContainsString("->whereIn('id', \$scope->projectIds)", $source);
+        self::assertStringContainsString("->where('organization_id', \$scope->organizationId)", $source);
+        self::assertStringContainsString("CashGapForecastContext::SCENARIO_BASE, 'name' => 'Базовый'", $source);
+        self::assertStringNotContainsString("'organization_id' =>", $source);
+    }
+}


### PR DESCRIPTION
Добавляет серверный endpoint реальных параметров R04 из авторизованного scope: доступные проекты, валюты источников, канонические сценарии и горизонт. Клиентские organization_id/project_id запрещены.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented a new Portfolio Liquidity report options endpoint, including controller, request validation, and service layer.</li>
<li>Added a new service to fetch active projects and available currencies for the portfolio liquidity report.</li>
<li>Registered the new route in the reporting module and updated the authorization middleware to include the new report.</li>
<li>Added a unit test to verify the contract for the new options route, ensuring proper middleware and authorization usage.</li>
</ul></div>