### PR TITLE
feat[admin]: добавлены параметры прогноза НЗП

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/WipCompletionForecastReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/WipCompletionForecastReportOptionsController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\WipCompletionForecastReportOptionsRequest;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class WipCompletionForecastReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private WipCompletionForecastOptionsService $options,
+    ) {}
+
+    public function __invoke(WipCompletionForecastReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, WipCompletionForecastCandidateContract::CODE)['context'];
+
+        return AdminResponse::success($this->options->options($context->scope));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -12,6 +12,7 @@ use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthor
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
@@ -79,6 +80,8 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.project-budget-plan-fact.options',
             'admin.reports.project-margin.runs.store',
             'admin.reports.project-margin.options',
+            'admin.reports.wip-completion-forecast.runs.store',
+            'admin.reports.wip-completion-forecast.options',
             'admin.reports.project-labor-cost.runs.store',
             'admin.reports.payroll-readiness.runs.store',
             'admin.reports.project-labor-cost.options',
@@ -126,6 +129,7 @@ final readonly class AuthorizeReportDefinitionAccess
         if (in_array($reportCode, [
             BudgetPlanFactCandidateContract::CODE,
             ProjectMarginCandidateContract::CODE,
+            WipCompletionForecastCandidateContract::CODE,
             ProjectLaborCostCandidateContract::CODE,
             PayrollReadinessCandidateContract::CODE,
             WorkforceCapacityCandidateContract::CODE,

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/WipCompletionForecastReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/WipCompletionForecastReportOptionsRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+final class WipCompletionForecastReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            ...$this->forbiddenClientFieldsRules(),
+            'project_id' => ['prohibited'],
+            'current_project_id' => ['prohibited'],
+            'scope' => ['prohibited'],
+            'actor_id' => ['prohibited'],
+        ];
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -9,6 +9,7 @@ use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessRe
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PortfolioLiquidityReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectLaborCostReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectMarginReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\WipCompletionForecastReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportCatalogController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportDrillDownController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportExportController;
@@ -112,6 +113,14 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'project_margin')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])
             ->name('project-margin.options');
+        Route::post('/projects/{project}/wip-completion-forecast/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'wip_completion_forecast')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('wip-completion-forecast.runs.store');
+        Route::get('/projects/{project}/wip-completion-forecast/options', WipCompletionForecastReportOptionsController::class)
+            ->defaults('reportCode', 'wip_completion_forecast')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('wip-completion-forecast.options');
         Route::post('/projects/{project}/project-labor-cost/runs', [ReportRunController::class, 'store'])
             ->defaults('reportCode', 'project_labor_cost')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])

--- a/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
+++ b/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
@@ -26,6 +26,7 @@ use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContr
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\ProjectFinanceQueryService;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastProvider;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastOptionsService;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastPublishedRuntimeBindingRegistrar;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Services\BudgetCatalogService;
@@ -92,6 +93,7 @@ final class BudgetingServiceProvider extends ServiceProvider
         $this->app->scoped(PortfolioLiquidityPublishedRuntimeBindingRegistrar::class);
         $this->app->singleton(WipCompletionForecastCandidateContract::class);
         $this->app->scoped(WipCompletionForecastProvider::class);
+        $this->app->scoped(WipCompletionForecastOptionsService::class);
         $this->app->scoped(ProjectFinanceQueryService::class);
         $this->app->scoped(WipCompletionForecastReportBindingFactory::class);
         $this->app->scoped(WipCompletionForecastPublishedRuntimeBindingRegistrar::class);

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastOptionsService.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Features\Budgeting\Models\EpmDataMartSnapshot;
+use App\BusinessModules\Features\Budgeting\Models\WipForecastVersion;
+use App\BusinessModules\Features\Budgeting\Services\EpmDataMartPayloadProjector;
+
+final readonly class WipCompletionForecastOptionsService
+{
+    public function options(ReportScope $scope): array
+    {
+        $projectId = count($scope->projectIds) === 1 ? $scope->projectIds[0] : null;
+        if ($projectId === null) {
+            return $this->unavailable('project_context_required');
+        }
+
+        $versions = WipForecastVersion::query()
+            ->where('organization_id', $scope->organizationId)
+            ->where('project_id', $projectId)
+            ->where('status', 'active')
+            ->orderByDesc('version_number')
+            ->limit(2)
+            ->get();
+        if ($versions->count() !== 1) {
+            return $this->unavailable('active_version_required');
+        }
+
+        $version = $versions->first();
+        $snapshot = EpmDataMartSnapshot::query()
+            ->where('organization_id', $scope->organizationId)
+            ->where('project_id', $projectId)
+            ->where('report_scope', 'wip_forecast')
+            ->where('status', 'succeeded')
+            ->where('formula_version', EpmDataMartPayloadProjector::FORMULA_VERSION)
+            ->whereNull('superseded_at')
+            ->where('period_start', $version->period_start)
+            ->where('period_end', $version->period_end)
+            ->latest('generated_at')
+            ->first();
+        if (! $snapshot instanceof EpmDataMartSnapshot) {
+            return [
+                ...$this->version($version),
+                'available' => false,
+                'reason' => 'source_snapshot_required',
+                'period' => null,
+                'currencies' => [],
+            ];
+        }
+
+        return [
+            ...$this->version($version),
+            'available' => true,
+            'reason' => null,
+            'period' => [
+                'from' => $snapshot->period_start?->format('Y-m-d'),
+                'to' => $snapshot->period_end?->format('Y-m-d'),
+                'as_of' => $snapshot->as_of_date?->format('Y-m-d'),
+                'run_as_of' => $snapshot->generated_at?->toIso8601String(),
+                'generated_at' => $snapshot->generated_at?->toIso8601String(),
+                'stale_at' => $snapshot->stale_at?->toIso8601String(),
+            ],
+            'currencies' => $snapshot->currency === null ? [] : [[
+                'id' => (string) $snapshot->currency,
+                'name' => (string) $snapshot->currency,
+            ]],
+        ];
+    }
+
+    private function unavailable(string $reason): array
+    {
+        return [
+            'available' => false,
+            'reason' => $reason,
+            'active_version' => null,
+            'period' => null,
+            'currencies' => [],
+        ];
+    }
+
+    private function version(WipForecastVersion $version): array
+    {
+        return ['active_version' => [
+            'id' => (int) $version->id,
+            'uuid' => (string) $version->uuid,
+            'name' => (string) $version->name,
+            'number' => (int) $version->version_number,
+            'status' => (string) $version->status,
+        ]];
+    }
+}

--- a/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
+++ b/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\AuthorizeReportDefinitionAccess;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastCandidateContract;
 use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
 use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
@@ -32,6 +33,8 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("->defaults('reportCode', 'project_margin')", $routes);
         self::assertStringContainsString("->middleware(['project.context', 'report.project-scope', \$resourceAccess])", $routes);
         self::assertStringContainsString("Route::get('/projects/{project}/project-margin/options'", $routes);
+        self::assertStringContainsString("Route::post('/projects/{project}/wip-completion-forecast/runs'", $routes);
+        self::assertStringContainsString("Route::get('/projects/{project}/wip-completion-forecast/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/project-labor-cost/runs'", $routes);
         self::assertStringContainsString("Route::get('/projects/{project}/project-labor-cost/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/payroll-readiness/runs'", $routes);
@@ -39,7 +42,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("Route::post('/workforce-capacity/runs'", $routes);
         self::assertStringContainsString("Route::get('/workforce-capacity/options'", $routes);
         self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
-        self::assertSame(8, substr_count($routes, "'report.project-scope'"));
+        self::assertSame(10, substr_count($routes, "'report.project-scope'"));
 
         $middlewareFile = (new ReflectionClass(AuthorizeReportDefinitionAccess::class))->getFileName();
         self::assertIsString($middlewareFile);
@@ -47,6 +50,8 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertIsString($middleware);
         self::assertStringContainsString("'admin.reports.project-margin.runs.store'", $middleware);
         self::assertStringContainsString("'admin.reports.project-margin.options'", $middleware);
+        self::assertStringContainsString("'admin.reports.wip-completion-forecast.runs.store'", $middleware);
+        self::assertStringContainsString("'admin.reports.wip-completion-forecast.options'", $middleware);
         self::assertStringContainsString('private function genericCreateRun', $middleware);
         self::assertStringContainsString('ProjectMarginCandidateContract::CODE', $middleware);
         self::assertStringContainsString('BudgetPlanFactCandidateContract::CODE', $middleware);
@@ -84,6 +89,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         return [
             'G09' => [ProjectMarginCandidateContract::CODE],
             'G10' => [BudgetPlanFactCandidateContract::CODE],
+            'G11' => [WipCompletionForecastCandidateContract::CODE],
             'G21' => [ProjectLaborCostCandidateContract::CODE],
             'G22' => [PayrollReadinessCandidateContract::CODE],
             'G19' => [WorkforceCapacityCandidateContract::CODE],

--- a/tests/Unit/Reporting/Http/WipCompletionForecastOptionsRequestContractTest.php
+++ b/tests/Unit/Reporting/Http/WipCompletionForecastOptionsRequestContractTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Http;
+
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\WipCompletionForecastReportOptionsRequest;
+use PHPUnit\Framework\TestCase;
+
+final class WipCompletionForecastOptionsRequestContractTest extends TestCase
+{
+    public function test_client_cannot_replace_server_owned_context(): void
+    {
+        $rules = (new WipCompletionForecastReportOptionsRequest)->rules();
+
+        foreach (['organization_id', 'project_id', 'current_project_id', 'user_id', 'actor_id', 'scope', 'permissions'] as $field) {
+            self::assertContains('prohibited', $rules[$field]);
+        }
+    }
+}


### PR DESCRIPTION
## Что сделано
- добавлены project-scoped routes запуска и options
- параметры берутся из единственной активной версии и фактического EPM-снимка
- организация, проект, пользователь и scope запрещены во входе клиента
- при отсутствии версии или снимка возвращается честное недоступное состояние

## Проверки
- php -l для всех изменённых PHP-файлов
- git diff --check
- PHPUnit локально недоступен: отсутствует vendor/bin/phpunit

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented WipCompletionForecastReportOptionsController to handle report options requests.</li>
<li>Created WipCompletionForecastOptionsService to fetch active WIP forecast versions and snapshots.</li>
<li>Added new routes for WIP completion forecast report runs and options.</li>
<li>Updated AuthorizeReportDefinitionAccess middleware to include authorization for the new report.</li>
<li>Added unit tests to verify route contracts and request validation.</li>
</ul></div>