### PR TITLE
fix[reports]: восстановлен каталог опубликованных отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportCatalogMetadata.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportCatalogMetadata.php
@@ -24,7 +24,7 @@ final readonly class ReportCatalogMetadata
             || trim($grain) === ''
             || ! in_array($wave, [1, 2, 3], true)
             || $manifestOrdinal < 0
-            || $manifestOrdinal > 27) {
+            || $manifestOrdinal > 28) {
             throw new InvalidArgumentException('report_catalog_metadata_invalid');
         }
     }

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -142,6 +142,41 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         self::assertSame('contractor_scorecard', $app->make(ReportSchedulingCapabilityRegistry::class)->published('contractor_scorecard')->code);
     }
 
+    public function test_provider_composes_metadata_for_every_published_builtin_report(): void
+    {
+        $app = new Application(dirname(__DIR__, 4));
+        $app->instance(DatabasePublishedReportDefinitionRegistry::class, $this->registry([]));
+        $app->instance(DatabaseReportCatalogMetadataRegistry::class, new class implements ReportCatalogMetadataRegistry
+        {
+            public function published(string $code): \App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata
+            {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+            }
+        });
+        $app->instance(DatabaseReportSchedulingCapabilityRegistry::class, new class implements ReportSchedulingCapabilityRegistry
+        {
+            public function published(string $code): \App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability
+            {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+            }
+        });
+        (new ReportingCatalogServiceProvider($app))->register();
+
+        $definitions = $app->make(ReportDefinitionRegistry::class);
+        $metadata = $app->make(ReportCatalogMetadataRegistry::class);
+        $ordinals = [];
+
+        foreach ($definitions->publishedCodes() as $code) {
+            $entry = $metadata->published($code);
+            self::assertSame($code, $entry->code);
+            $ordinals[] = $entry->manifestOrdinal;
+        }
+
+        self::assertSame(count($ordinals), count(array_unique($ordinals)));
+        self::assertContains(CustomerSlaCandidateContract::CODE, $definitions->publishedCodes());
+        self::assertContains(28, $ordinals);
+    }
+
     public function test_budget_plan_fact_is_available_without_database_publication(): void
     {
         $builtins = new BuiltinPublishedReportDefinitionRegistry(


### PR DESCRIPTION
## Причина\nПоследний опубликованный отчёт customer_sla имеет ordinal 28, однако DTO каталога ошибочно отклонял значение выше 27. При сборке каталога это вызывало 500 для всего endpoint.\n\n## Изменения\n- расширена допустимая граница ordinal до 28;\n- добавлен регрессионный тест полной композиции metadata для каждого опубликованного встроенного отчёта.\n\n## Проверки\n- php -l изменённых файлов;\n- git diff --check.\n\nPHPUnit и PHPStan не запущены: в рабочем каталоге отсутствует vendor/.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Increased the maximum allowed manifest ordinal value from 27 to 28 in ReportCatalogMetadata.</li>
<li>Added a new unit test to verify that all published built-in reports have valid, unique metadata, specifically confirming support for the new ordinal value 28.</li>
</ul></div>