### PR TITLE
feat[reports]: реальные options контроля EVM

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ProjectEvmControlReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ProjectEvmControlReportOptionsController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ProjectEvmControlReportOptionsRequest;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Services\ProjectEvmControlOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class ProjectEvmControlReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private ProjectEvmControlOptionsService $options,
+    ) {}
+
+    public function __invoke(ProjectEvmControlReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, ProjectEvmControlCandidateContract::CODE)['context'];
+
+        return AdminResponse::success($this->options->options($context->scope, $request->asOf()));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -82,6 +82,7 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.project-margin.runs.store',
             'admin.reports.project-margin.options',
             'admin.reports.project-evm-control.runs.store',
+            'admin.reports.project-evm-control.options',
             'admin.reports.wip-completion-forecast.runs.store',
             'admin.reports.wip-completion-forecast.options',
             'admin.reports.project-labor-cost.runs.store',

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/CreateReportRunRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/CreateReportRunRequest.php
@@ -8,7 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Input\CreateReportRunData;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
-use DateTimeImmutable;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
 
 final class CreateReportRunRequest extends ReportFormRequest
 {
@@ -30,7 +30,7 @@ final class CreateReportRunRequest extends ReportFormRequest
                 'required',
                 'string',
                 static function (string $attribute, mixed $value, callable $fail): void {
-                    if (self::parseAsOf($value) === null) {
+                    if (ReportAsOfParser::parse($value) === null) {
                         $fail(trans_message('reports.errors.report_request_invalid'));
                     }
                 },
@@ -58,7 +58,7 @@ final class CreateReportRunRequest extends ReportFormRequest
 
     public function toData(): CreateReportRunData
     {
-        $asOf = self::parseAsOf($this->validated('as_of'));
+        $asOf = ReportAsOfParser::parse($this->validated('as_of'));
         if ($asOf === null) {
             throw ReportContractException::fromCode(
                 ReportErrorCode::REPORT_REQUEST_INVALID,
@@ -74,27 +74,5 @@ final class CreateReportRunRequest extends ReportFormRequest
             (string) $this->validated('locale', 'ru-RU'),
             $this->validated('saved_view_id'),
         );
-    }
-
-    private static function parseAsOf(mixed $value): ?DateTimeImmutable
-    {
-        if (!is_string($value)
-            || preg_match(
-                '/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,6})?(?:Z|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])$/D',
-                $value,
-            ) !== 1) {
-            return null;
-        }
-
-        $format = str_contains($value, '.') ? '!Y-m-d\TH:i:s.uP' : '!Y-m-d\TH:i:sP';
-        $date = DateTimeImmutable::createFromFormat($format, $value);
-        $errors = DateTimeImmutable::getLastErrors();
-
-        if ($date === false
-            || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))) {
-            return null;
-        }
-
-        return $date;
     }
 }

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ProjectEvmControlReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ProjectEvmControlReportOptionsRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use DateTimeImmutable;
+
+final class ProjectEvmControlReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'as_of' => [
+                'required',
+                'string',
+                static function (string $attribute, mixed $value, callable $fail): void {
+                    if (ReportAsOfParser::parse($value) === null) {
+                        $fail(trans_message('reports.errors.report_request_invalid'));
+                    }
+                },
+            ],
+            ...$this->forbiddenClientFieldsRules(),
+            'project_id' => ['prohibited'],
+            'current_project_id' => ['prohibited'],
+            'scope' => ['prohibited'],
+            'actor_id' => ['prohibited'],
+        ];
+    }
+
+    protected function acceptedQueryFields(): array
+    {
+        return ['as_of'];
+    }
+
+    public function asOf(): DateTimeImmutable
+    {
+        $asOf = ReportAsOfParser::parse($this->validated('as_of'));
+        if ($asOf === null) {
+            throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => ['as_of']],
+            );
+        }
+
+        return $asOf;
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Support/ReportAsOfParser.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Support/ReportAsOfParser.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Support;
+
+use DateTimeImmutable;
+
+final class ReportAsOfParser
+{
+    public static function parse(mixed $value): ?DateTimeImmutable
+    {
+        if (! is_string($value)
+            || preg_match(
+                '/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,6})?(?:Z|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])$/D',
+                $value,
+            ) !== 1
+        ) {
+            return null;
+        }
+
+        $format = str_contains($value, '.') ? '!Y-m-d\TH:i:s.uP' : '!Y-m-d\TH:i:sP';
+        $date = DateTimeImmutable::createFromFormat($format, $value);
+        $errors = DateTimeImmutable::getLastErrors();
+        if ($date === false
+            || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))
+        ) {
+            return null;
+        }
+
+        return $date;
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -7,6 +7,7 @@ use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PortfolioLiquidityReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectEvmControlReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectLaborCostReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectMarginReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\WipCompletionForecastReportOptionsController;
@@ -117,6 +118,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'project_evm_control')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])
             ->name('project-evm-control.runs.store');
+        Route::get('/projects/{project}/project-evm-control/options', ProjectEvmControlReportOptionsController::class)
+            ->defaults('reportCode', 'project_evm_control')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('project-evm-control.options');
         Route::post('/projects/{project}/wip-completion-forecast/runs', [ReportRunController::class, 'store'])
             ->defaults('reportCode', 'wip_completion_forecast')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])

--- a/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
+++ b/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
@@ -29,6 +29,7 @@ use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmCo
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Providers\ProjectEvmControlReportProvider;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Queries\ProjectEvmControlRowQuery;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Readiness\ProjectControlReadinessProbe;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Services\ProjectEvmControlOptionsService;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\ProjectFinanceQueryService;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastCandidateContract;
@@ -103,6 +104,7 @@ final class BudgetingServiceProvider extends ServiceProvider
         $this->app->scoped(ProjectEvmControlRowQuery::class);
         $this->app->scoped(ProjectEvmControlDrillDownProvider::class);
         $this->app->scoped(ProjectControlReadinessProbe::class);
+        $this->app->scoped(ProjectEvmControlOptionsService::class);
         $this->app->scoped(ProjectEvmControlReportBindingFactory::class);
         $this->app->scoped(ProjectEvmControlPublishedRuntimeBindingRegistrar::class);
         $this->app->singleton(WipCompletionForecastCandidateContract::class);

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/Services/ProjectEvmControlOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/Services/ProjectEvmControlOptionsService.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Services;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\DTO\ProjectControlSourceIdentity;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\DTO\ProjectControlSourceRow;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Exceptions\ProjectControlSourceGapException;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
+use App\Enums\CurrencyCode;
+use DateTimeImmutable;
+use Illuminate\Database\ConnectionInterface;
+use InvalidArgumentException;
+
+final readonly class ProjectEvmControlOptionsService
+{
+    public function __construct(
+        private ProjectControlSourceAssembler $sources,
+        private ProjectEvmControlBuiltinPublishedReport $published,
+        private ConnectionInterface $connection,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function options(ReportScope $scope, DateTimeImmutable $asOf): array
+    {
+        $query = new ReportQuery(
+            $this->published->definition()->payload(),
+            $scope,
+            new ReportFilterSet(['status_date' => $asOf->format('Y-m-d')]),
+            [],
+            $asOf,
+            'ru-RU',
+        );
+
+        try {
+            $source = $this->sources->assemble($scope, $query);
+        } catch (ProjectControlSourceGapException) {
+            return $this->unavailable($asOf, 'source_incomplete');
+        } catch (InvalidArgumentException) {
+            return $this->unavailable($asOf, 'source_unavailable');
+        }
+
+        $identity = $source['identity'] ?? null;
+        $rows = $source['rows'] ?? null;
+        if (! $identity instanceof ProjectControlSourceIdentity || ! is_array($rows)) {
+            return $this->unavailable($asOf, 'source_unavailable');
+        }
+
+        $taskWbs = [];
+        $wbsCodes = [];
+        $contractorIds = [];
+        $costCenterIds = [];
+        $currencies = [];
+        foreach ($rows as $row) {
+            if (! $row instanceof ProjectControlSourceRow) {
+                return $this->unavailable($asOf, 'source_unavailable');
+            }
+            $taskWbs[$row->taskId] = $row->wbsCode;
+            if ($row->wbsCode !== null && trim($row->wbsCode) !== '') {
+                $wbsCodes[trim($row->wbsCode)] = true;
+            }
+            if ($row->contractorId !== null) {
+                $contractorIds[$row->contractorId] = true;
+            }
+            if ($row->costCenterId !== null) {
+                $costCenterIds[$row->costCenterId] = true;
+            }
+            $currencies[$row->amounts->currency] = true;
+        }
+
+        $tasks = $this->tasks($scope, $identity->scheduleId, $taskWbs);
+        $contractors = $this->namedOptions(
+            'contractors',
+            $scope->organizationId,
+            array_keys($contractorIds),
+        );
+        $costCenters = $this->namedOptions(
+            'responsibility_centers',
+            $scope->organizationId,
+            array_keys($costCenterIds),
+            true,
+        );
+        if (count($tasks) !== count($taskWbs)
+            || count($contractors) !== count($contractorIds)
+            || count($costCenters) !== count($costCenterIds)
+        ) {
+            return $this->unavailable($asOf, 'source_reference_missing');
+        }
+
+        $wbs = array_map(
+            static fn (string $code): array => ['id' => $code, 'name' => $code],
+            array_keys($wbsCodes),
+        );
+        $currencyLabels = CurrencyCode::options();
+        $currencyOptions = [];
+        foreach (array_keys($currencies) as $code) {
+            if (! isset($currencyLabels[$code])) {
+                return $this->unavailable($asOf, 'source_unavailable');
+            }
+            $currencyOptions[] = ['id' => $code, 'name' => $currencyLabels[$code]];
+        }
+        $baseline = $this->baseline($scope, $identity);
+        $wipVersion = $this->wipVersion($scope, $identity);
+        if ($baseline === null || $wipVersion === null) {
+            return $this->unavailable($asOf, 'source_reference_missing');
+        }
+
+        return [
+            'available' => true,
+            'reason' => null,
+            'as_of' => $this->exactDateTime($asOf),
+            'status_date' => $asOf->format('Y-m-d'),
+            'baseline' => $baseline,
+            'wip_version' => $wipVersion,
+            'tasks' => $tasks,
+            'wbs' => $this->sorted($wbs),
+            'contractors' => $contractors,
+            'cost_centers' => $costCenters,
+            'currencies' => $this->sorted($currencyOptions),
+        ];
+    }
+
+    /**
+     * @param  array<int, ?string>  $taskWbs
+     * @return list<array{id:int,name:string}>
+     */
+    private function tasks(ReportScope $scope, int $scheduleId, array $taskWbs): array
+    {
+        if ($taskWbs === []) {
+            return [];
+        }
+        $projectId = count($scope->projectIds) === 1 ? $scope->projectIds[0] : null;
+        if ($projectId === null) {
+            return [];
+        }
+        $rows = $this->connection->table('schedule_tasks as task')
+            ->join('project_schedules as schedule', function ($join): void {
+                $join->on('schedule.id', '=', 'task.schedule_id')
+                    ->on('schedule.organization_id', '=', 'task.organization_id');
+            })
+            ->where('task.organization_id', $scope->organizationId)
+            ->where('task.schedule_id', $scheduleId)
+            ->where('schedule.project_id', $projectId)
+            ->whereIn('task.id', array_keys($taskWbs))
+            ->get(['task.id', 'task.name']);
+
+        $options = [];
+        foreach ($rows as $row) {
+            $name = trim((string) $row->name);
+            if ($name === '') {
+                continue;
+            }
+            $wbs = $taskWbs[(int) $row->id] ?? null;
+            $options[] = [
+                'id' => (int) $row->id,
+                'name' => $wbs === null ? $name : $wbs.' — '.$name,
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<array{id:int,name:string}>
+     */
+    private function namedOptions(string $table, int $organizationId, array $ids, bool $withCode = false): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        $columns = $withCode ? ['id', 'name', 'code'] : ['id', 'name'];
+        $rows = $this->connection->table($table)
+            ->where('organization_id', $organizationId)
+            ->whereIn('id', $ids)
+            ->get($columns);
+
+        $options = [];
+        foreach ($rows as $row) {
+            $name = trim((string) $row->name);
+            if ($name === '') {
+                continue;
+            }
+            $code = $withCode ? trim((string) $row->code) : '';
+            $options[] = [
+                'id' => (int) $row->id,
+                'name' => $code === '' ? $name : $code.' — '.$name,
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /** @return array<string, mixed>|null */
+    private function baseline(ReportScope $scope, ProjectControlSourceIdentity $identity): ?array
+    {
+        $row = $this->connection->table('project_control_baseline_versions')
+            ->where('organization_id', $scope->organizationId)
+            ->where('project_id', $identity->projectId)
+            ->where('schedule_id', $identity->scheduleId)
+            ->where('version_number', $identity->baselineVersion)
+            ->first(['id', 'version_number', 'approved_at']);
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $row->id,
+            'version_number' => (int) $row->version_number,
+            'approved_at' => (new DateTimeImmutable((string) $row->approved_at))->format(DATE_ATOM),
+        ];
+    }
+
+    /** @return array<string, mixed>|null */
+    private function wipVersion(ReportScope $scope, ProjectControlSourceIdentity $identity): ?array
+    {
+        $value = str_starts_with($identity->wipVersion, 'wip_forecast:')
+            ? substr($identity->wipVersion, strlen('wip_forecast:'))
+            : '';
+        if ($value === '') {
+            return null;
+        }
+        $query = $this->connection->table('wip_forecast_versions')
+            ->where('organization_id', $scope->organizationId)
+            ->where('project_id', $identity->projectId);
+        if (ctype_digit($value)) {
+            $query->where('id', (int) $value);
+        } else {
+            $query->where('uuid', $value);
+        }
+        $row = $query->first(['id', 'uuid', 'name', 'version_number', 'status', 'as_of_date']);
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $row->id,
+            'uuid' => (string) $row->uuid,
+            'name' => (string) $row->name,
+            'version_number' => (int) $row->version_number,
+            'status' => (string) $row->status,
+            'as_of_date' => (string) $row->as_of_date,
+        ];
+    }
+
+    /** @param list<array{id:int|string,name:string}> $items */
+    private function sorted(array $items): array
+    {
+        usort($items, static fn (array $left, array $right): int => strnatcasecmp(
+            (string) $left['name'],
+            (string) $right['name'],
+        ));
+
+        return $items;
+    }
+
+    /** @return array<string, mixed> */
+    private function unavailable(DateTimeImmutable $asOf, string $reason): array
+    {
+        return [
+            'available' => false,
+            'reason' => $reason,
+            'as_of' => $this->exactDateTime($asOf),
+            'status_date' => $asOf->format('Y-m-d'),
+            'baseline' => null,
+            'wip_version' => null,
+            'tasks' => [],
+            'wbs' => [],
+            'contractors' => [],
+            'cost_centers' => [],
+            'currencies' => [],
+        ];
+    }
+
+    private function exactDateTime(DateTimeImmutable $value): string
+    {
+        return $value->format('u') === '000000'
+            ? $value->format(DATE_ATOM)
+            : $value->format('Y-m-d\TH:i:s.uP');
+    }
+}

--- a/tests/Unit/Budgeting/ProjectEvmControlOptionsServiceTest.php
+++ b/tests/Unit/Budgeting/ProjectEvmControlOptionsServiceTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Budgeting;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Services\ProjectControlSourceAssembler;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Services\ProjectEvmControlOptionsService;
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectEvmControlOptionsServiceTest extends TestCase
+{
+    private Capsule $database;
+
+    private ConnectionInterface $connection;
+
+    private ProjectEvmControlOptionsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->database = new Capsule;
+        $this->database->addConnection(['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+        $this->database->setAsGlobal();
+        $this->database->bootEloquent();
+        $this->connection = $this->database->getConnection();
+        $this->createSchema();
+        $this->seed();
+        $this->service = new ProjectEvmControlOptionsService(
+            new ProjectControlSourceAssembler,
+            new ProjectEvmControlBuiltinPublishedReport(new ProjectEvmControlCandidateContract),
+            $this->connection,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Model::unsetConnectionResolver();
+
+        parent::tearDown();
+    }
+
+    public function test_options_use_exact_runtime_source_and_server_project_scope(): void
+    {
+        $options = $this->service->options(
+            $this->scope(10),
+            new DateTimeImmutable('2026-08-04T15:00:00+03:00'),
+        );
+
+        self::assertTrue($options['available']);
+        self::assertNull($options['reason']);
+        self::assertSame('2026-08-04T15:00:00+03:00', $options['as_of']);
+        self::assertSame(2, $options['baseline']['version_number']);
+        self::assertSame(2, $options['wip_version']['version_number']);
+        self::assertSame([
+            ['id' => 1001, 'name' => '1 — Фундамент'],
+            ['id' => 1002, 'name' => '1.1 — Каркас'],
+        ], $options['tasks']);
+        self::assertSame([
+            ['id' => '1', 'name' => '1'],
+            ['id' => '1.1', 'name' => '1.1'],
+        ], $options['wbs']);
+        self::assertSame([['id' => 301, 'name' => 'Подрядчик А']], $options['contractors']);
+        self::assertSame([['id' => 401, 'name' => 'ЦФО-1 — Строительство']], $options['cost_centers']);
+        self::assertSame([
+            ['id' => 'RUB', 'name' => 'RUB'],
+            ['id' => 'USD', 'name' => 'USD'],
+        ], $options['currencies']);
+
+        $otherProject = $this->service->options(
+            $this->scope(20),
+            new DateTimeImmutable('2026-08-04T15:00:00+03:00'),
+        );
+        self::assertSame([['id' => 2001, 'name' => '9 — Чужой проект']], $otherProject['tasks']);
+    }
+
+    public function test_task_resource_scope_is_applied_by_the_same_runtime_assembler(): void
+    {
+        $scope = new ReportScope(
+            1,
+            [1],
+            [10],
+            [new ReportScopedResource('task', 1001, 10)],
+            new DateTimeZone('Europe/Moscow'),
+        );
+
+        $options = $this->service->options(
+            $scope,
+            new DateTimeImmutable('2026-08-04T15:00:00+03:00'),
+        );
+
+        self::assertTrue($options['available']);
+        self::assertSame([['id' => 1001, 'name' => '1 — Фундамент']], $options['tasks']);
+        self::assertSame([['id' => 'RUB', 'name' => 'RUB']], $options['currencies']);
+    }
+
+    public function test_exact_as_of_does_not_expose_sources_approved_later_the_same_day(): void
+    {
+        $beforeApproval = $this->service->options(
+            $this->scope(10),
+            new DateTimeImmutable('2026-08-04T10:00:00+03:00'),
+        );
+        $afterApproval = $this->service->options(
+            $this->scope(10),
+            new DateTimeImmutable('2026-08-04T15:00:00+03:00'),
+        );
+
+        self::assertTrue($beforeApproval['available']);
+        self::assertSame(1, $beforeApproval['baseline']['version_number']);
+        self::assertSame(1, $beforeApproval['wip_version']['version_number']);
+        self::assertCount(1, $beforeApproval['tasks']);
+        self::assertSame(2, $afterApproval['baseline']['version_number']);
+        self::assertSame(2, $afterApproval['wip_version']['version_number']);
+        self::assertCount(2, $afterApproval['tasks']);
+    }
+
+    public function test_runtime_source_gap_is_unavailable_instead_of_returning_partial_options(): void
+    {
+        $this->connection->table('wip_forecast_lines')->where('id', 2)->delete();
+
+        $options = $this->service->options(
+            $this->scope(10),
+            new DateTimeImmutable('2026-08-04T15:00:00+03:00'),
+        );
+
+        self::assertFalse($options['available']);
+        self::assertSame('source_incomplete', $options['reason']);
+        self::assertSame([], $options['tasks']);
+    }
+
+    public function test_runtime_validation_failure_is_unavailable_without_exposing_technical_reason(): void
+    {
+        $this->connection->table('wip_forecast_lines')->where('id', 2)->update([
+            'dimensions' => $this->json([
+                'task_id' => 1001,
+                'contractor_id' => 'invalid',
+                'cost_center_id' => 401,
+            ]),
+        ]);
+
+        $options = $this->service->options(
+            $this->scope(10),
+            new DateTimeImmutable('2026-08-04T15:00:00+03:00'),
+        );
+
+        self::assertFalse($options['available']);
+        self::assertSame('source_unavailable', $options['reason']);
+    }
+
+    private function scope(int $projectId): ReportScope
+    {
+        return new ReportScope(1, [1], [$projectId], [], new DateTimeZone('Europe/Moscow'));
+    }
+
+    private function createSchema(): void
+    {
+        foreach ([
+            'CREATE TABLE project_control_baseline_versions (id INTEGER PRIMARY KEY, organization_id INTEGER, project_id INTEGER, schedule_id INTEGER, version_number INTEGER, approved_at TEXT, approved_by INTEGER, source_hash TEXT, source_payload TEXT)',
+            'CREATE TABLE wip_forecast_versions (id INTEGER PRIMARY KEY, uuid TEXT, organization_id INTEGER, project_id INTEGER, version_number INTEGER, name TEXT, status TEXT, as_of_date TEXT, source_snapshot_hash TEXT, approved_by INTEGER NULL, activated_by INTEGER NULL, approved_at TEXT NULL, activated_at TEXT NULL, deleted_at TEXT NULL)',
+            'CREATE TABLE wip_forecast_lines (id INTEGER PRIMARY KEY, forecast_version_id INTEGER, organization_id INTEGER, project_id INTEGER, currency TEXT, percent_complete TEXT, ac TEXT, etc TEXT NULL, dimensions TEXT, group_values TEXT, source_row_refs TEXT)',
+            'CREATE TABLE project_schedules (id INTEGER PRIMARY KEY, organization_id INTEGER, project_id INTEGER)',
+            'CREATE TABLE schedule_tasks (id INTEGER PRIMARY KEY, organization_id INTEGER, schedule_id INTEGER, name TEXT)',
+            'CREATE TABLE contractors (id INTEGER PRIMARY KEY, organization_id INTEGER, name TEXT)',
+            'CREATE TABLE responsibility_centers (id INTEGER PRIMARY KEY, organization_id INTEGER, code TEXT, name TEXT)',
+        ] as $statement) {
+            $this->connection->statement($statement);
+        }
+    }
+
+    private function seed(): void
+    {
+        $this->connection->table('project_schedules')->insert([
+            ['id' => 50, 'organization_id' => 1, 'project_id' => 10],
+            ['id' => 60, 'organization_id' => 1, 'project_id' => 20],
+        ]);
+        $this->connection->table('schedule_tasks')->insert([
+            ['id' => 1001, 'organization_id' => 1, 'schedule_id' => 50, 'name' => 'Фундамент'],
+            ['id' => 1002, 'organization_id' => 1, 'schedule_id' => 50, 'name' => 'Каркас'],
+            ['id' => 2001, 'organization_id' => 1, 'schedule_id' => 60, 'name' => 'Чужой проект'],
+        ]);
+        $this->connection->table('contractors')->insert([
+            ['id' => 301, 'organization_id' => 1, 'name' => 'Подрядчик А'],
+            ['id' => 302, 'organization_id' => 1, 'name' => 'Подрядчик Б'],
+        ]);
+        $this->connection->table('responsibility_centers')->insert([
+            ['id' => 401, 'organization_id' => 1, 'code' => 'ЦФО-1', 'name' => 'Строительство'],
+            ['id' => 402, 'organization_id' => 1, 'code' => 'ЦФО-2', 'name' => 'Другой проект'],
+        ]);
+
+        $this->connection->table('project_control_baseline_versions')->insert([
+            $this->baseline(1, 10, 50, 1, '2026-08-01 08:00:00', [
+                $this->baselineRow(1001, '1', 'RUB'),
+            ]),
+            $this->baseline(2, 10, 50, 2, '2026-08-04 14:00:00', [
+                $this->baselineRow(1001, '1', 'RUB'),
+                $this->baselineRow(1002, '1.1', 'USD'),
+            ]),
+            $this->baseline(3, 20, 60, 1, '2026-08-01 08:00:00', [
+                $this->baselineRow(2001, '9', 'RUB'),
+            ]),
+        ]);
+        $this->connection->table('wip_forecast_versions')->insert([
+            $this->version(10, 'wip-10', 10, 1, 'Прогноз 1', '2026-08-01', '2026-08-01 09:00:00'),
+            $this->version(11, 'wip-11', 10, 2, 'Прогноз 2', '2026-08-04', '2026-08-04 14:00:00'),
+            $this->version(20, 'wip-20', 20, 1, 'Чужой прогноз', '2026-08-01', '2026-08-01 09:00:00'),
+        ]);
+        $this->connection->table('wip_forecast_lines')->insert([
+            $this->line(1, 10, 10, 1001, 'RUB', 301, 401),
+            $this->line(2, 11, 10, 1001, 'RUB', 301, 401),
+            $this->line(3, 11, 10, 1002, 'USD'),
+            $this->line(4, 20, 20, 2001, 'RUB', 302, 402),
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function baseline(int $id, int $projectId, int $scheduleId, int $version, string $approvedAt, array $rows): array
+    {
+        return [
+            'id' => $id,
+            'organization_id' => 1,
+            'project_id' => $projectId,
+            'schedule_id' => $scheduleId,
+            'version_number' => $version,
+            'approved_at' => $approvedAt,
+            'approved_by' => 7,
+            'source_hash' => str_repeat(dechex($id), 64),
+            'source_payload' => $this->json(['rows' => $rows]),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function baselineRow(int $taskId, string $wbs, string $currency): array
+    {
+        return [
+            'task_id' => $taskId,
+            'wbs_code' => $wbs,
+            'currency' => $currency,
+            'bac' => '100.00',
+            'baseline_curve_version' => 'curve-v1',
+            'baseline_curve' => [['date' => '2026-08-01', 'planned_value_minor' => 5000]],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function version(
+        int $id,
+        string $uuid,
+        int $projectId,
+        int $version,
+        string $name,
+        string $asOfDate,
+        string $activatedAt,
+    ): array {
+        return [
+            'id' => $id,
+            'uuid' => $uuid,
+            'organization_id' => 1,
+            'project_id' => $projectId,
+            'version_number' => $version,
+            'name' => $name,
+            'status' => 'active',
+            'as_of_date' => $asOfDate,
+            'source_snapshot_hash' => 'source-'.$id,
+            'approved_by' => null,
+            'activated_by' => 8,
+            'approved_at' => null,
+            'activated_at' => $activatedAt,
+            'deleted_at' => null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function line(
+        int $id,
+        int $versionId,
+        int $projectId,
+        int $taskId,
+        string $currency,
+        ?int $contractorId = null,
+        ?int $costCenterId = null,
+    ): array {
+        return [
+            'id' => $id,
+            'forecast_version_id' => $versionId,
+            'organization_id' => 1,
+            'project_id' => $projectId,
+            'currency' => $currency,
+            'percent_complete' => '50.0000',
+            'ac' => '40.00',
+            'etc' => '60.00',
+            'dimensions' => $this->json(array_filter([
+                'task_id' => $taskId,
+                'contractor_id' => $contractorId,
+                'cost_center_id' => $costCenterId,
+            ], static fn (mixed $value): bool => $value !== null)),
+            'group_values' => $this->json([]),
+            'source_row_refs' => $this->json([]),
+        ];
+    }
+
+    private function json(array $value): string
+    {
+        return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/tests/Unit/Reporting/Http/ProjectEvmControlOptionsRequestContractTest.php
+++ b/tests/Unit/Reporting/Http/ProjectEvmControlOptionsRequestContractTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Http;
+
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ProjectEvmControlReportOptionsRequest;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectEvmControlOptionsRequestContractTest extends TestCase
+{
+    public function test_client_cannot_replace_server_owned_context(): void
+    {
+        $rules = (new ProjectEvmControlReportOptionsRequest)->rules();
+
+        foreach (['organization_id', 'project_id', 'current_project_id', 'user_id', 'actor_id', 'scope', 'permissions'] as $field) {
+            self::assertContains('prohibited', $rules[$field]);
+        }
+    }
+
+    public function test_options_require_the_same_exact_as_of_contract_as_runtime(): void
+    {
+        $rules = (new ProjectEvmControlReportOptionsRequest)->rules();
+
+        self::assertSame(['required', 'string'], array_slice($rules['as_of'], 0, 2));
+        $parsed = ReportAsOfParser::parse('2026-08-05T14:15:16.123456+03:00');
+        self::assertNotNull($parsed);
+        self::assertSame('123456', $parsed->format('u'));
+    }
+
+    #[DataProvider('invalidAsOfProvider')]
+    public function test_invalid_as_of_is_rejected_by_shared_parser(mixed $value): void
+    {
+        self::assertNull(ReportAsOfParser::parse($value));
+    }
+
+    public static function invalidAsOfProvider(): array
+    {
+        return [
+            'date only' => ['2026-08-05'],
+            'timezone missing' => ['2026-08-05T14:15:16'],
+            'invalid day' => ['2026-02-30T14:15:16Z'],
+            'too many fractions' => ['2026-08-05T14:15:16.1234567Z'],
+            'not string' => [123],
+        ];
+    }
+}

--- a/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
+++ b/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
@@ -35,6 +35,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("->middleware(['project.context', 'report.project-scope', \$resourceAccess])", $routes);
         self::assertStringContainsString("Route::get('/projects/{project}/project-margin/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/project-evm-control/runs'", $routes);
+        self::assertStringContainsString("Route::get('/projects/{project}/project-evm-control/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/wip-completion-forecast/runs'", $routes);
         self::assertStringContainsString("Route::get('/projects/{project}/wip-completion-forecast/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/project-labor-cost/runs'", $routes);
@@ -44,7 +45,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("Route::post('/workforce-capacity/runs'", $routes);
         self::assertStringContainsString("Route::get('/workforce-capacity/options'", $routes);
         self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
-        self::assertSame(11, substr_count($routes, "'report.project-scope'"));
+        self::assertSame(12, substr_count($routes, "'report.project-scope'"));
 
         $middlewareFile = (new ReflectionClass(AuthorizeReportDefinitionAccess::class))->getFileName();
         self::assertIsString($middlewareFile);
@@ -53,6 +54,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("'admin.reports.project-margin.runs.store'", $middleware);
         self::assertStringContainsString("'admin.reports.project-margin.options'", $middleware);
         self::assertStringContainsString("'admin.reports.project-evm-control.runs.store'", $middleware);
+        self::assertStringContainsString("'admin.reports.project-evm-control.options'", $middleware);
         self::assertStringContainsString("'admin.reports.wip-completion-forecast.runs.store'", $middleware);
         self::assertStringContainsString("'admin.reports.wip-completion-forecast.options'", $middleware);
         self::assertStringContainsString('private function genericCreateRun', $middleware);

--- a/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
+++ b/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
@@ -10,6 +10,7 @@ use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\BindOrganizationRep
 use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\BindProjectReportScope;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\CreateReportRunRequest;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\GetReportCatalogRequest;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ProjectEvmControlReportOptionsRequest;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ProjectLaborCostReportOptionsRequest;
 use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ReportFormRequest;
 use App\Domain\Authorization\Http\Middleware\InterfaceMiddleware;
@@ -105,6 +106,21 @@ final class ReportInterfaceMiddlewareContractTest extends TestCase
 
         self::assertSame(ReportErrorCode::REPORT_REQUEST_INVALID, $exception->errorCode);
         self::assertSame(['fields' => ['search']], $exception->safeFields);
+    }
+
+    public function test_project_evm_options_reject_inexact_as_of(): void
+    {
+        $request = $this->reportRequest(
+            ProjectEvmControlReportOptionsRequest::class,
+            'GET',
+            ['as_of' => '2026-08-05'],
+            [],
+        );
+
+        $exception = $this->middlewareValidationException($request);
+
+        self::assertSame(ReportErrorCode::REPORT_REQUEST_INVALID, $exception->errorCode);
+        self::assertSame(['fields' => ['as_of']], $exception->safeFields);
     }
 
     public function test_project_report_scope_rejects_client_supplied_organization_or_project(): void
@@ -406,6 +422,12 @@ final class ReportInterfaceMiddlewareContractTest extends TestCase
                 ProjectLaborCostReportOptionsRequest::class,
                 'GET',
                 ['type' => 'employees', 'search' => 'Иванов', 'page' => 2],
+                [],
+            ],
+            'project evm options' => [
+                ProjectEvmControlReportOptionsRequest::class,
+                'GET',
+                ['as_of' => '2026-08-05T23:59:59+03:00'],
                 [],
             ],
         ];


### PR DESCRIPTION
## Что изменено
- добавлен project-scoped options endpoint для R05 project_evm_control
- полный permission/ABAC-контекст берётся через ReportHttpAuthorizationOrchestrator
- options используют тот же ProjectControlSourceAssembler и точный as_of, что runtime
- возвращаются только реальные задачи, WBS, подрядчики, ЦФО и валюты выбранного сервером проекта
- source gaps и невалидные данные закрываются unavailable без технического текста
- общий точный parser as_of вынесен без изменения runtime-контракта

## Проверки
- php -l: 12 затронутых PHP-файлов
- git diff --check
- ручной smoke parser exact as_of
- независимое review: clean
- PHPUnit/PHPStan локально недоступны: vendor отсутствует; исполняемые проверки выполняет CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced ProjectEvmControlReportOptionsController to handle EVM control report options.</li>
<li>Refactored 'as_of' date parsing into a dedicated ReportAsOfParser service.</li>
<li>Updated middleware to authorize access to the new EVM control options route.</li>
<li>Added new request validation and service logic for EVM control report options.</li>
<li>Added unit tests for the new service and request contracts.</li>
</ul></div>