### PR TITLE
fix[reports]: evidence суммы фиксированных распределений

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/Reporting/DTO/HoldingAllocationContextSnapshot.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/DTO/HoldingAllocationContextSnapshot.php
@@ -18,20 +18,35 @@ final readonly class HoldingAllocationContextSnapshot
         public int $organizationId,
         public int $projectId,
         public string $allocationType,
-        public string $allocatedPercentage,
+        public ?string $allocatedAmount,
+        public ?string $allocatedPercentage,
         public string $evidenceHash,
         public string $coverageStartedAt,
     ) {
-        try {
-            $percentage = BigDecimal::of($allocatedPercentage);
-        } catch (MathException) {
-            throw new InvalidArgumentException('holding_allocation_context_snapshot_invalid');
+        $amount = null;
+        if ($allocatedAmount !== null) {
+            try {
+                $amount = BigDecimal::of($allocatedAmount);
+            } catch (MathException) {
+                throw new InvalidArgumentException('holding_allocation_context_snapshot_invalid');
+            }
         }
+        $percentage = null;
+        if ($allocatedPercentage !== null) {
+            try {
+                $percentage = BigDecimal::of($allocatedPercentage);
+            } catch (MathException) {
+                throw new InvalidArgumentException('holding_allocation_context_snapshot_invalid');
+            }
+        }
+        $type = ContractAllocationTypeEnum::tryFrom($allocationType);
 
         if (min($eventId, $allocationId, $contractId, $organizationId, $projectId) < 1
-            || ContractAllocationTypeEnum::tryFrom($allocationType) === null
-            || $percentage->isNegative()
-            || $percentage->isGreaterThan(100)
+            || $type === null
+            || ($amount !== null && $amount->isNegative())
+            || ($percentage !== null && ($percentage->isNegative() || $percentage->isGreaterThan(100)))
+            || ($type === ContractAllocationTypeEnum::FIXED && $amount === null)
+            || ($type !== ContractAllocationTypeEnum::FIXED && $percentage === null)
             || preg_match('/^[a-f0-9]{64}$/D', $evidenceHash) !== 1
             || trim($coverageStartedAt) === '') {
             throw new InvalidArgumentException('holding_allocation_context_snapshot_invalid');

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Listeners/ProjectHoldingAllocationFacts.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Listeners/ProjectHoldingAllocationFacts.php
@@ -87,6 +87,7 @@ final readonly class ProjectHoldingAllocationFacts implements ShouldQueueAfterCo
                 $contractId,
                 $projectId,
                 $recognizedAt,
+                requirePercentage: true,
             );
         } catch (InvalidArgumentException $exception) {
             $allocation = null;

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingAllocationContextResolver.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingAllocationContextResolver.php
@@ -22,6 +22,7 @@ final readonly class HoldingAllocationContextResolver
         DateTimeInterface $asOf,
         ?int $allocationId = null,
         bool $requireActive = true,
+        bool $requirePercentage = false,
     ): HoldingAllocationContextSnapshot {
         if (min($organizationId, $contractId, $projectId) < 1
             || ($allocationId !== null && $allocationId < 1)) {
@@ -54,10 +55,14 @@ final readonly class HoldingAllocationContextResolver
         $event = $latest
             ->orderByDesc('allocation_id')
             ->first();
-        if (! is_object($event)
-            || (int) $event->organization_id !== $organizationId
-            || ! (bool) $event->is_resolvable
-            || $event->allocated_percentage === null
+        if (! is_object($event) || (int) $event->organization_id !== $organizationId) {
+            throw new InvalidArgumentException('holding_allocation_context_unavailable');
+        }
+        $effectiveCoverage = (string) $event->allocation_type === 'fixed'
+            ? $this->coverage->assertCovers(HoldingReportingSourceCoverage::ALLOCATION_AMOUNTS, $asOf)
+            : $coverage;
+        if (! (bool) $event->is_resolvable
+            || ($requirePercentage && $event->allocated_percentage === null)
             || ($requireActive && ((bool) $event->is_deleted || ! (bool) $event->is_active))) {
             throw new InvalidArgumentException('holding_allocation_context_unavailable');
         }
@@ -69,9 +74,10 @@ final readonly class HoldingAllocationContextResolver
             (int) $event->organization_id,
             (int) $event->project_id,
             (string) $event->allocation_type,
-            (string) $event->allocated_percentage,
+            $event->allocated_amount === null ? null : (string) $event->allocated_amount,
+            $event->allocated_percentage === null ? null : (string) $event->allocated_percentage,
             (string) $event->evidence_hash,
-            (string) $coverage['coverage_started_at'],
+            (string) $effectiveCoverage['coverage_started_at'],
         );
     }
 }

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingAllocationFactProjector.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingAllocationFactProjector.php
@@ -160,33 +160,39 @@ final readonly class HoldingAllocationFactProjector
                 $history->created_at,
                 allocationId: (int) $allocation->getKey(),
                 requireActive: $active,
+                requirePercentage: $type !== ContractAllocationTypeEnum::FIXED,
             );
             if ($allocationContext->allocationId !== (int) $allocation->getKey()
                 || $allocationContext->allocationType !== $type->value) {
                 throw new InvalidArgumentException('holding_allocation_context_unavailable');
             }
-            $expectedPercentage = ! $active
-                ? BigDecimal::of(0)
-                : match ($type) {
-                    ContractAllocationTypeEnum::FIXED => BigDecimal::of(
-                        (string) ($state['allocated_amount'] ?? throw new InvalidArgumentException(
-                            'holding_allocation_context_unavailable',
-                        )),
-                    )
-                        ->multipliedBy(100)
-                        ->dividedBy(BigDecimal::of($dimensionTotal), 8, RoundingMode::HalfUp),
-                    ContractAllocationTypeEnum::PERCENTAGE => BigDecimal::of(
-                        (string) ($state['allocated_percentage'] ?? throw new InvalidArgumentException(
-                            'holding_allocation_context_unavailable',
-                        )),
-                    ),
-                    ContractAllocationTypeEnum::AUTO,
-                    ContractAllocationTypeEnum::CUSTOM => BigDecimal::of(
-                        $allocationContext->allocatedPercentage,
-                    ),
-                };
-            if (! BigDecimal::of($allocationContext->allocatedPercentage)->isEqualTo($expectedPercentage)) {
-                throw new InvalidArgumentException('holding_allocation_context_unavailable');
+            if ($type === ContractAllocationTypeEnum::FIXED) {
+                $expectedAmount = BigDecimal::of(
+                    $active ? (string) ($state['allocated_amount'] ?? '') : '0',
+                );
+                if ($allocationContext->allocatedAmount === null
+                    || ! BigDecimal::of($allocationContext->allocatedAmount)->isEqualTo($expectedAmount)) {
+                    throw new InvalidArgumentException('holding_allocation_context_unavailable');
+                }
+            } else {
+                $expectedPercentage = ! $active
+                    ? BigDecimal::of(0)
+                    : match ($type) {
+                        ContractAllocationTypeEnum::PERCENTAGE => BigDecimal::of(
+                            (string) ($state['allocated_percentage'] ?? throw new InvalidArgumentException(
+                                'holding_allocation_context_unavailable',
+                            )),
+                        ),
+                        ContractAllocationTypeEnum::AUTO,
+                        ContractAllocationTypeEnum::CUSTOM => BigDecimal::of(
+                            $allocationContext->allocatedPercentage
+                                ?? throw new InvalidArgumentException('holding_allocation_context_unavailable'),
+                        ),
+                    };
+                if ($allocationContext->allocatedPercentage === null
+                    || ! BigDecimal::of($allocationContext->allocatedPercentage)->isEqualTo($expectedPercentage)) {
+                    throw new InvalidArgumentException('holding_allocation_context_unavailable');
+                }
             }
         } catch (InvalidArgumentException|MathException $exception) {
             $this->recordGap([
@@ -207,7 +213,7 @@ final readonly class HoldingAllocationFactProjector
         $counterpartyOrganizationId = $dimension->counterpartyOrganizationId;
 
         $fixedMinor = $type === ContractAllocationTypeEnum::FIXED
-            ? $this->moneyToMinor($active ? (string) ($state['allocated_amount'] ?? '0') : '0')
+            ? $this->moneyToMinor($allocationContext->allocatedAmount ?? '0')
             : null;
         $percentage = $type !== ContractAllocationTypeEnum::FIXED
             ? ($active ? $allocationContext->allocatedPercentage : '0')

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingReportingSourceCoverage.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingReportingSourceCoverage.php
@@ -17,6 +17,8 @@ final readonly class HoldingReportingSourceCoverage
 
     public const ALLOCATION_DIMENSIONS = 'allocation_dimensions';
 
+    public const ALLOCATION_AMOUNTS = 'allocation_amount_dimensions';
+
     public function assertCovers(string $sourceCode, DateTimeInterface $asOf): array
     {
         $coverage = DB::table('holding_reporting_context_coverage')

--- a/database/migrations/2026_08_05_020000_capture_holding_fixed_allocation_amount_evidence.php
+++ b/database/migrations/2026_08_05_020000_capture_holding_fixed_allocation_amount_evidence.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('holding_allocation_context_events', function (Blueprint $table): void {
+            $table->decimal('allocated_amount', 20, 2)->nullable()->after('allocation_type');
+        });
+
+        DB::unprepared(<<<'SQL'
+CREATE OR REPLACE FUNCTION most_capture_holding_allocation_context_for_contract_v1(
+    contract_key bigint,
+    observed_value timestamptz
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    allocation_row record;
+    project_count bigint;
+    total_accepted numeric;
+    project_accepted numeric;
+    resolved_amount numeric;
+    resolved_percentage numeric;
+    resolvable_value boolean;
+    evidence_payload jsonb;
+BEGIN
+    SELECT COUNT(DISTINCT project_id)
+    INTO project_count
+    FROM contract_project
+    WHERE contract_id = contract_key;
+
+    SELECT COALESCE(SUM(amount) FILTER (WHERE is_approved), 0)
+    INTO total_accepted
+    FROM contract_performance_acts
+    WHERE contract_id = contract_key;
+
+    FOR allocation_row IN
+        SELECT
+            allocations.id,
+            allocations.contract_id,
+            contracts.organization_id,
+            allocations.project_id,
+            allocations.allocation_type,
+            allocations.allocated_amount,
+            allocations.allocated_percentage,
+            allocations.custom_formula,
+            allocations.is_active,
+            allocations.deleted_at,
+            contracts.total_amount,
+            contracts.is_multi_project,
+            contracts.deleted_at AS contract_deleted_at
+        FROM contract_project_allocations AS allocations
+        JOIN contracts ON contracts.id = allocations.contract_id
+        WHERE allocations.contract_id = contract_key
+    LOOP
+        resolved_amount := NULL;
+        resolved_percentage := NULL;
+
+        IF allocation_row.deleted_at IS NULL
+            AND allocation_row.contract_deleted_at IS NULL
+            AND allocation_row.is_active THEN
+            CASE allocation_row.allocation_type
+                WHEN 'fixed' THEN
+                    resolved_amount := allocation_row.allocated_amount;
+                    IF allocation_row.total_amount > 0 AND allocation_row.allocated_amount >= 0 THEN
+                        resolved_percentage := allocation_row.allocated_amount * 100 / allocation_row.total_amount;
+                    END IF;
+                WHEN 'percentage' THEN
+                    resolved_percentage := allocation_row.allocated_percentage;
+                WHEN 'auto' THEN
+                    IF NOT allocation_row.is_multi_project THEN
+                        resolved_percentage := 100;
+                    ELSIF total_accepted > 0 THEN
+                        SELECT COALESCE(SUM(amount) FILTER (WHERE is_approved), 0)
+                        INTO project_accepted
+                        FROM contract_performance_acts
+                        WHERE contract_id = contract_key
+                            AND project_id = allocation_row.project_id;
+                        resolved_percentage := project_accepted * 100 / total_accepted;
+                    ELSIF project_count > 0 THEN
+                        resolved_percentage := 100::numeric / project_count;
+                    END IF;
+                WHEN 'custom' THEN
+                    IF jsonb_typeof(allocation_row.custom_formula::jsonb) = 'object'
+                        AND allocation_row.custom_formula::jsonb->>'type' = 'coefficient' THEN
+                        IF NOT allocation_row.custom_formula::jsonb ? 'coefficient' THEN
+                            resolved_percentage := 100;
+                        ELSIF (allocation_row.custom_formula::jsonb->>'coefficient') ~ '^-?[0-9]+([.][0-9]+)?$' THEN
+                            resolved_percentage := (allocation_row.custom_formula::jsonb->>'coefficient')::numeric * 100;
+                        END IF;
+                    END IF;
+            END CASE;
+        ELSE
+            resolved_amount := CASE WHEN allocation_row.allocation_type = 'fixed' THEN 0 ELSE NULL END;
+            resolved_percentage := 0;
+        END IF;
+
+        IF resolved_percentage IS NOT NULL THEN
+            resolved_percentage := round(resolved_percentage, 8);
+        END IF;
+        resolvable_value := CASE allocation_row.allocation_type
+            WHEN 'fixed' THEN resolved_amount IS NOT NULL AND resolved_amount >= 0
+            ELSE resolved_percentage IS NOT NULL
+                AND resolved_percentage >= 0
+                AND resolved_percentage <= 100
+        END;
+        evidence_payload := jsonb_build_object(
+            'allocation_id', allocation_row.id,
+            'contract_id', allocation_row.contract_id,
+            'organization_id', allocation_row.organization_id,
+            'project_id', allocation_row.project_id,
+            'allocation_type', allocation_row.allocation_type,
+            'allocated_amount', resolved_amount,
+            'allocated_percentage', resolved_percentage,
+            'is_resolvable', resolvable_value,
+            'is_active', allocation_row.is_active,
+            'is_deleted', allocation_row.deleted_at IS NOT NULL
+                OR allocation_row.contract_deleted_at IS NOT NULL
+        );
+
+        INSERT INTO holding_allocation_context_events (
+            allocation_id,
+            contract_id,
+            organization_id,
+            project_id,
+            allocation_type,
+            allocated_amount,
+            allocated_percentage,
+            is_resolvable,
+            is_active,
+            observed_at,
+            is_deleted,
+            evidence_hash
+        ) VALUES (
+            allocation_row.id,
+            allocation_row.contract_id,
+            allocation_row.organization_id,
+            allocation_row.project_id,
+            allocation_row.allocation_type,
+            resolved_amount,
+            resolved_percentage,
+            resolvable_value,
+            allocation_row.is_active,
+            observed_value,
+            allocation_row.deleted_at IS NOT NULL OR allocation_row.contract_deleted_at IS NOT NULL,
+            encode(sha256(convert_to(evidence_payload::text || '|' || observed_value::text, 'UTF8')), 'hex')
+        );
+    END LOOP;
+END;
+$$
+SQL);
+
+        DB::unprepared(<<<'SQL'
+CREATE OR REPLACE FUNCTION most_capture_holding_allocation_context_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    old_contract_id bigint;
+    new_contract_id bigint;
+    organization_value bigint;
+    observed_value timestamptz;
+    evidence_payload jsonb;
+BEGIN
+    observed_value := clock_timestamp();
+    old_contract_id := CASE WHEN TG_OP = 'INSERT' THEN NULL ELSE OLD.contract_id END;
+    new_contract_id := CASE WHEN TG_OP = 'DELETE' THEN NULL ELSE NEW.contract_id END;
+
+    IF TG_OP = 'DELETE' THEN
+        SELECT organization_id
+        INTO organization_value
+        FROM contracts
+        WHERE id = OLD.contract_id;
+        IF organization_value IS NULL THEN
+            SELECT organization_id
+            INTO organization_value
+            FROM holding_allocation_context_events
+            WHERE allocation_id = OLD.id
+            ORDER BY observed_at DESC, id DESC
+            LIMIT 1;
+        END IF;
+        evidence_payload := jsonb_build_object(
+            'allocation_id', OLD.id,
+            'contract_id', OLD.contract_id,
+            'organization_id', organization_value,
+            'project_id', OLD.project_id,
+            'allocation_type', OLD.allocation_type,
+            'allocated_amount', CASE WHEN OLD.allocation_type = 'fixed' THEN 0 ELSE NULL END,
+            'allocated_percentage', 0,
+            'is_resolvable', true,
+            'is_active', false,
+            'is_deleted', true
+        );
+        INSERT INTO holding_allocation_context_events (
+            allocation_id,
+            contract_id,
+            organization_id,
+            project_id,
+            allocation_type,
+            allocated_amount,
+            allocated_percentage,
+            is_resolvable,
+            is_active,
+            observed_at,
+            is_deleted,
+            evidence_hash
+        ) VALUES (
+            OLD.id,
+            OLD.contract_id,
+            organization_value,
+            OLD.project_id,
+            OLD.allocation_type,
+            CASE WHEN OLD.allocation_type = 'fixed' THEN 0 ELSE NULL END,
+            0,
+            true,
+            false,
+            observed_value,
+            true,
+            encode(sha256(convert_to(evidence_payload::text || '|' || observed_value::text, 'UTF8')), 'hex')
+        );
+    END IF;
+
+    IF old_contract_id IS NOT NULL THEN
+        PERFORM most_capture_holding_allocation_context_for_contract_v1(old_contract_id, observed_value);
+    END IF;
+    IF new_contract_id IS NOT NULL AND new_contract_id IS DISTINCT FROM old_contract_id THEN
+        PERFORM most_capture_holding_allocation_context_for_contract_v1(new_contract_id, observed_value);
+    END IF;
+
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$
+SQL);
+
+        DB::unprepared(<<<'SQL'
+CREATE OR REPLACE FUNCTION most_capture_holding_fixed_allocation_checkpoint_v1(
+    observed_value timestamptz
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    contract_key bigint;
+BEGIN
+    FOR contract_key IN SELECT id FROM contracts LOOP
+        PERFORM most_capture_holding_allocation_context_for_contract_v1(contract_key, observed_value);
+    END LOOP;
+END;
+$$
+SQL);
+
+        $checkpoint = DB::selectOne('SELECT clock_timestamp() AS value');
+        $checkpointAt = is_object($checkpoint) ? (string) ($checkpoint->value ?? '') : '';
+        if ($checkpointAt === '') {
+            throw new RuntimeException('holding_fixed_allocation_checkpoint_unavailable');
+        }
+
+        DB::selectOne(
+            'SELECT most_capture_holding_fixed_allocation_checkpoint_v1(?::timestamptz)',
+            [$checkpointAt],
+        );
+        DB::statement('DROP FUNCTION most_capture_holding_fixed_allocation_checkpoint_v1(timestamptz)');
+        DB::table('holding_reporting_context_coverage')->insert([
+            'source_code' => 'allocation_amount_dimensions',
+            'coverage_started_at' => $checkpointAt,
+            'evidence_hash' => hash(
+                'sha256',
+                'holding-reporting-context.v1:allocation_amount_dimensions:'.$checkpointAt,
+            ),
+        ]);
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/tests/Unit/Reporting/Waves23/HoldingReportingContextContractTest.php
+++ b/tests/Unit/Reporting/Waves23/HoldingReportingContextContractTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 final class HoldingReportingContextContractTest extends TestCase
 {
     #[Test]
-    public function allocation_context_accepts_only_resolved_percentage_in_closed_range(): void
+    public function fixed_allocation_context_uses_exact_amount_without_requiring_contract_percentage(): void
     {
         $snapshot = new HoldingAllocationContextSnapshot(
             1,
@@ -22,12 +22,14 @@ final class HoldingReportingContextContractTest extends TestCase
             4,
             5,
             'fixed',
-            '25.00000000',
+            '250.00',
+            null,
             hash('sha256', 'allocation-context'),
             '2026-08-05T10:00:00+00:00',
         );
 
-        self::assertSame('25.00000000', $snapshot->allocatedPercentage);
+        self::assertSame('250.00', $snapshot->allocatedAmount);
+        self::assertNull($snapshot->allocatedPercentage);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('holding_allocation_context_snapshot_invalid');
@@ -38,9 +40,36 @@ final class HoldingReportingContextContractTest extends TestCase
             4,
             5,
             'fixed',
+            '250.00',
             '100.00000001',
             hash('sha256', 'allocation-context'),
             '2026-08-05T10:00:00+00:00',
+        );
+    }
+
+    #[Test]
+    public function corrective_checkpoint_appends_fixed_amount_evidence_without_rewriting_history(): void
+    {
+        $source = $this->source(
+            'database/migrations/2026_08_05_020000_capture_holding_fixed_allocation_amount_evidence.php',
+        );
+
+        foreach ([
+            "decimal('allocated_amount', 20, 2)",
+            "'allocated_amount', resolved_amount",
+            "'allocation_amount_dimensions'",
+            'most_capture_holding_fixed_allocation_checkpoint_v1',
+            "WHEN 'fixed' THEN resolved_amount IS NOT NULL AND resolved_amount >= 0",
+        ] as $contract) {
+            self::assertStringContainsString($contract, $source);
+        }
+        self::assertStringNotContainsString('UPDATE holding_allocation_context_events', $source);
+        self::assertStringContainsString(
+            'HoldingReportingSourceCoverage::ALLOCATION_AMOUNTS',
+            $this->source(
+                'app/BusinessModules/Core/MultiOrganization/Reporting/Services/'
+                .'HoldingAllocationContextResolver.php',
+            ),
         );
     }
 


### PR DESCRIPTION
## Что исправлено
- `fixed`-распределение теперь доказывается точной суммой, даже если сумма контракта равна нулю
- добавлен отдельный append-only checkpoint `allocation_amount_dimensions`, старые evidence-строки не изменяются
- процент остаётся обязательным только для сценариев, где он действительно нужен, включая cash allocation
- проектор сверяет фиксированную сумму с immutable allocation event

## Production discovery
- 32 живых fixed-распределения
- у всех сумма заполнена и неотрицательна
- до исправления все 32 были `is_resolvable=false` из-за нулевой суммы контрактов

## Проверки
- `php -l` для 7 изменённых PHP-файлов
- `git diff --check`
- независимое ревью diff
- PHPUnit/PHPStan локально недоступны: `vendor` отсутствует; доказательство ожидается в основном deploy workflow

Миграции локально не запускались.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated HoldingAllocationContextSnapshot DTO to support both allocatedAmount and allocatedPercentage, with validation logic adjusted for FIXED vs other allocation types.</li>
<li>Modified HoldingAllocationContextResolver to handle optional percentage requirements and resolve fixed allocation amounts based on new coverage source.</li>
<li>Updated HoldingAllocationFactProjector to validate fixed allocation amounts and percentage-based allocations separately.</li>
<li>Added a new database migration to capture fixed allocation amount evidence.</li>
<li>Introduced a new coverage source constant ALLOCATION_AMOUNTS in HoldingReportingSourceCoverage.</li>
</ul></div>