### PR TITLE
feat[reports]: параметры потоков по договорам холдинга

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/MultiOrganizationServiceProvider.php
+++ b/app/BusinessModules/Core/MultiOrganization/MultiOrganizationServiceProvider.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Core\MultiOrganization\Reporting\Queries\IntercompanyCon
 use App\BusinessModules\Core\MultiOrganization\Reporting\Readiness\IntercompanyContractFlowReadinessProbe;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationCheckpointSourceAssembler;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationFactProjector;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\IntercompanyContractFlowOptionsService;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\IntercompanyContractFlowSnapshotMaterializer;
 use App\BusinessModules\Core\Payments\Events\PaymentDocumentPaid;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
@@ -36,6 +37,7 @@ class MultiOrganizationServiceProvider extends ServiceProvider
         $this->app->singleton(IntercompanyContractFlowCandidateContract::class);
         $this->app->scoped(HoldingAllocationFactProjector::class);
         $this->app->scoped(HoldingAllocationCheckpointSourceAssembler::class);
+        $this->app->scoped(IntercompanyContractFlowOptionsService::class);
         $this->app->scoped(IntercompanyContractFlowSnapshotMaterializer::class);
         $this->app->scoped(IntercompanyContractFlowsReportProvider::class);
         $this->app->scoped(IntercompanyContractFlowRowQuery::class);

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/IntercompanyContractFlowOptionsService.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/IntercompanyContractFlowOptionsService.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\MultiOrganization\Reporting\Services;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationCheckpointSource;
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\Enums\Contract\ContractWorkTypeCategoryEnum;
+use App\Enums\CurrencyCode;
+use Carbon\CarbonImmutable;
+use DateTimeImmutable;
+use Illuminate\Database\ConnectionInterface;
+use InvalidArgumentException;
+
+final readonly class IntercompanyContractFlowOptionsService
+{
+    public function __construct(
+        private HoldingAllocationCheckpointSourceAssembler $sources,
+        private IntercompanyContractFlowBuiltinPublishedReport $published,
+        private ConnectionInterface $connection,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function options(ReportScope $scope, DateTimeImmutable $asOf): array
+    {
+        $query = new ReportQuery(
+            $this->published->definition()->payload(),
+            $scope,
+            new ReportFilterSet([]),
+            [],
+            $asOf,
+            'ru-RU',
+        );
+
+        try {
+            $batch = $this->sources->assemble($scope, $query);
+        } catch (InvalidArgumentException) {
+            return $this->unavailable($asOf, 'source_unavailable');
+        }
+        if ($batch->gaps !== []) {
+            return $this->unavailable($asOf, 'source_incomplete', $batch->coverageStartedAt, $scope);
+        }
+
+        $organizationIds = [];
+        $projectIds = [];
+        $counterpartyIds = [];
+        $contractIds = [];
+        $workTypeCategories = [];
+        $currencies = [];
+        foreach ($batch->sources as $source) {
+            if (! $source instanceof HoldingAllocationCheckpointSource) {
+                return $this->unavailable($asOf, 'source_unavailable');
+            }
+            $fact = $source->fact;
+            if (! in_array($fact->contributorOrganizationId, $batch->hierarchy->organizationIds, true)
+                || ! in_array($fact->projectId, $scope->projectIds, true)) {
+                return $this->unavailable($asOf, 'source_unavailable');
+            }
+
+            $organizationIds[$fact->contributorOrganizationId] = true;
+            $projectIds[$fact->projectId] = true;
+            $contractIds[$fact->contractId] = true;
+            if ($fact->counterpartyOrganizationId !== null) {
+                $counterpartyIds[$fact->counterpartyOrganizationId] = true;
+            }
+            if ($fact->workTypeCategory !== null) {
+                $workTypeCategories[$fact->workTypeCategory] = true;
+            }
+            if ($fact->currency !== null) {
+                $currencies[$fact->currency] = true;
+            }
+        }
+
+        $organizations = $this->organizationOptions(
+            array_keys($organizationIds),
+            $batch->hierarchy->organizationIds,
+        );
+        $projects = $this->projectOptions(array_keys($projectIds), $scope->projectIds);
+        $counterparties = $this->organizationOptions(array_keys($counterpartyIds));
+        $contracts = $this->contractOptions(
+            array_keys($contractIds),
+            $batch->hierarchy->organizationIds,
+        );
+        if (count($organizations) !== count($organizationIds)
+            || count($projects) !== count($projectIds)
+            || count($counterparties) !== count($counterpartyIds)
+            || count($contracts) !== count($contractIds)) {
+            return $this->unavailable($asOf, 'source_reference_missing');
+        }
+
+        $workTypes = $this->workTypeOptions(array_keys($workTypeCategories));
+        $currencyOptions = $this->currencyOptions(array_keys($currencies));
+        if ($workTypes === null || $currencyOptions === null) {
+            return $this->unavailable($asOf, 'source_unavailable');
+        }
+
+        $coverageDate = CarbonImmutable::parse($batch->coverageStartedAt)
+            ->setTimezone($scope->timezone)
+            ->toDateString();
+
+        return [
+            'available' => true,
+            'reason' => null,
+            'as_of' => $this->exactDateTime($asOf),
+            'period' => [
+                'coverage_started_at' => $this->exactDateTime(
+                    new DateTimeImmutable($batch->coverageStartedAt),
+                ),
+                'default_from' => $coverageDate,
+                'default_to' => CarbonImmutable::instance($asOf)
+                    ->setTimezone($scope->timezone)
+                    ->toDateString(),
+            ],
+            'organizations' => $organizations,
+            'projects' => $projects,
+            'counterparties' => $counterparties,
+            'work_type_categories' => $workTypes,
+            'contracts' => $contracts,
+            'currencies' => $currencyOptions,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @param  list<int>|null  $allowedIds
+     * @return list<array{id:int,name:string}>
+     */
+    private function organizationOptions(array $ids, ?array $allowedIds = null): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        if ($allowedIds !== null && array_diff($ids, $allowedIds) !== []) {
+            return [];
+        }
+
+        $rows = $this->connection->table('organizations')
+            ->whereIn('id', $ids)
+            ->whereNull('deleted_at')
+            ->get(['id', 'name']);
+
+        return $this->namedRows($rows->all());
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @param  list<int>  $allowedIds
+     * @return list<array{id:int,name:string}>
+     */
+    private function projectOptions(array $ids, array $allowedIds): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        if (array_diff($ids, $allowedIds) !== []) {
+            return [];
+        }
+
+        $rows = $this->connection->table('projects')
+            ->whereIn('id', $ids)
+            ->whereNull('deleted_at')
+            ->get(['id', 'name']);
+
+        return $this->namedRows($rows->all());
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @param  list<int>  $organizationIds
+     * @return list<array{id:int,name:string}>
+     */
+    private function contractOptions(array $ids, array $organizationIds): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $rows = $this->connection->table('contracts')
+            ->whereIn('id', $ids)
+            ->whereIn('organization_id', $organizationIds)
+            ->whereNull('deleted_at')
+            ->get(['id', 'number', 'subject']);
+        $options = [];
+        foreach ($rows as $row) {
+            $number = trim((string) $row->number);
+            $subject = trim((string) $row->subject);
+            if ($number === '') {
+                continue;
+            }
+            $options[] = [
+                'id' => (int) $row->id,
+                'name' => $subject === '' ? $number : $number.' — '.$subject,
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<string>  $codes
+     * @return list<array{id:string,name:string}>|null
+     */
+    private function workTypeOptions(array $codes): ?array
+    {
+        $options = [];
+        foreach ($codes as $code) {
+            $workType = ContractWorkTypeCategoryEnum::tryFrom($code);
+            if ($workType === null) {
+                return null;
+            }
+            $options[] = [
+                'id' => $workType->value,
+                'name' => trans_message('contract.work_type_category.'.$workType->value, locale: 'ru'),
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<string>  $codes
+     * @return list<array{id:string,name:string}>|null
+     */
+    private function currencyOptions(array $codes): ?array
+    {
+        $labels = CurrencyCode::options();
+        $options = [];
+        foreach ($codes as $code) {
+            if (! isset($labels[$code])) {
+                return null;
+            }
+            $options[] = ['id' => $code, 'name' => $labels[$code]];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<object>  $rows
+     * @return list<array{id:int,name:string}>
+     */
+    private function namedRows(array $rows): array
+    {
+        $options = [];
+        foreach ($rows as $row) {
+            $name = trim((string) $row->name);
+            if ($name !== '') {
+                $options[] = ['id' => (int) $row->id, 'name' => $name];
+            }
+        }
+
+        return $this->sorted($options);
+    }
+
+    /** @param list<array{id:int|string,name:string}> $options */
+    private function sorted(array $options): array
+    {
+        usort($options, static fn (array $left, array $right): int => strnatcasecmp(
+            (string) $left['name'],
+            (string) $right['name'],
+        ));
+
+        return $options;
+    }
+
+    /** @return array<string, mixed> */
+    private function unavailable(
+        DateTimeImmutable $asOf,
+        string $reason,
+        ?string $coverageStartedAt = null,
+        ?ReportScope $scope = null,
+    ): array {
+        $coverageDate = $coverageStartedAt !== null && $scope !== null
+            ? CarbonImmutable::parse($coverageStartedAt)->setTimezone($scope->timezone)->toDateString()
+            : null;
+
+        return [
+            'available' => false,
+            'reason' => $reason,
+            'as_of' => $this->exactDateTime($asOf),
+            'period' => [
+                'coverage_started_at' => $coverageStartedAt === null
+                    ? null
+                    : $this->exactDateTime(new DateTimeImmutable($coverageStartedAt)),
+                'default_from' => $coverageDate,
+                'default_to' => $scope === null
+                    ? null
+                    : CarbonImmutable::instance($asOf)->setTimezone($scope->timezone)->toDateString(),
+            ],
+            'organizations' => [],
+            'projects' => [],
+            'counterparties' => [],
+            'work_type_categories' => [],
+            'contracts' => [],
+            'currencies' => [],
+        ];
+    }
+
+    private function exactDateTime(DateTimeImmutable $value): string
+    {
+        return $value->format('u') === '000000'
+            ? $value->format(DATE_ATOM)
+            : $value->format('Y-m-d\TH:i:s.uP');
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/IntercompanyContractFlowReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/IntercompanyContractFlowReportOptionsController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowCandidateContract;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\IntercompanyContractFlowOptionsService;
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\IntercompanyContractFlowReportOptionsRequest;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class IntercompanyContractFlowReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private IntercompanyContractFlowOptionsService $options,
+    ) {}
+
+    public function __invoke(IntercompanyContractFlowReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, IntercompanyContractFlowCandidateContract::CODE)['context'];
+
+        return AdminResponse::success($this->options->options($context->scope, $request->asOf()));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -6,6 +6,7 @@ namespace App\BusinessModules\Core\Reporting\Http\Admin\Middleware;
 
 use App\BusinessModules\Core\Reporting\Application\Access\ReportDefinitionModuleAuthorizer;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Access\ReportHttpAuthorizationTargetResolver;
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowCandidateContract;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthorizationTarget;
@@ -91,7 +92,9 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.payroll-readiness.options',
             'admin.reports.workforce-capacity.runs.store',
             'admin.reports.workforce-capacity.options',
-            'admin.reports.portfolio-liquidity.options' => $this->targets->createRun(
+            'admin.reports.portfolio-liquidity.options',
+            'admin.reports.intercompany-contract-flows.runs.store',
+            'admin.reports.intercompany-contract-flows.options' => $this->targets->createRun(
                 $this->routeId($request, 'reportCode'),
             ),
             'admin.reports.runs.show', 'admin.reports.runs.rows' => $this->targets->run(
@@ -137,6 +140,7 @@ final readonly class AuthorizeReportDefinitionAccess
             ProjectLaborCostCandidateContract::CODE,
             PayrollReadinessCandidateContract::CODE,
             WorkforceCapacityCandidateContract::CODE,
+            IntercompanyContractFlowCandidateContract::CODE,
         ], true)) {
             $this->deny();
         }

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/IntercompanyContractFlowReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/IntercompanyContractFlowReportOptionsRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use DateTimeImmutable;
+
+final class IntercompanyContractFlowReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'as_of' => [
+                'required',
+                'string',
+                static function (string $attribute, mixed $value, callable $fail): void {
+                    if (ReportAsOfParser::parse($value) === null) {
+                        $fail(trans_message('reports.errors.report_request_invalid'));
+                    }
+                },
+            ],
+            ...$this->forbiddenClientFieldsRules(),
+            'current_organization_id' => ['prohibited'],
+            'holding_organization_ids' => ['prohibited'],
+            'organization_ids' => ['prohibited'],
+            'project_id' => ['prohibited'],
+            'current_project_id' => ['prohibited'],
+            'project_ids' => ['prohibited'],
+            'scope' => ['prohibited'],
+            'actor_id' => ['prohibited'],
+        ];
+    }
+
+    protected function acceptedQueryFields(): array
+    {
+        return ['as_of'];
+    }
+
+    public function asOf(): DateTimeImmutable
+    {
+        $asOf = ReportAsOfParser::parse($this->validated('as_of'));
+        if ($asOf === null) {
+            throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => ['as_of']],
+            );
+        }
+
+        return $asOf;
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMatrix;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\IntercompanyContractFlowReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PortfolioLiquidityReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectEvmControlReportOptionsController;
@@ -95,6 +96,14 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'portfolio_liquidity')
             ->middleware(['report.organization-scope', $resourceAccess])
             ->name('portfolio-liquidity.options');
+        Route::post('/intercompany-contract-flows/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'intercompany_contract_flows')
+            ->middleware($resourceAccess)
+            ->name('intercompany-contract-flows.runs.store');
+        Route::get('/intercompany-contract-flows/options', IntercompanyContractFlowReportOptionsController::class)
+            ->defaults('reportCode', 'intercompany_contract_flows')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('intercompany-contract-flows.options');
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');

--- a/tests/Unit/Reporting/IntercompanyContractFlowOptionsContractTest.php
+++ b/tests/Unit/Reporting/IntercompanyContractFlowOptionsContractTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowCandidateContract;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\IntercompanyContractFlowOptionsService;
+use App\BusinessModules\Core\Reporting\Application\Access\ReportDefinitionModuleAuthorizer;
+use App\BusinessModules\Core\Reporting\Application\Contracts\Access\ReportHttpAuthorizationTargetResolver;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\AuthorizeReportDefinitionAccess;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\IntercompanyContractFlowReportOptionsRequest;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\HttpFoundation\Response;
+
+final class IntercompanyContractFlowOptionsContractTest extends TestCase
+{
+    public function test_routes_use_the_dedicated_holding_contract_and_disable_the_generic_run_path(): void
+    {
+        $routes = file_get_contents(base_path('app/BusinessModules/Core/Reporting/routes.php'));
+        $middleware = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php',
+        ));
+
+        self::assertIsString($routes);
+        self::assertStringContainsString("Route::post('/intercompany-contract-flows/runs'", $routes);
+        self::assertStringContainsString("Route::get('/intercompany-contract-flows/options'", $routes);
+        self::assertStringContainsString("->defaults('reportCode', 'intercompany_contract_flows')", $routes);
+        self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
+        self::assertIsString($middleware);
+        self::assertStringContainsString("'admin.reports.intercompany-contract-flows.runs.store'", $middleware);
+        self::assertStringContainsString("'admin.reports.intercompany-contract-flows.options'", $middleware);
+        self::assertStringContainsString('IntercompanyContractFlowCandidateContract::CODE', $middleware);
+    }
+
+    public function test_options_use_the_runtime_checkpoint_and_only_server_scope_references(): void
+    {
+        $source = file_get_contents((new ReflectionClass(
+            IntercompanyContractFlowOptionsService::class,
+        ))->getFileName());
+        $controller = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Controllers/IntercompanyContractFlowReportOptionsController.php',
+        ));
+
+        self::assertIsString($source);
+        self::assertStringContainsString('$this->sources->assemble($scope, $query)', $source);
+        self::assertStringContainsString('$batch->hierarchy->organizationIds', $source);
+        self::assertStringContainsString('$scope->projectIds', $source);
+        self::assertStringContainsString('CurrencyCode::options()', $source);
+        self::assertStringContainsString("trans_message('contract.work_type_category.'", $source);
+        self::assertStringNotContainsString("'organization_id' =>", $source);
+        self::assertIsString($controller);
+        self::assertStringContainsString(
+            '->createRun($request, IntercompanyContractFlowCandidateContract::CODE)',
+            $controller,
+        );
+        self::assertStringContainsString('$context->scope', $controller);
+        self::assertStringNotContainsString("input('organization_id')", $controller);
+        self::assertStringNotContainsString("input('project_id')", $controller);
+    }
+
+    public function test_generic_run_route_cannot_bypass_the_holding_contract(): void
+    {
+        $request = Request::create(
+            '/api/v1/admin/reports/'.IntercompanyContractFlowCandidateContract::CODE.'/runs',
+            'POST',
+        );
+        $request->setUserResolver(static fn (): User => new User);
+        $request->attributes->set('current_organization_id', 1);
+        $route = new Route(['POST'], '/api/v1/admin/reports/{reportCode}/runs', static fn (): null => null);
+        $route->name('admin.reports.runs.store');
+        $route->bind($request);
+        $route->setParameter('reportCode', IntercompanyContractFlowCandidateContract::CODE);
+        $request->setRouteResolver(static fn (): Route => $route);
+
+        $middleware = new AuthorizeReportDefinitionAccess(
+            $this->createMock(ReportHttpAuthorizationTargetResolver::class),
+            (new ReflectionClass(ReportDefinitionModuleAuthorizer::class))->newInstanceWithoutConstructor(),
+        );
+
+        try {
+            $middleware->handle($request, static fn (): Response => new Response(status: 204));
+            self::fail('The generic run route must reject the holding report.');
+        } catch (ReportContractException $exception) {
+            self::assertSame(ReportErrorCode::REPORT_SCOPE_FORBIDDEN, $exception->errorCode);
+        }
+    }
+
+    public function test_options_reject_client_context_and_require_exact_as_of(): void
+    {
+        $rules = (new IntercompanyContractFlowReportOptionsRequest)->rules();
+
+        foreach ([
+            'organization_id',
+            'current_organization_id',
+            'holding_organization_ids',
+            'organization_ids',
+            'project_id',
+            'current_project_id',
+            'project_ids',
+            'user_id',
+            'actor_id',
+            'scope',
+            'permissions',
+        ] as $field) {
+            self::assertContains('prohibited', $rules[$field]);
+        }
+        self::assertSame(['required', 'string'], array_slice($rules['as_of'], 0, 2));
+        self::assertNotNull(ReportAsOfParser::parse('2026-08-05T14:15:16.123456+03:00'));
+        self::assertNull(ReportAsOfParser::parse('2026-08-05'));
+    }
+}


### PR DESCRIPTION
## Что изменено
- добавлен отдельный organization-scoped endpoint options для R03
- options формируются из того же immutable checkpoint-среза, что и runtime
- организации, проекты, контрагенты и договоры ограничены server auth/context
- добавлен отдельный canonical run route, generic run path для R03 закрыт
- клиентская подмена organization/project/user/scope отклоняется
- валюты берутся из общего CurrencyCode, виды работ возвращаются с русскими названиями

## Проверки
- php -l для 7 изменённых PHP-файлов
- git diff --check
- semantic fingerprints runtime повторно совпали с pinned hashes
- локальные PHPUnit/PHPStan недоступны: vendor отсутствует; целевые тесты выполняет CI

## Граница релиза
Только backend options/route contract R03. Runtime, admin UI и evidence не смешаны.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced IntercompanyContractFlowOptionsService to provide report options for intercompany contract flows.</li>
<li>Registered the new service in MultiOrganizationServiceProvider.</li>
<li>Added a new controller IntercompanyContractFlowReportOptionsController to handle report option requests.</li>
<li>Implemented middleware AuthorizeReportDefinitionAccess to secure report definition access.</li>
<li>Added a new request validation class IntercompanyContractFlowReportOptionsRequest and updated routes.</li>
</ul></div>