### PR TITLE
fix[reports]: восстановлена видимость отчетов владельцу

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Access/LaravelCurrentReportAbacEvaluator.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Access/LaravelCurrentReportAbacEvaluator.php
@@ -11,6 +11,7 @@ use App\Domain\Authorization\Enums\ConditionType;
 use App\Domain\Authorization\Models\OrganizationCustomRole;
 use App\Domain\Authorization\Models\RoleCondition;
 use App\Domain\Authorization\Models\UserRoleAssignment;
+use App\Domain\Authorization\ValueObjects\ModulePermissionAliases;
 use App\Domain\Authorization\ValueObjects\PermissionSet;
 use DateTimeImmutable;
 use Illuminate\Support\Facades\DB;
@@ -128,9 +129,29 @@ final class LaravelCurrentReportAbacEvaluator implements CurrentReportAbacEvalua
                     continue;
                 }
 
-                $permissions[] = $modulePermission === '*' || str_starts_with($modulePermission, $module.'.')
-                    ? ($modulePermission === '*' ? $module.'.*' : $modulePermission)
-                    : $module.'.'.$modulePermission;
+                $moduleVariants = ModulePermissionAliases::variants($module);
+                if ($modulePermission === '*') {
+                    foreach ($moduleVariants as $variant) {
+                        $permissions[] = $variant.'.*';
+                    }
+
+                    continue;
+                }
+
+                $qualifiedForModule = false;
+                foreach ($moduleVariants as $variant) {
+                    if (str_starts_with($modulePermission, $variant.'.')) {
+                        $qualifiedForModule = true;
+                        break;
+                    }
+                }
+                if ($qualifiedForModule) {
+                    $permissions[] = $modulePermission;
+
+                    continue;
+                }
+
+                $permissions[] = $module.'.'.$modulePermission;
             }
         }
 

--- a/app/Domain/Authorization/Services/PermissionResolver.php
+++ b/app/Domain/Authorization/Services/PermissionResolver.php
@@ -4,6 +4,7 @@ namespace App\Domain\Authorization\Services;
 
 use App\Domain\Authorization\Models\OrganizationCustomRole;
 use App\Domain\Authorization\Models\UserRoleAssignment;
+use App\Domain\Authorization\ValueObjects\ModulePermissionAliases;
 use App\Services\Logging\LoggingService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -642,80 +643,7 @@ class PermissionResolver
      */
     protected function expandModuleVariants(string $module): array
     {
-        $normalizedHyphen = str_replace('_', '-', $module);
-        $normalizedUnderscore = str_replace('-', '_', $module);
-
-        $moduleMapping = [
-            'projects' => 'project-management',
-            'schedule' => 'schedule-management',
-            'schedule_management' => 'schedule-management',
-            'construction-journal' => 'budget-estimates',
-            'construction_journal' => 'budget-estimates',
-            'estimates' => 'budget-estimates',
-            'act_reports' => 'act-reporting',
-            'act-reports' => 'act-reporting',
-            'ai_estimates' => 'ai-estimates',
-            'estimate_generation' => 'ai-estimates',
-            'time_tracking' => 'time-tracking',
-            'report_templates' => 'report-templates',
-            'warehouse' => 'basic-warehouse',
-            'contracts' => 'contract-management',
-            'mdm' => 'catalog-management',
-            'materials' => 'catalog-management',
-            'suppliers' => 'catalog-management',
-            'contractors' => 'catalog-management',
-            'work_types' => 'catalog-management',
-            'work-types' => 'catalog-management',
-            'measurement_units' => 'catalog-management',
-            'measurement-units' => 'catalog-management',
-            'cost_categories' => 'catalog-management',
-            'cost-categories' => 'catalog-management',
-            'completed_works' => 'workflow-management',
-            'completed-works' => 'workflow-management',
-            'workforce' => 'workforce-management',
-            'one_c_exchange' => 'one-c-basic-exchange',
-            'one-c-exchange' => 'one-c-basic-exchange',
-            'organizations' => 'contractor-portal',
-            'contractor_invitations' => 'contractor-portal',
-            'contractor-invitations' => 'contractor-portal',
-            'contractor_marketplace' => 'contractor-portal',
-            'contractor-marketplace' => 'contractor-portal',
-        ];
-
-        $reverseMapping = [
-            'project-management' => 'projects',
-            'budget-estimates' => 'estimates',
-            'schedule-management' => 'schedule',
-            'act-reporting' => 'act_reports',
-            'time-tracking' => 'time_tracking',
-            'report-templates' => 'report_templates',
-            'basic-warehouse' => 'warehouse',
-            'contract-management' => 'contracts',
-            'catalog-management' => 'mdm',
-            'workflow-management' => 'completed_works',
-            'workforce-management' => 'workforce',
-            'one-c-basic-exchange' => 'one_c_exchange',
-            'contractor-portal' => 'contractor_marketplace',
-            'ai-estimates' => 'estimate_generation',
-        ];
-
-        $variants = [
-            $module,
-            $normalizedHyphen,
-            $normalizedUnderscore,
-        ];
-
-        foreach ([$module, $normalizedHyphen, $normalizedUnderscore] as $candidate) {
-            if (isset($moduleMapping[$candidate])) {
-                $variants[] = $moduleMapping[$candidate];
-            }
-
-            if (isset($reverseMapping[$candidate])) {
-                $variants[] = $reverseMapping[$candidate];
-            }
-        }
-
-        return array_values(array_unique($variants));
+        return ModulePermissionAliases::variants($module);
     }
 
     protected function buildPermissionVariants(string $requestedModule, string $resolvedModule, string $action): array

--- a/app/Domain/Authorization/ValueObjects/ModulePermissionAliases.php
+++ b/app/Domain/Authorization/ValueObjects/ModulePermissionAliases.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Authorization\ValueObjects;
+
+final class ModulePermissionAliases
+{
+    private const CANONICAL_BY_ALIAS = [
+        'projects' => 'project-management',
+        'schedule' => 'schedule-management',
+        'schedule_management' => 'schedule-management',
+        'construction-journal' => 'budget-estimates',
+        'construction_journal' => 'budget-estimates',
+        'estimates' => 'budget-estimates',
+        'act_reports' => 'act-reporting',
+        'act-reports' => 'act-reporting',
+        'ai_estimates' => 'ai-estimates',
+        'estimate_generation' => 'ai-estimates',
+        'time_tracking' => 'time-tracking',
+        'report_templates' => 'report-templates',
+        'warehouse' => 'basic-warehouse',
+        'contracts' => 'contract-management',
+        'mdm' => 'catalog-management',
+        'materials' => 'catalog-management',
+        'suppliers' => 'catalog-management',
+        'contractors' => 'catalog-management',
+        'work_types' => 'catalog-management',
+        'work-types' => 'catalog-management',
+        'measurement_units' => 'catalog-management',
+        'measurement-units' => 'catalog-management',
+        'cost_categories' => 'catalog-management',
+        'cost-categories' => 'catalog-management',
+        'completed_works' => 'workflow-management',
+        'completed-works' => 'workflow-management',
+        'workforce' => 'workforce-management',
+        'one_c_exchange' => 'one-c-basic-exchange',
+        'one-c-exchange' => 'one-c-basic-exchange',
+        'organizations' => 'contractor-portal',
+        'contractor_invitations' => 'contractor-portal',
+        'contractor-invitations' => 'contractor-portal',
+        'contractor_marketplace' => 'contractor-portal',
+        'contractor-marketplace' => 'contractor-portal',
+    ];
+
+    private const PREFERRED_ALIAS_BY_CANONICAL = [
+        'project-management' => 'projects',
+        'budget-estimates' => 'estimates',
+        'schedule-management' => 'schedule',
+        'act-reporting' => 'act_reports',
+        'time-tracking' => 'time_tracking',
+        'report-templates' => 'report_templates',
+        'basic-warehouse' => 'warehouse',
+        'contract-management' => 'contracts',
+        'catalog-management' => 'mdm',
+        'workflow-management' => 'completed_works',
+        'workforce-management' => 'workforce',
+        'one-c-basic-exchange' => 'one_c_exchange',
+        'contractor-portal' => 'contractor_marketplace',
+        'ai-estimates' => 'estimate_generation',
+    ];
+
+    public static function variants(string $module): array
+    {
+        $normalizedHyphen = str_replace('_', '-', $module);
+        $normalizedUnderscore = str_replace('-', '_', $module);
+        $variants = [$module, $normalizedHyphen, $normalizedUnderscore];
+
+        foreach ([$module, $normalizedHyphen, $normalizedUnderscore] as $candidate) {
+            if (isset(self::CANONICAL_BY_ALIAS[$candidate])) {
+                $variants[] = self::CANONICAL_BY_ALIAS[$candidate];
+            }
+
+            if (isset(self::PREFERRED_ALIAS_BY_CANONICAL[$candidate])) {
+                $variants[] = self::PREFERRED_ALIAS_BY_CANONICAL[$candidate];
+            }
+        }
+
+        return array_values(array_unique($variants));
+    }
+}

--- a/config/RoleDefinitions/lk/organization_owner.json
+++ b/config/RoleDefinitions/lk/organization_owner.json
@@ -78,7 +78,9 @@
       "reports.download",
       "reports.manage",
       "reports.sensitive",
-      "reports.audit"
+      "reports.audit",
+      "reports.project_control.view",
+      "reports.project_control.export"
     ],
     "finance": [
       "*"

--- a/tests/Feature/Reporting/Access/LaravelCurrentReportAbacEvaluatorTest.php
+++ b/tests/Feature/Reporting/Access/LaravelCurrentReportAbacEvaluatorTest.php
@@ -85,6 +85,53 @@ final class LaravelCurrentReportAbacEvaluatorTest extends TestCase
         ));
     }
 
+    #[DataProvider('organizationOwnerPublishedReportPermissions')]
+    public function test_organization_owner_grants_published_report_permission(string $permission): void
+    {
+        $assignment = new UserRoleAssignment([
+            'role_slug' => 'organization_owner',
+            'role_type' => UserRoleAssignment::TYPE_SYSTEM,
+        ]);
+        $method = new ReflectionMethod(LaravelCurrentReportAbacEvaluator::class, 'roleGrants');
+
+        self::assertTrue($method->invoke(
+            new LaravelCurrentReportAbacEvaluator,
+            $assignment,
+            $permission,
+            1,
+        ));
+    }
+
+    public function test_explicit_fully_qualified_aliased_module_permission_is_preserved(): void
+    {
+        $assignment = new UserRoleAssignment([
+            'role_slug' => 'web_admin',
+            'role_type' => UserRoleAssignment::TYPE_SYSTEM,
+        ]);
+        $method = new ReflectionMethod(LaravelCurrentReportAbacEvaluator::class, 'roleGrants');
+
+        self::assertTrue($method->invoke(
+            new LaravelCurrentReportAbacEvaluator,
+            $assignment,
+            'time_tracking.view',
+            1,
+        ));
+    }
+
+    public function test_unrelated_module_namespace_does_not_grant_permission(): void
+    {
+        $method = new ReflectionMethod(LaravelCurrentReportAbacEvaluator::class, 'systemRoleGrants');
+
+        self::assertFalse($method->invoke(
+            new LaravelCurrentReportAbacEvaluator,
+            [
+                'system_permissions' => [],
+                'module_permissions' => ['finance' => ['users.delete']],
+            ],
+            'users.delete',
+        ));
+    }
+
     public static function malformedTimeConditions(): array
     {
         return [
@@ -97,6 +144,19 @@ final class LaravelCurrentReportAbacEvaluatorTest extends TestCase
             'invalid working day value' => [['working_days' => [7]]],
             'invalid working hour' => [['working_hours' => '29:00-30:00']],
             'reversed working hours' => [['working_hours' => '18:00-09:00']],
+        ];
+    }
+
+    public static function organizationOwnerPublishedReportPermissions(): array
+    {
+        return [
+            'schedule report' => ['schedule.view'],
+            'time tracking report' => ['time_tracking.view'],
+            'warehouse report' => ['warehouse.advanced.view'],
+            'workforce reports' => ['workforce.view'],
+            'contractor report' => ['contractor_marketplace.profile.view'],
+            'project control report' => ['reports.project_control.view'],
+            'project control export' => ['reports.project_control.export'],
         ];
     }
 }


### PR DESCRIPTION
Исправляет server-side RBAC/ABAC фильтрацию canonical report catalog для organization_owner.\n\n- общий backend helper алиасов permission namespace используется PermissionResolver и report ABAC;\n- wildcard активного модуля работает для schedule/time_tracking/warehouse/workforce/contractor_marketplace;\n- organization_owner получает точные view/export права R05 project control;\n- unrelated namespace остаётся fail-closed;\n- inactive multi-organization продолжает скрывать корпоративный R03.\n\nПроверки: php -l 4 PHP-файлов; JSON parse/role assertions; alias matrix; git diff --check; независимое review, HIGH fail-closed замечание устранено и точечно закрыто. PHPUnit/Larastan локально недоступны: vendor отсутствует; добавленные regression tests выполняются CI/deploy.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Extracted module alias logic into a new ValueObject `ModulePermissionAliases` to centralize variant resolution.</li>
<li>Refactored `LaravelCurrentReportAbacEvaluator` and `PermissionResolver` to use the new `ModulePermissionAliases` service.</li>
<li>Updated `LaravelCurrentReportAbacEvaluator` to correctly handle wildcard permissions across module variants.</li>
<li>Added new permissions `reports.project_control.view` and `reports.project_control.export` to the `organization_owner` role.</li>
<li>Added new feature tests to verify permission granting for aliased modules and organization owner roles.</li>
</ul></div>