### PR TITLE
fix: исправлен fingerprint runtime отчёта холдинга

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
@@ -44,7 +44,7 @@ final readonly class HoldingPerformanceCandidateContract
     public const FORMULA_VERSION = 'holding_performance.v1';
     public const SOURCE_SCHEMA_VERSION = 'holding_allocation_facts.v2';
     public const FORMULA_HASH = '59c4e2d23349656ae8948679fcea4dc59da5be20792b865afb17da2b9a667f20';
-    public const SOURCE_HASH = '84b44cd2bf4d78e669ac6157592de51e883bfaae0ee959ce6f5ffe75384298a0';
+    public const SOURCE_HASH = 'd67f655bb2bf811289ae7fab8177a25d2dac78bd08d3a3a3b22be7f292aff344';
 
     public function filters(): array
     {


### PR DESCRIPTION
## Причина
Production workflow 31037076967 остановил сборку до deploy: runtime gate обнаружил drift holding_performance_candidate_contract_drift.

Локальный fingerprint ранее был рассчитан по ошибочно сопоставленным namespace/path. Новый hash вычислен напрямую из 23 git blobs в точном порядке ssertRuntimeMatches с разрешением фактических use-импортов.

## Изменение
- исправлен только HoldingPerformanceCandidateContract::SOURCE_HASH
- runtime/source код не изменяется

## Проверки
- независимый пересчёт git blobs: d67f655bb2bf811289ae7fab8177a25d2dac78bd08d3a3a3b22be7f292aff344
- php -l
- git diff --check
- независимое review: CLEAN