### PR TITLE
feat: добавлен read-only просмотр фактов холдинга

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
@@ -44,7 +44,7 @@ final readonly class HoldingPerformanceCandidateContract
     public const FORMULA_VERSION = 'holding_performance.v1';
     public const SOURCE_SCHEMA_VERSION = 'holding_allocation_facts.v2';
     public const FORMULA_HASH = '59c4e2d23349656ae8948679fcea4dc59da5be20792b865afb17da2b9a667f20';
-    public const SOURCE_HASH = 'd67f655bb2bf811289ae7fab8177a25d2dac78bd08d3a3a3b22be7f292aff344';
+    public const SOURCE_HASH = 'b93427f0607561fc20896e566b21a209d8b7a5cfbf04afae84500fee66f5f22c';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/AcceptedWorkHoldingFactProducer.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/AcceptedWorkHoldingFactProducer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Core\MultiOrganization\Reporting\Services;
 
+use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationFact;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAllocationFactVersion;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAcceptedWorkEventVersion;
 use App\Models\Contract;
@@ -86,6 +87,16 @@ final readonly class AcceptedWorkHoldingFactProducer
         }
 
         return $this->projector->persist($this->projector->project($source), $source);
+    }
+
+    public function previewEvent(HoldingAcceptedWorkEventVersion $event): ?HoldingAllocationFact
+    {
+        $projection = $this->projectionForEvent($event);
+        $source = $projection['source'];
+
+        return $projection['missing'] === [] && is_array($source)
+            ? $this->projector->project($source)
+            : null;
     }
 
     private function projectionForEvent(HoldingAcceptedWorkEventVersion $event): array

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPaymentEventFactProducer.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPaymentEventFactProducer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Core\MultiOrganization\Reporting\Services;
 
+use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationFact;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAllocationFactVersion;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingPaymentTransactionEventVersion;
 use App\BusinessModules\Core\Payments\Enums\PaymentTransactionStatus;
@@ -45,6 +46,16 @@ final readonly class HoldingPaymentEventFactProducer
         }
 
         return $this->projector->persist($this->projector->project($source), $source);
+    }
+
+    public function previewEvent(HoldingPaymentTransactionEventVersion $event): ?HoldingAllocationFact
+    {
+        $projection = $this->projection($event);
+        $source = $projection['source'];
+
+        return $projection['missing'] === [] && is_array($source)
+            ? $this->projector->project($source)
+            : null;
     }
 
     private function projection(HoldingPaymentTransactionEventVersion $event): array

--- a/tests/Integration/Reporting/Waves23/HoldingPerformanceProjectionPostgresTest.php
+++ b/tests/Integration/Reporting/Waves23/HoldingPerformanceProjectionPostgresTest.php
@@ -6,11 +6,15 @@ namespace Tests\Integration\Reporting\Waves23;
 
 use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceBuiltinPublishedReport;
 use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceCandidateContract;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAcceptedWorkEventVersion;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingPaymentTransactionEventVersion;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\AcceptedWorkHoldingFactProducer;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationCheckpointSourceAssembler;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationFactProjector;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceImmutableEventSource;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceFormula;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceProjectionCoverageInspector;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPaymentEventFactProducer;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
@@ -33,6 +37,204 @@ use Tests\TestCase;
 #[Group('postgres')]
 final class HoldingPerformanceProjectionPostgresTest extends TestCase
 {
+    #[Test]
+    public function event_fact_previews_are_behaviorally_read_only(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            self::markTestSkipped('PostgreSQL integration only.');
+        }
+
+        DB::beginTransaction();
+
+        try {
+            $identity = random_int(500000000, 599999999);
+            $organizationId = $identity;
+            $projectId = $identity + 1;
+            $contractId = $identity + 2;
+            $allocationId = $identity + 3;
+            $coverageStartedAt = DB::table('holding_reporting_context_coverage')
+                ->whereIn('source_code', [
+                    'contract_dimensions',
+                    'organization_hierarchy',
+                    'allocation_dimensions',
+                ])
+                ->max('coverage_started_at');
+            self::assertIsString($coverageStartedAt);
+            $observedAt = CarbonImmutable::parse($coverageStartedAt);
+            $recognizedAt = $observedAt->addDay()->setTime(12, 0);
+            DB::table('holding_organization_hierarchy_events')->insert([
+                'organization_id' => $organizationId,
+                'parent_organization_id' => null,
+                'is_active' => true,
+                'hierarchy_level' => 0,
+                'hierarchy_path' => (string) $organizationId,
+                'observed_at' => $observedAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'preview-hierarchy-'.$identity),
+            ]);
+            DB::table('holding_contract_dimension_events')->insert([
+                'contract_id' => $contractId,
+                'organization_id' => $organizationId,
+                'contractor_id' => null,
+                'counterparty_organization_id' => null,
+                'contract_status' => 'active',
+                'work_type_category' => null,
+                'total_amount' => '1000.00',
+                'currency' => 'RUB',
+                'observed_at' => $observedAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'preview-contract-'.$identity),
+            ]);
+            DB::table('holding_allocation_context_events')->insert([
+                'allocation_id' => $allocationId,
+                'contract_id' => $contractId,
+                'organization_id' => $organizationId,
+                'project_id' => $projectId,
+                'allocation_type' => 'percentage',
+                'allocated_amount' => null,
+                'allocated_percentage' => '50.0000',
+                'is_resolvable' => true,
+                'is_active' => true,
+                'observed_at' => $observedAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'preview-allocation-'.$identity),
+            ]);
+
+            $acceptedActiveId = DB::table('holding_accepted_work_event_versions')->insertGetId([
+                'event_key' => 'preview-accepted-active-'.str()->uuid(),
+                'performance_act_id' => $identity + 10,
+                'contract_id' => $contractId,
+                'project_id' => $projectId,
+                'organization_id' => $organizationId,
+                'active' => true,
+                'amount' => '125.50',
+                'status' => 'approved',
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addSecond(),
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'preview-accepted-active-'.$identity),
+            ]);
+            $acceptedInactiveId = DB::table('holding_accepted_work_event_versions')->insertGetId([
+                'event_key' => 'preview-accepted-inactive-'.str()->uuid(),
+                'performance_act_id' => $identity + 11,
+                'contract_id' => $contractId,
+                'project_id' => $projectId,
+                'organization_id' => $organizationId,
+                'active' => false,
+                'amount' => '125.50',
+                'status' => 'draft',
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addSeconds(2),
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'preview-accepted-inactive-'.$identity),
+            ]);
+            $acceptedMissingId = DB::table('holding_accepted_work_event_versions')->insertGetId([
+                'event_key' => 'preview-accepted-missing-'.str()->uuid(),
+                'performance_act_id' => $identity + 12,
+                'contract_id' => $contractId,
+                'project_id' => $projectId,
+                'organization_id' => $organizationId,
+                'active' => true,
+                'amount' => '125.50',
+                'status' => 'approved',
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addSeconds(3),
+                'history_complete' => false,
+                'source_hash' => hash('sha256', 'preview-accepted-missing-'.$identity),
+            ]);
+            $paymentActiveId = DB::table('holding_payment_transaction_event_versions')->insertGetId([
+                'transaction_id' => $identity + 20,
+                'payment_document_id' => $identity + 21,
+                'organization_id' => $organizationId,
+                'project_id' => $projectId,
+                'contract_id' => $contractId,
+                'document_organization_id' => $organizationId,
+                'document_project_id' => $projectId,
+                'contract_organization_id' => $organizationId,
+                'contract_project_id' => $projectId,
+                'amount' => '200.00',
+                'currency' => 'RUB',
+                'status' => 'completed',
+                'active' => true,
+                'recognized_at' => $recognizedAt,
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addSecond(),
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'preview-payment-active-'.$identity),
+            ]);
+            $paymentInactiveId = DB::table('holding_payment_transaction_event_versions')->insertGetId([
+                'transaction_id' => $identity + 22,
+                'payment_document_id' => $identity + 23,
+                'organization_id' => $organizationId,
+                'project_id' => $projectId,
+                'contract_id' => $contractId,
+                'document_organization_id' => $organizationId,
+                'document_project_id' => $projectId,
+                'contract_organization_id' => $organizationId,
+                'contract_project_id' => $projectId,
+                'amount' => null,
+                'currency' => null,
+                'status' => 'cancelled',
+                'active' => false,
+                'recognized_at' => $recognizedAt,
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addSeconds(2),
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'preview-payment-inactive-'.$identity),
+            ]);
+            $paymentMissingId = DB::table('holding_payment_transaction_event_versions')->insertGetId([
+                'transaction_id' => $identity + 24,
+                'payment_document_id' => $identity + 25,
+                'organization_id' => $organizationId,
+                'project_id' => $projectId,
+                'contract_id' => $contractId,
+                'document_organization_id' => $organizationId,
+                'document_project_id' => $projectId,
+                'contract_organization_id' => $organizationId,
+                'contract_project_id' => $projectId,
+                'amount' => '200.00',
+                'currency' => 'RUB',
+                'status' => 'completed',
+                'active' => true,
+                'recognized_at' => $recognizedAt,
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addSeconds(3),
+                'history_complete' => false,
+                'source_hash' => hash('sha256', 'preview-payment-missing-'.$identity),
+            ]);
+
+            $accepted = $this->app->make(AcceptedWorkHoldingFactProducer::class);
+            $payments = $this->app->make(HoldingPaymentEventFactProducer::class);
+            $factCount = DB::table('holding_allocation_fact_versions')
+                ->where('organization_id', $organizationId)
+                ->count();
+            $gapCount = DB::table('holding_allocation_projection_gaps')
+                ->where('organization_id', $organizationId)
+                ->count();
+            $acceptedFact = $accepted->previewEvent(HoldingAcceptedWorkEventVersion::query()->findOrFail($acceptedActiveId));
+            $paymentFact = $payments->previewEvent(HoldingPaymentTransactionEventVersion::query()->findOrFail($paymentActiveId));
+
+            self::assertNotNull($acceptedFact);
+            self::assertSame(12_550, $acceptedFact->amountMinor);
+            self::assertSame('accepted_accrual', $acceptedFact->monetaryBasis);
+            self::assertNotNull($paymentFact);
+            self::assertSame(10_000, $paymentFact->amountMinor);
+            self::assertSame('cash', $paymentFact->monetaryBasis);
+            self::assertNull($accepted->previewEvent(HoldingAcceptedWorkEventVersion::query()->findOrFail($acceptedInactiveId)));
+            self::assertNull($accepted->previewEvent(HoldingAcceptedWorkEventVersion::query()->findOrFail($acceptedMissingId)));
+            self::assertNull($payments->previewEvent(HoldingPaymentTransactionEventVersion::query()->findOrFail($paymentInactiveId)));
+            self::assertNull($payments->previewEvent(HoldingPaymentTransactionEventVersion::query()->findOrFail($paymentMissingId)));
+            self::assertSame($factCount, DB::table('holding_allocation_fact_versions')
+                ->where('organization_id', $organizationId)
+                ->count());
+            self::assertSame($gapCount, DB::table('holding_allocation_projection_gaps')
+                ->where('organization_id', $organizationId)
+                ->count());
+        } finally {
+            DB::rollBack();
+        }
+    }
+
     #[Test]
     public function checkpoint_day_is_rejected_until_the_first_complete_business_day(): void
     {

--- a/tests/Unit/Reporting/Waves23/HoldingPerformancePublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/HoldingPerformancePublishedContractTest.php
@@ -187,6 +187,38 @@ final class HoldingPerformancePublishedContractTest extends TestCase
     }
 
     #[Test]
+    public function event_fact_previews_reuse_projection_without_persistence_side_effects(): void
+    {
+        $accepted = file_get_contents(dirname(__DIR__, 4).'/app/BusinessModules/Core/MultiOrganization/Reporting/Services/AcceptedWorkHoldingFactProducer.php');
+        $payments = file_get_contents(dirname(__DIR__, 4).'/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPaymentEventFactProducer.php');
+
+        self::assertIsString($accepted);
+        self::assertIsString($payments);
+        foreach ([$accepted, $payments] as $producer) {
+            self::assertStringContainsString('public function previewEvent(', $producer);
+            self::assertStringContainsString('?HoldingAllocationFact', $producer);
+            self::assertSame(1, substr_count($producer, 'public function previewEvent('));
+        }
+
+        $acceptedPreview = substr(
+            $accepted,
+            strpos($accepted, 'public function previewEvent('),
+            strpos($accepted, 'private function projectionForEvent(') - strpos($accepted, 'public function previewEvent('),
+        );
+        $paymentPreview = substr(
+            $payments,
+            strpos($payments, 'public function previewEvent('),
+            strpos($payments, 'private function projection(') - strpos($payments, 'public function previewEvent('),
+        );
+
+        foreach ([$acceptedPreview, $paymentPreview] as $preview) {
+            self::assertStringContainsString('$this->projector->project($source)', $preview);
+            self::assertStringNotContainsString('persist(', $preview);
+            self::assertStringNotContainsString('recordGap(', $preview);
+        }
+    }
+
+    #[Test]
     public function canonical_execution_hash_keeps_raw_materialized_identity_separate(): void
     {
         $definition = (new HoldingPerformanceBuiltinPublishedReport(new HoldingPerformanceCandidateContract))


### PR DESCRIPTION
## Что изменено
- добавлен чистый preview активных фактов приёмки и оплаты без persist и записи gaps
- сохранено единое point-in-time разрешение и расчёт через существующие producers/projector
- обновлён точный runtime fingerprint R02
- добавлены контрактная и PostgreSQL-поведенческая проверки active/inactive/missing и отсутствия записей

## Проверки
- php -l для 5 затронутых PHP-файлов
- git diff --cached --check
- SOURCE_HASH пересчитан по точным 23 staged Git blobs: b93427f0607561fc20896e566b21a209d8b7a5cfbf04afae84500fee66f5f22c
- независимое review: CLEAN
- локальный PHPUnit/PHPStan недоступен: vendor отсутствует; выполняет основной CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated SOURCE_HASH in HoldingPerformanceCandidateContract.</li>
<li>Added previewEvent methods to AcceptedWorkHoldingFactProducer and HoldingPaymentEventFactProducer to support event previewing.</li>
<li>Refactored ProjectMaterialStockService to remove dependency on MobileProjectAccessResolver and implement direct project user access checks.</li>
<li>Updated various mobile controllers and services to integrate with the new MobileProjectAccessResolver logic.</li>
<li>Added and updated tests for project access resolution and holding performance projections.</li>
</ul></div>