### PR TITLE
fix[backend]: раскрыть ошибки записи в S3

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -57,7 +57,7 @@ return [
             // bucket устанавливается динамически в OrgBucketService
             'endpoint' => env('AWS_ENDPOINT', 'https://storage.yandexcloud.net'),
             'use_path_style_endpoint' => false, // для Yandex Object Storage нужен virtual-host style
-            'throw'   => false,
+            'throw'   => true,
             'report'  => false,
         ],
 


### PR DESCRIPTION
## GlitchTip\n- PROHELPER-BACKEND-FV / issue 542: [FileService] upload(): put returned false\n- http://5.129.220.32:8000/prohelper-backend/issues/542\n\n## Причина\nУ S3-диска была отключена генерация исключений, поэтому Laravel подавлял диагностическую ошибку провайдера и возвращал только false.\n\n## Изменения\n- включено выбрасывание исключений при ошибке записи на основном S3-диске;\n- FileService уже обрабатывает исключение и логирует безопасный технический контекст.\n\n## Проверки\n- php -l config/filesystems.php;\n- git diff --check.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated the 'throw' configuration option from false to true for the S3-compatible filesystem driver in config/filesystems.php.</li>
</ul></div>