### PR TITLE
fix[backend]: обработать сбой загрузки фото дефекта

### DIFF
--- a/app/BusinessModules/Features/QualityControl/Services/QualityDefectService.php
+++ b/app/BusinessModules/Features/QualityControl/Services/QualityDefectService.php
@@ -290,13 +290,17 @@ final class QualityDefectService
             $url = $photo['url'] ?? null;
 
             if (($photo['file'] ?? null) instanceof UploadedFile) {
-                $url = $this->fileService->upload(
-                    $photo['file'],
-                    "quality-control/defects/{$defect->id}",
-                    null,
-                    'private',
-                    $organization
-                );
+                try {
+                    $url = $this->fileService->upload(
+                        $photo['file'],
+                        "quality-control/defects/{$defect->id}",
+                        null,
+                        'private',
+                        $organization
+                    );
+                } catch (\Throwable) {
+                    throw new DomainException(trans_message('quality_control.errors.photo_upload_failed'));
+                }
 
                 if ($url === false) {
                     throw new DomainException(trans_message('quality_control.errors.photo_upload_failed'));


### PR DESCRIPTION
## GlitchTip\n- PROHELPER-BACKEND-G0 / issue 543: quality_control.mobile.defects.store.error\n- PROHELPER-BACKEND-G1 / issue 544: [FileService] S3 put() exception\n\n## Причина\nS3 provider returns 403 AccessDenied on PutObject. The Quality Defect service allowed the storage exception to bypass its expected upload-failure path, producing a generic 500 and duplicate GlitchTip event.\n\n## Изменения\n- переводит исключение загрузки фото в доменную ошибку с локализованным сообщением;\n- API возвращает контролируемый отказ вместо 500;\n- FileService retains the primary S3 diagnostic.\n\n## Проверки\n- php -l изменённого сервиса;\n- git diff --check.\n\n## Внешнее действие\nНужно выдать используемому S3 ключу право PutObject на bucket prohelper-storage (org-* prefix).

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Wrapped the photo upload process in a try-catch block to handle potential exceptions during file storage.</li>
<li>Added a specific DomainException with a localized error message when a photo upload fails.</li>
</ul></div>