### PR TITLE
feat: добавить параметры отчёта по холдингу

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/MultiOrganizationServiceProvider.php
+++ b/app/BusinessModules/Core/MultiOrganization/MultiOrganizationServiceProvider.php
@@ -23,6 +23,7 @@ use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAccepte
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPaymentEventFactProducer;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceImmutableEventSource;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceImmutableProjectionSynchronizer;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceOptionsService;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceProjectionCoverageInspector;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceSnapshotMaterializer;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\IntercompanyContractFlowOptionsService;
@@ -54,6 +55,7 @@ class MultiOrganizationServiceProvider extends ServiceProvider
         $this->app->scoped(HoldingPaymentEventFactProducer::class);
         $this->app->scoped(HoldingPerformanceImmutableEventSource::class);
         $this->app->scoped(HoldingPerformanceImmutableProjectionSynchronizer::class);
+        $this->app->scoped(HoldingPerformanceOptionsService::class);
         $this->app->scoped(HoldingPerformanceProjectionCoverageInspector::class);
         $this->app->scoped(HoldingPerformanceSnapshotMaterializer::class);
         $this->app->scoped(HoldingPerformanceReportProvider::class);

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceOptionDimensionQuery.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceOptionDimensionQuery.php
@@ -1,0 +1,691 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\MultiOrganization\Reporting\Services;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationContextSnapshot;
+use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingContractDimensionSnapshot;
+use App\BusinessModules\Core\Payments\Enums\PaymentTransactionStatus;
+use App\Enums\CurrencyCode;
+use App\Models\ContractPerformanceAct;
+use Brick\Math\BigDecimal;
+use Brick\Math\Exception\MathException;
+use Brick\Math\RoundingMode;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Builder;
+use InvalidArgumentException;
+
+final readonly class HoldingPerformanceOptionDimensionQuery
+{
+    public function __construct(
+        private ConnectionInterface $connection,
+    ) {}
+
+    /**
+     * @param  list<int>  $organizationIds
+     * @param  list<int>  $projectIds
+     * @return array{
+     *     complete:bool,
+     *     dimensions:list<array{
+     *         organization_id:int,
+     *         project_id:int,
+     *         contractor_id:int|null,
+     *         contract_status:string,
+     *         currency:string|null,
+     *         recognized_on:string
+     *     }>
+     * }
+     */
+    public function resolve(
+        int $holdingId,
+        array $organizationIds,
+        array $projectIds,
+        DateTimeInterface $coverageStartedAt,
+        DateTimeInterface $asOf,
+        DateTimeInterface $recordedCutoff,
+    ): array {
+        $organizations = $this->identities($organizationIds);
+        $projects = $this->identities($projectIds);
+        if ($holdingId < 1 || $asOf < $coverageStartedAt || $recordedCutoff < $coverageStartedAt) {
+            throw new InvalidArgumentException('holding_performance_period_outside_coverage');
+        }
+
+        $dimensions = [];
+        foreach ($this->acceptedRows(
+            $organizations,
+            $projects,
+            $coverageStartedAt,
+            $asOf,
+            $recordedCutoff,
+        ) as $row) {
+            $dimension = $this->acceptedDimension(
+                $row,
+                $holdingId,
+                $organizations,
+                $projects,
+                $coverageStartedAt,
+            );
+            if ($dimension === null) {
+                return ['complete' => false, 'dimensions' => []];
+            }
+            if ($dimension !== []) {
+                $dimensions[] = $dimension;
+            }
+        }
+        foreach ($this->paymentRows(
+            $organizations,
+            $projects,
+            $coverageStartedAt,
+            $asOf,
+            $recordedCutoff,
+        ) as $row) {
+            $dimension = $this->paymentDimension(
+                $row,
+                $holdingId,
+                $organizations,
+                $projects,
+                $coverageStartedAt,
+            );
+            if ($dimension === null) {
+                return ['complete' => false, 'dimensions' => []];
+            }
+            if ($dimension !== []) {
+                $dimensions[] = $dimension;
+            }
+        }
+
+        return ['complete' => true, 'dimensions' => $dimensions];
+    }
+
+    /** @return list<object> */
+    private function acceptedRows(
+        array $organizationIds,
+        array $projectIds,
+        DateTimeInterface $coverageStartedAt,
+        DateTimeInterface $asOf,
+        DateTimeInterface $recordedCutoff,
+    ): array {
+        $eventAlias = 'accepted_event';
+        $query = $this->connection->table('holding_accepted_work_event_versions as '.$eventAlias)
+            ->whereIn($eventAlias.'.organization_id', $organizationIds)
+            ->whereIn($eventAlias.'.project_id', $projectIds)
+            ->whereBetween($eventAlias.'.occurred_at', [$coverageStartedAt, $asOf])
+            ->where($eventAlias.'.recorded_at', '<=', $recordedCutoff)
+            ->whereNotExists(function (Builder $newer) use ($eventAlias, $asOf, $recordedCutoff): void {
+                $newer
+                    ->selectRaw('1')
+                    ->from('holding_accepted_work_event_versions as newer_event')
+                    ->whereColumn('newer_event.performance_act_id', $eventAlias.'.performance_act_id')
+                    ->where('newer_event.occurred_at', '<=', $asOf)
+                    ->where('newer_event.recorded_at', '<=', $recordedCutoff)
+                    ->where(fn (Builder $tuple): Builder => $this->newerCaptureTuple(
+                        $tuple,
+                        'newer_event',
+                        $eventAlias,
+                    ));
+            })
+            ->where(function (Builder $relevant) use ($eventAlias, $asOf, $recordedCutoff): void {
+                $relevant
+                    ->where($eventAlias.'.active', true)
+                    ->orWhereExists(function (Builder $prior) use ($eventAlias, $asOf, $recordedCutoff): void {
+                        $prior
+                            ->selectRaw('1')
+                            ->from('holding_accepted_work_event_versions as prior_event')
+                            ->whereColumn('prior_event.performance_act_id', $eventAlias.'.performance_act_id')
+                            ->where('prior_event.active', true)
+                            ->where('prior_event.occurred_at', '<=', $asOf)
+                            ->where('prior_event.recorded_at', '<=', $recordedCutoff)
+                            ->where(fn (Builder $tuple): Builder => $this->olderCaptureTuple(
+                                $tuple,
+                                'prior_event',
+                                $eventAlias,
+                            ));
+                    });
+            });
+
+        return $this->withPointInTimeDimensions($query, $eventAlias, 'occurred_at')
+            ->select($this->dimensionColumns($eventAlias, [
+                'id as event_version_id',
+                'performance_act_id as source_id',
+                'contract_id',
+                'project_id',
+                'organization_id',
+                'active',
+                'amount',
+                'status',
+                'occurred_at as recognized_at',
+                'history_complete',
+                'source_hash',
+            ]))
+            ->orderBy($eventAlias.'.id')
+            ->get()
+            ->all();
+    }
+
+    /** @return list<object> */
+    private function paymentRows(
+        array $organizationIds,
+        array $projectIds,
+        DateTimeInterface $coverageStartedAt,
+        DateTimeInterface $asOf,
+        DateTimeInterface $recordedCutoff,
+    ): array {
+        $eventAlias = 'payment_event';
+        $query = $this->connection->table('holding_payment_transaction_event_versions as '.$eventAlias)
+            ->whereIn($eventAlias.'.organization_id', $organizationIds)
+            ->where(function (Builder $scope) use ($eventAlias, $projectIds): void {
+                $scope
+                    ->whereIn($eventAlias.'.project_id', $projectIds)
+                    ->orWhere(fn (Builder $gap): Builder => $gap
+                        ->whereNull($eventAlias.'.project_id')
+                        ->where($eventAlias.'.history_complete', false));
+            })
+            ->where(function (Builder $window) use ($eventAlias, $coverageStartedAt, $asOf): void {
+                $window
+                    ->whereBetween($eventAlias.'.recognized_at', [$coverageStartedAt, $asOf])
+                    ->orWhere(fn (Builder $gap): Builder => $gap
+                        ->where($eventAlias.'.history_complete', false)
+                        ->whereBetween($eventAlias.'.occurred_at', [$coverageStartedAt, $asOf]));
+            })
+            ->where($eventAlias.'.occurred_at', '<=', $asOf)
+            ->where($eventAlias.'.recorded_at', '<=', $recordedCutoff)
+            ->whereNotExists(function (Builder $newer) use ($eventAlias, $asOf, $recordedCutoff): void {
+                $newer
+                    ->selectRaw('1')
+                    ->from('holding_payment_transaction_event_versions as newer_event')
+                    ->whereColumn('newer_event.transaction_id', $eventAlias.'.transaction_id')
+                    ->where('newer_event.occurred_at', '<=', $asOf)
+                    ->where('newer_event.recorded_at', '<=', $recordedCutoff)
+                    ->where(fn (Builder $tuple): Builder => $this->newerCaptureTuple(
+                        $tuple,
+                        'newer_event',
+                        $eventAlias,
+                    ));
+            })
+            ->where(function (Builder $relevant) use ($eventAlias, $asOf, $recordedCutoff): void {
+                $relevant
+                    ->where($eventAlias.'.active', true)
+                    ->orWhereExists(function (Builder $prior) use ($eventAlias, $asOf, $recordedCutoff): void {
+                        $prior
+                            ->selectRaw('1')
+                            ->from('holding_payment_transaction_event_versions as prior_event')
+                            ->whereColumn('prior_event.transaction_id', $eventAlias.'.transaction_id')
+                            ->where('prior_event.active', true)
+                            ->where('prior_event.occurred_at', '<=', $asOf)
+                            ->where('prior_event.recorded_at', '<=', $recordedCutoff)
+                            ->where(fn (Builder $tuple): Builder => $this->olderCaptureTuple(
+                                $tuple,
+                                'prior_event',
+                                $eventAlias,
+                            ));
+                    });
+            });
+
+        return $this->withPointInTimeDimensions($query, $eventAlias, 'recognized_at')
+            ->select($this->dimensionColumns($eventAlias, [
+                'id as event_version_id',
+                'transaction_id as source_id',
+                'contract_id',
+                'project_id',
+                'organization_id',
+                'document_organization_id',
+                'document_project_id',
+                'contract_organization_id',
+                'contract_project_id',
+                'active',
+                'amount',
+                'currency as event_currency',
+                'status',
+                'recognized_at',
+                'occurred_at',
+                'history_complete',
+                'source_hash',
+            ]))
+            ->orderBy($eventAlias.'.id')
+            ->get()
+            ->all();
+    }
+
+    private function withPointInTimeDimensions(
+        Builder $query,
+        string $eventAlias,
+        string $effectiveColumn,
+    ): Builder {
+        $hierarchy = $this->connection->table('holding_organization_hierarchy_events as contributor_hierarchy')
+            ->select([
+                'contributor_hierarchy.organization_id',
+                'contributor_hierarchy.parent_organization_id',
+                'contributor_hierarchy.is_active',
+                'contributor_hierarchy.is_deleted',
+            ])
+            ->selectRaw(
+                'COALESCE(contributor_hierarchy.parent_organization_id, '
+                .'contributor_hierarchy.organization_id) AS holding_id',
+            )
+            ->where($eventAlias.'.active', true)
+            ->whereColumn('contributor_hierarchy.organization_id', $eventAlias.'.organization_id')
+            ->whereColumn('contributor_hierarchy.observed_at', '<=', $eventAlias.'.'.$effectiveColumn)
+            ->orderByDesc('contributor_hierarchy.observed_at')
+            ->orderByDesc('contributor_hierarchy.id')
+            ->limit(1);
+        $hierarchyState = $this->hierarchyState($eventAlias, $effectiveColumn);
+        $dimension = $this->connection->table('holding_contract_dimension_events as contract_dimension')
+            ->select([
+                'contract_dimension.id',
+                'contract_dimension.contract_id',
+                'contract_dimension.organization_id',
+                'contract_dimension.contractor_id',
+                'contract_dimension.counterparty_organization_id',
+                'contract_dimension.contract_status',
+                'contract_dimension.work_type_category',
+                'contract_dimension.total_amount',
+                'contract_dimension.currency',
+                'contract_dimension.is_deleted',
+                'contract_dimension.evidence_hash',
+            ])
+            ->where($eventAlias.'.active', true)
+            ->whereColumn('contract_dimension.contract_id', $eventAlias.'.contract_id')
+            ->whereColumn('contract_dimension.observed_at', '<=', $eventAlias.'.'.$effectiveColumn)
+            ->orderByDesc('contract_dimension.observed_at')
+            ->orderByDesc('contract_dimension.id')
+            ->limit(1);
+        $allocation = $this->connection->table('holding_allocation_context_events as allocation_context')
+            ->select([
+                'allocation_context.id',
+                'allocation_context.allocation_id',
+                'allocation_context.contract_id',
+                'allocation_context.organization_id',
+                'allocation_context.project_id',
+                'allocation_context.allocation_type',
+                'allocation_context.allocated_amount',
+                'allocation_context.allocated_percentage',
+                'allocation_context.is_resolvable',
+                'allocation_context.is_active',
+                'allocation_context.is_deleted',
+                'allocation_context.evidence_hash',
+            ])
+            ->where($eventAlias.'.active', true)
+            ->whereColumn('allocation_context.contract_id', $eventAlias.'.contract_id')
+            ->whereColumn('allocation_context.project_id', $eventAlias.'.project_id')
+            ->whereColumn('allocation_context.observed_at', '<=', $eventAlias.'.'.$effectiveColumn)
+            ->whereNotExists(function (Builder $newer) use ($eventAlias, $effectiveColumn): void {
+                $newer
+                    ->selectRaw('1')
+                    ->from('holding_allocation_context_events as newer_allocation')
+                    ->whereColumn('newer_allocation.allocation_id', 'allocation_context.allocation_id')
+                    ->whereColumn('newer_allocation.contract_id', $eventAlias.'.contract_id')
+                    ->whereColumn('newer_allocation.project_id', $eventAlias.'.project_id')
+                    ->whereColumn('newer_allocation.observed_at', '<=', $eventAlias.'.'.$effectiveColumn)
+                    ->where(function (Builder $newerTuple): void {
+                        $newerTuple
+                            ->whereColumn('newer_allocation.observed_at', '>', 'allocation_context.observed_at')
+                            ->orWhere(function (Builder $sameObserved): void {
+                                $sameObserved
+                                    ->whereColumn(
+                                        'newer_allocation.observed_at',
+                                        'allocation_context.observed_at',
+                                    )
+                                    ->whereColumn('newer_allocation.id', '>', 'allocation_context.id');
+                            });
+                    });
+            })
+            ->where('allocation_context.is_deleted', false)
+            ->where('allocation_context.is_active', true)
+            ->orderByDesc('allocation_context.allocation_id')
+            ->limit(1);
+
+        return $query
+            ->leftJoinLateral($hierarchy, 'event_hierarchy')
+            ->leftJoinLateral($hierarchyState, 'hierarchy_state')
+            ->leftJoinLateral($dimension, 'event_dimension')
+            ->leftJoinLateral($allocation, 'event_allocation');
+    }
+
+    private function hierarchyState(string $eventAlias, string $effectiveColumn): Builder
+    {
+        $candidateIds = $this->connection->table('holding_organization_hierarchy_events as hierarchy_candidate')
+            ->select('hierarchy_candidate.organization_id')
+            ->whereColumn('hierarchy_candidate.observed_at', '<=', $eventAlias.'.'.$effectiveColumn)
+            ->where(function (Builder $scope): void {
+                $scope
+                    ->whereColumn('hierarchy_candidate.organization_id', 'event_hierarchy.holding_id')
+                    ->orWhereColumn(
+                        'hierarchy_candidate.parent_organization_id',
+                        'event_hierarchy.holding_id',
+                    );
+            })
+            ->distinct();
+        $timeline = $this->connection->table('holding_organization_hierarchy_events as latest_hierarchy')
+            ->select([
+                'latest_hierarchy.organization_id',
+                'latest_hierarchy.parent_organization_id',
+                'latest_hierarchy.is_active',
+                'latest_hierarchy.is_deleted',
+                'latest_hierarchy.evidence_hash',
+            ])
+            ->selectRaw(
+                'ROW_NUMBER() OVER (PARTITION BY latest_hierarchy.organization_id '
+                .'ORDER BY latest_hierarchy.observed_at DESC, latest_hierarchy.id DESC) AS timeline_position',
+            )
+            ->whereIn('latest_hierarchy.organization_id', $candidateIds)
+            ->whereColumn('latest_hierarchy.observed_at', '<=', $eventAlias.'.'.$effectiveColumn);
+
+        return $this->connection->table('holding_organization_hierarchy_events')
+            ->fromSub($timeline, 'historical_hierarchy')
+            ->selectRaw(
+                'COUNT(*) FILTER (WHERE historical_hierarchy.organization_id = '
+                .$eventAlias.'.organization_id) AS contributor_count',
+            )
+            ->selectRaw(
+                'COUNT(*) FILTER (WHERE historical_hierarchy.organization_id = '
+                .'event_hierarchy.holding_id) AS root_count',
+            )
+            ->selectRaw(
+                "COALESCE(BOOL_AND(historical_hierarchy.evidence_hash ~ '^[a-f0-9]{64}$'), false) "
+                .'AS hierarchy_evidence_valid',
+            )
+            ->where($eventAlias.'.active', true)
+            ->where('historical_hierarchy.timeline_position', 1)
+            ->where('historical_hierarchy.is_deleted', false)
+            ->where('historical_hierarchy.is_active', true)
+            ->where(function (Builder $member): void {
+                $member
+                    ->whereColumn('historical_hierarchy.organization_id', 'event_hierarchy.holding_id')
+                    ->orWhereColumn(
+                        'historical_hierarchy.parent_organization_id',
+                        'event_hierarchy.holding_id',
+                    );
+            });
+    }
+
+    /** @param list<string> $eventColumns @return list<string> */
+    private function dimensionColumns(string $eventAlias, array $eventColumns): array
+    {
+        return [
+            ...array_map(static fn (string $column): string => $eventAlias.'.'.$column, $eventColumns),
+            'event_hierarchy.holding_id as historical_holding_id',
+            'hierarchy_state.contributor_count',
+            'hierarchy_state.root_count',
+            'hierarchy_state.hierarchy_evidence_valid',
+            'event_dimension.id as dimension_event_id',
+            'event_dimension.contract_id as dimension_contract_id',
+            'event_dimension.organization_id as dimension_organization_id',
+            'event_dimension.contractor_id',
+            'event_dimension.counterparty_organization_id',
+            'event_dimension.contract_status',
+            'event_dimension.work_type_category',
+            'event_dimension.total_amount',
+            'event_dimension.currency as dimension_currency',
+            'event_dimension.is_deleted as dimension_is_deleted',
+            'event_dimension.evidence_hash as dimension_evidence_hash',
+            'event_allocation.id as allocation_event_id',
+            'event_allocation.allocation_id',
+            'event_allocation.contract_id as allocation_contract_id',
+            'event_allocation.organization_id as allocation_organization_id',
+            'event_allocation.project_id as allocation_project_id',
+            'event_allocation.allocation_type',
+            'event_allocation.allocated_amount',
+            'event_allocation.allocated_percentage',
+            'event_allocation.is_resolvable as allocation_is_resolvable',
+            'event_allocation.is_active as allocation_is_active',
+            'event_allocation.is_deleted as allocation_is_deleted',
+            'event_allocation.evidence_hash as allocation_evidence_hash',
+        ];
+    }
+
+    private function acceptedDimension(
+        object $row,
+        int $holdingId,
+        array $organizationIds,
+        array $projectIds,
+        DateTimeInterface $coverageStartedAt,
+    ): ?array {
+        $organizationId = (int) $row->organization_id;
+        $projectId = (int) $row->project_id;
+        if (min(
+            $organizationId,
+            $projectId,
+            (int) $row->contract_id,
+            (int) $row->source_id,
+            (int) $row->event_version_id,
+        ) < 1
+            || $this->databaseBoolean($row->history_complete) !== true
+            || $this->recognizedOn($row->recognized_at) === null
+            || ($row->source_hash !== null
+                && preg_match('/^[a-f0-9]{64}$/D', (string) $row->source_hash) !== 1)) {
+            return null;
+        }
+        $active = $this->databaseBoolean($row->active);
+        if ($active === null) {
+            return null;
+        }
+        if (! $active) {
+            return [];
+        }
+        if (! in_array(
+            (string) $row->status,
+            [ContractPerformanceAct::STATUS_APPROVED, ContractPerformanceAct::STATUS_SIGNED],
+            true,
+        ) || ! $this->validMoney((string) $row->amount)) {
+            return null;
+        }
+
+        return $this->activeDimension(
+            $row,
+            $holdingId,
+            $organizationIds,
+            $projectIds,
+            $coverageStartedAt,
+            false,
+            null,
+        );
+    }
+
+    private function paymentDimension(
+        object $row,
+        int $holdingId,
+        array $organizationIds,
+        array $projectIds,
+        DateTimeInterface $coverageStartedAt,
+    ): ?array {
+        $organizationId = (int) $row->organization_id;
+        $projectId = (int) ($row->project_id ?? 0);
+        if (min(
+            $organizationId,
+            $projectId,
+            (int) ($row->contract_id ?? 0),
+            (int) $row->source_id,
+            (int) $row->event_version_id,
+        ) < 1
+            || $this->databaseBoolean($row->history_complete) !== true
+            || $this->recognizedOn($row->recognized_at) === null
+            || (int) ($row->document_organization_id ?? 0) !== $organizationId
+            || (int) ($row->contract_organization_id ?? 0) !== $organizationId
+            || (int) ($row->document_project_id ?? 0) !== $projectId
+            || (int) ($row->contract_project_id ?? 0) !== $projectId
+            || preg_match('/^[a-f0-9]{64}$/D', (string) $row->source_hash) !== 1) {
+            return null;
+        }
+        $active = $this->databaseBoolean($row->active);
+        if ($active === null) {
+            return null;
+        }
+        if (! $active) {
+            return [];
+        }
+
+        $rawCurrency = is_string($row->event_currency)
+            ? mb_strtoupper(trim($row->event_currency))
+            : '';
+        if (preg_match('/^[A-Z]{3}$/D', $rawCurrency) !== 1
+            || $row->amount === null
+            || ! is_numeric($row->amount)
+            || ! $this->validMoney((string) $row->amount)
+            || ! in_array(
+                PaymentTransactionStatus::tryFrom((string) $row->status),
+                [PaymentTransactionStatus::COMPLETED, PaymentTransactionStatus::REFUNDED],
+                true,
+            )) {
+            return null;
+        }
+
+        return $this->activeDimension(
+            $row,
+            $holdingId,
+            $organizationIds,
+            $projectIds,
+            $coverageStartedAt,
+            true,
+            $rawCurrency,
+        );
+    }
+
+    private function activeDimension(
+        object $row,
+        int $holdingId,
+        array $organizationIds,
+        array $projectIds,
+        DateTimeInterface $coverageStartedAt,
+        bool $requirePercentage,
+        ?string $eventCurrency,
+    ): ?array {
+        $organizationId = (int) $row->organization_id;
+        $projectId = (int) $row->project_id;
+        if (! in_array($organizationId, $organizationIds, true)
+            || ! in_array($projectId, $projectIds, true)
+            || (int) ($row->historical_holding_id ?? 0) !== $holdingId
+            || (int) ($row->contributor_count ?? 0) < 1
+            || (int) ($row->root_count ?? 0) < 1
+            || $this->databaseBoolean($row->hierarchy_evidence_valid ?? null) !== true
+            || $this->databaseBoolean($row->dimension_is_deleted ?? null) !== false
+            || $this->databaseBoolean($row->allocation_is_resolvable ?? null) !== true
+            || $this->databaseBoolean($row->allocation_is_active ?? null) !== true
+            || $this->databaseBoolean($row->allocation_is_deleted ?? null) !== false) {
+            return null;
+        }
+
+        try {
+            $dimension = new HoldingContractDimensionSnapshot(
+                (int) ($row->dimension_event_id ?? 0),
+                (int) ($row->dimension_contract_id ?? 0),
+                (int) ($row->dimension_organization_id ?? 0),
+                $row->contractor_id === null ? null : (int) $row->contractor_id,
+                $row->counterparty_organization_id === null
+                    ? null
+                    : (int) $row->counterparty_organization_id,
+                (string) ($row->contract_status ?? ''),
+                $row->work_type_category === null ? null : (string) $row->work_type_category,
+                $row->total_amount === null ? null : (string) $row->total_amount,
+                mb_strtoupper(trim((string) ($row->dimension_currency ?? ''))),
+                CurrencyCode::tryFrom(mb_strtoupper(trim((string) ($row->dimension_currency ?? ''))))?->value,
+                (string) ($row->dimension_evidence_hash ?? ''),
+                $coverageStartedAt->format(DateTimeInterface::ATOM),
+            );
+            $allocation = new HoldingAllocationContextSnapshot(
+                (int) ($row->allocation_event_id ?? 0),
+                (int) ($row->allocation_id ?? 0),
+                (int) ($row->allocation_contract_id ?? 0),
+                (int) ($row->allocation_organization_id ?? 0),
+                (int) ($row->allocation_project_id ?? 0),
+                (string) ($row->allocation_type ?? ''),
+                $row->allocated_amount === null ? null : (string) $row->allocated_amount,
+                $row->allocated_percentage === null ? null : (string) $row->allocated_percentage,
+                (string) ($row->allocation_evidence_hash ?? ''),
+                $coverageStartedAt->format(DateTimeInterface::ATOM),
+            );
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+        if ($dimension->organizationId !== $organizationId
+            || $dimension->contractId !== (int) $row->contract_id
+            || $allocation->organizationId !== $organizationId
+            || $allocation->contractId !== (int) $row->contract_id
+            || $allocation->projectId !== $projectId
+            || ($requirePercentage && $allocation->allocatedPercentage === null)
+            || ($eventCurrency !== null && $eventCurrency !== $dimension->rawCurrency)) {
+            return null;
+        }
+
+        $recognizedOn = $this->recognizedOn($row->recognized_at);
+        if ($recognizedOn === null) {
+            return null;
+        }
+
+        return [
+            'organization_id' => $organizationId,
+            'project_id' => $projectId,
+            'contractor_id' => $dimension->contractorId,
+            'contract_status' => $dimension->contractStatus,
+            'currency' => $dimension->currency,
+            'recognized_on' => $recognizedOn,
+        ];
+    }
+
+    private function recognizedOn(mixed $value): ?string
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d');
+        }
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+        try {
+            return CarbonImmutable::parse($value)->format('Y-m-d');
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    private function validMoney(string $amount): bool
+    {
+        try {
+            BigDecimal::of($amount)->multipliedBy(100)->toScale(0, RoundingMode::HalfUp)->toInt();
+
+            return true;
+        } catch (MathException) {
+            return false;
+        }
+    }
+
+    private function databaseBoolean(mixed $value): ?bool
+    {
+        return match ($value) {
+            true, 1, '1', 't', 'true' => true,
+            false, 0, '0', 'f', 'false' => false,
+            default => null,
+        };
+    }
+
+    /** @return list<int> */
+    private function identities(array $ids): array
+    {
+        $normalized = array_values(array_unique(array_map('intval', $ids)));
+        sort($normalized, SORT_NUMERIC);
+        if ($normalized === [] || array_filter($normalized, static fn (int $id): bool => $id < 1) !== []) {
+            throw new InvalidArgumentException('holding_performance_scope_invalid');
+        }
+
+        return $normalized;
+    }
+
+    private function newerCaptureTuple(Builder $query, string $candidate, string $base): Builder
+    {
+        return $query
+            ->whereColumn($candidate.'.recorded_at', '>', $base.'.recorded_at')
+            ->orWhere(fn (Builder $sameRecorded): Builder => $sameRecorded
+                ->whereColumn($candidate.'.recorded_at', $base.'.recorded_at')
+                ->whereColumn($candidate.'.id', '>', $base.'.id'));
+    }
+
+    private function olderCaptureTuple(Builder $query, string $candidate, string $base): Builder
+    {
+        return $query
+            ->whereColumn($candidate.'.recorded_at', '<', $base.'.recorded_at')
+            ->orWhere(fn (Builder $sameRecorded): Builder => $sameRecorded
+                ->whereColumn($candidate.'.recorded_at', $base.'.recorded_at')
+                ->whereColumn($candidate.'.id', '<', $base.'.id'));
+    }
+}

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceOptionsService.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceOptionsService.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\MultiOrganization\Reporting\Services;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationCheckpointSource;
+use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationFact;
+use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceBuiltinPublishedReport;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\Enums\Contract\ContractStatusEnum;
+use App\Enums\CurrencyCode;
+use Carbon\CarbonImmutable;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Illuminate\Database\ConnectionInterface;
+use InvalidArgumentException;
+
+final readonly class HoldingPerformanceOptionsService
+{
+    public function __construct(
+        private HoldingAllocationCheckpointSourceAssembler $sources,
+        private HoldingPerformanceImmutableEventSource $events,
+        private HoldingPerformanceOptionDimensionQuery $optionDimensions,
+        private HoldingPerformanceBuiltinPublishedReport $published,
+        private ConnectionInterface $connection,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function options(
+        ReportScope $scope,
+        DateTimeImmutable $asOf,
+        ?string $periodFrom = null,
+        ?string $periodTo = null,
+    ): array {
+        if ($this->connection->transactionLevel() > 0) {
+            return $this->optionsWithinStableView($scope, $asOf, $periodFrom, $periodTo);
+        }
+
+        return $this->connection->transaction(function () use (
+            $scope,
+            $asOf,
+            $periodFrom,
+            $periodTo,
+        ): array {
+            if ($this->connection->getDriverName() === 'pgsql') {
+                $this->connection->statement('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY');
+            }
+
+            return $this->optionsWithinStableView($scope, $asOf, $periodFrom, $periodTo);
+        }, 3);
+    }
+
+    /** @return array<string, mixed> */
+    private function optionsWithinStableView(
+        ReportScope $scope,
+        DateTimeImmutable $asOf,
+        ?string $periodFrom,
+        ?string $periodTo,
+    ): array {
+        $coverageStartedAt = null;
+        try {
+            $coverageStartedAt = $this->events->coverageStartedAt(
+                $this->sources->coverageStartedAt($asOf),
+                $scope->timezone,
+            );
+            $coverageDate = $this->localDate($coverageStartedAt, $scope);
+            $selectedFrom = $periodFrom ?? $coverageDate;
+            $selectedTo = $periodTo ?? $this->localDate($asOf, $scope);
+            $filters = [
+                'period_from' => $selectedFrom,
+                'period_to' => $selectedTo,
+            ];
+            $this->events->assertPeriodCovered($filters, $coverageStartedAt, $scope->timezone);
+            $query = new ReportQuery(
+                $this->published->definition()->payload(),
+                $scope,
+                new ReportFilterSet($filters),
+                [],
+                $asOf,
+                'ru-RU',
+            );
+            $openingBoundary = $this->sources->openingBoundary($query);
+            $batch = $this->sources->assembleOpeningState($scope, $query, $openingBoundary);
+            $recordedCutoff = now()->toImmutable();
+            $eventDimensions = $this->optionDimensions->resolve(
+                $batch->hierarchy->holdingId,
+                $batch->hierarchy->organizationIds,
+                $scope->projectIds,
+                $coverageStartedAt,
+                $asOf,
+                $recordedCutoff,
+            );
+        } catch (InvalidArgumentException) {
+            return $this->unavailable($scope, $asOf, $coverageStartedAt, $periodFrom, $periodTo);
+        }
+        if ($batch->gaps !== [] || ! $eventDimensions['complete']) {
+            return $this->unavailable(
+                $scope,
+                $asOf,
+                $coverageStartedAt,
+                $selectedFrom,
+                $selectedTo,
+                'source_incomplete',
+            );
+        }
+
+        $organizationIds = [];
+        $projectIds = [];
+        $contractorIds = [];
+        $contractStatuses = [];
+        $currencies = [];
+        foreach ($batch->sources as $source) {
+            if (! $source instanceof HoldingAllocationCheckpointSource) {
+                return $this->unavailable($scope, $asOf, $coverageStartedAt, $selectedFrom, $selectedTo);
+            }
+            if (! $this->collectDimensions(
+                $source->fact,
+                $batch->hierarchy->organizationIds,
+                $scope->projectIds,
+                $organizationIds,
+                $projectIds,
+                $contractorIds,
+                $contractStatuses,
+                $currencies,
+            )) {
+                return $this->unavailable($scope, $asOf, $coverageStartedAt, $selectedFrom, $selectedTo);
+            }
+        }
+
+        foreach ($eventDimensions['dimensions'] as $dimension) {
+            if ($this->eventFallsWithinPeriod($dimension, $selectedFrom, $selectedTo)
+                && ! $this->collectOptionDimension(
+                    $dimension['organization_id'],
+                    $dimension['project_id'],
+                    $dimension['contractor_id'],
+                    $dimension['contract_status'],
+                    $dimension['currency'],
+                    $batch->hierarchy->organizationIds,
+                    $scope->projectIds,
+                    $organizationIds,
+                    $projectIds,
+                    $contractorIds,
+                    $contractStatuses,
+                    $currencies,
+                )) {
+                return $this->unavailable($scope, $asOf, $coverageStartedAt, $selectedFrom, $selectedTo);
+            }
+        }
+
+        $organizations = $this->organizationOptions(
+            array_keys($organizationIds),
+            $batch->hierarchy->organizationIds,
+        );
+        $projects = $this->projectOptions(array_keys($projectIds), $scope->projectIds);
+        $contractors = $this->contractorOptions(
+            array_keys($contractorIds),
+            $batch->hierarchy->organizationIds,
+        );
+        if (count($organizations) !== count($organizationIds)
+            || count($projects) !== count($projectIds)
+            || count($contractors) !== count($contractorIds)) {
+            return $this->unavailable(
+                $scope,
+                $asOf,
+                $coverageStartedAt,
+                $selectedFrom,
+                $selectedTo,
+                'source_reference_missing',
+            );
+        }
+
+        $statuses = $this->statusOptions(array_keys($contractStatuses));
+        $currencyOptions = $this->currencyOptions(array_keys($currencies));
+        if ($statuses === null || $currencyOptions === null) {
+            return $this->unavailable($scope, $asOf, $coverageStartedAt, $selectedFrom, $selectedTo);
+        }
+
+        return [
+            'available' => true,
+            'reason' => null,
+            'as_of' => $this->exactDateTime($asOf),
+            'period' => $this->period($scope, $asOf, $coverageStartedAt, $selectedFrom, $selectedTo),
+            'organizations' => $organizations,
+            'projects' => $projects,
+            'contractors' => $contractors,
+            'contract_statuses' => $statuses,
+            'currencies' => $currencyOptions,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $allowedOrganizationIds
+     * @param  list<int>  $allowedProjectIds
+     * @param  array<int, true>  $organizationIds
+     * @param  array<int, true>  $projectIds
+     * @param  array<int, true>  $contractorIds
+     * @param  array<string, true>  $contractStatuses
+     * @param  array<string, true>  $currencies
+     */
+    private function collectDimensions(
+        HoldingAllocationFact $fact,
+        array $allowedOrganizationIds,
+        array $allowedProjectIds,
+        array &$organizationIds,
+        array &$projectIds,
+        array &$contractorIds,
+        array &$contractStatuses,
+        array &$currencies,
+    ): bool {
+        return $this->collectOptionDimension(
+            $fact->contributorOrganizationId,
+            $fact->projectId,
+            $fact->contractorId,
+            $fact->contractStatus,
+            $fact->currency,
+            $allowedOrganizationIds,
+            $allowedProjectIds,
+            $organizationIds,
+            $projectIds,
+            $contractorIds,
+            $contractStatuses,
+            $currencies,
+        );
+    }
+
+    private function collectOptionDimension(
+        int $organizationId,
+        int $projectId,
+        ?int $contractorId,
+        string $contractStatus,
+        ?string $currency,
+        array $allowedOrganizationIds,
+        array $allowedProjectIds,
+        array &$organizationIds,
+        array &$projectIds,
+        array &$contractorIds,
+        array &$contractStatuses,
+        array &$currencies,
+    ): bool {
+        if (! in_array($organizationId, $allowedOrganizationIds, true)
+            || ! in_array($projectId, $allowedProjectIds, true)) {
+            return false;
+        }
+
+        $organizationIds[$organizationId] = true;
+        $projectIds[$projectId] = true;
+        $contractStatuses[$contractStatus] = true;
+        if ($contractorId !== null) {
+            $contractorIds[$contractorId] = true;
+        }
+        if ($currency !== null) {
+            $currencies[$currency] = true;
+        }
+
+        return true;
+    }
+
+    private function eventFallsWithinPeriod(
+        array $dimension,
+        string $periodFrom,
+        string $periodTo,
+    ): bool {
+        return $dimension['recognized_on'] >= $periodFrom && $dimension['recognized_on'] <= $periodTo;
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @param  list<int>  $allowedIds
+     * @return list<array{id:int,name:string}>
+     */
+    private function organizationOptions(array $ids, array $allowedIds): array
+    {
+        if ($ids === [] || array_diff($ids, $allowedIds) !== []) {
+            return [];
+        }
+
+        $rows = $this->connection->table('organizations')
+            ->whereIn('id', $ids)
+            ->whereNull('deleted_at')
+            ->get(['id', 'name']);
+
+        return $this->namedRows($rows->all());
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @param  list<int>  $allowedIds
+     * @return list<array{id:int,name:string}>
+     */
+    private function projectOptions(array $ids, array $allowedIds): array
+    {
+        if ($ids === [] || array_diff($ids, $allowedIds) !== []) {
+            return [];
+        }
+
+        $rows = $this->connection->table('projects')
+            ->whereIn('id', $ids)
+            ->whereNull('deleted_at')
+            ->get(['id', 'name']);
+
+        return $this->namedRows($rows->all());
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @param  list<int>  $organizationIds
+     * @return list<array{id:int,name:string}>
+     */
+    private function contractorOptions(array $ids, array $organizationIds): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $rows = $this->connection->table('contractors')
+            ->whereIn('id', $ids)
+            ->whereIn('organization_id', $organizationIds)
+            ->whereNull('deleted_at')
+            ->get(['id', 'name']);
+
+        return $this->namedRows($rows->all());
+    }
+
+    /**
+     * @param  list<string>  $codes
+     * @return list<array{id:string,name:string}>|null
+     */
+    private function statusOptions(array $codes): ?array
+    {
+        $options = [];
+        foreach ($codes as $code) {
+            $status = ContractStatusEnum::tryFrom($code);
+            if ($status === null) {
+                return null;
+            }
+            $options[] = [
+                'id' => $status->value,
+                'name' => trans_message('contract.statuses.'.$status->value, locale: 'ru'),
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<string>  $codes
+     * @return list<array{id:string,name:string}>|null
+     */
+    private function currencyOptions(array $codes): ?array
+    {
+        $labels = CurrencyCode::options();
+        $options = [];
+        foreach ($codes as $code) {
+            if (! isset($labels[$code])) {
+                return null;
+            }
+            $options[] = ['id' => $code, 'name' => $labels[$code]];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<object>  $rows
+     * @return list<array{id:int,name:string}>
+     */
+    private function namedRows(array $rows): array
+    {
+        $options = [];
+        foreach ($rows as $row) {
+            $name = trim((string) $row->name);
+            if ($name !== '') {
+                $options[] = ['id' => (int) $row->id, 'name' => $name];
+            }
+        }
+
+        return $this->sorted($options);
+    }
+
+    /** @param list<array{id:int|string,name:string}> $options */
+    private function sorted(array $options): array
+    {
+        usort($options, static fn (array $left, array $right): int => strnatcasecmp(
+            (string) $left['name'],
+            (string) $right['name'],
+        ));
+
+        return $options;
+    }
+
+    /** @return array<string, mixed> */
+    private function unavailable(
+        ReportScope $scope,
+        DateTimeImmutable $asOf,
+        ?DateTimeInterface $coverageStartedAt,
+        ?string $selectedFrom,
+        ?string $selectedTo,
+        string $reason = 'source_unavailable',
+    ): array {
+        return [
+            'available' => false,
+            'reason' => $reason,
+            'as_of' => $this->exactDateTime($asOf),
+            'period' => $this->period($scope, $asOf, $coverageStartedAt, $selectedFrom, $selectedTo),
+            'organizations' => [],
+            'projects' => [],
+            'contractors' => [],
+            'contract_statuses' => [],
+            'currencies' => [],
+        ];
+    }
+
+    /** @return array<string, string|null> */
+    private function period(
+        ReportScope $scope,
+        DateTimeImmutable $asOf,
+        ?DateTimeInterface $coverageStartedAt,
+        ?string $selectedFrom,
+        ?string $selectedTo,
+    ): array {
+        return [
+            'coverage_started_at' => $coverageStartedAt === null
+                ? null
+                : $this->exactDateTime(DateTimeImmutable::createFromInterface($coverageStartedAt)),
+            'default_from' => $coverageStartedAt === null
+                ? null
+                : $this->localDate($coverageStartedAt, $scope),
+            'default_to' => $this->localDate($asOf, $scope),
+            'selected_from' => $selectedFrom,
+            'selected_to' => $selectedTo,
+        ];
+    }
+
+    private function localDate(DateTimeInterface $value, ReportScope $scope): string
+    {
+        return CarbonImmutable::instance($value)->setTimezone($scope->timezone)->toDateString();
+    }
+
+    private function exactDateTime(DateTimeImmutable $value): string
+    {
+        return $value->format('u') === '000000'
+            ? $value->format(DATE_ATOM)
+            : $value->format('Y-m-d\TH:i:s.uP');
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/HoldingPerformanceReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/HoldingPerformanceReportOptionsController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceCandidateContract;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceOptionsService;
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\HoldingPerformanceReportOptionsRequest;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class HoldingPerformanceReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private HoldingPerformanceOptionsService $options,
+    ) {}
+
+    public function __invoke(HoldingPerformanceReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, HoldingPerformanceCandidateContract::CODE)['context'];
+
+        return AdminResponse::success($this->options->options(
+            $context->scope,
+            $request->asOf(),
+            $request->periodFrom(),
+            $request->periodTo(),
+        ));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -95,6 +95,7 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.workforce-capacity.options',
             'admin.reports.portfolio-liquidity.options',
             'admin.reports.holding-performance.runs.store',
+            'admin.reports.holding-performance.options',
             'admin.reports.intercompany-contract-flows.runs.store',
             'admin.reports.intercompany-contract-flows.options' => $this->targets->createRun(
                 $this->routeId($request, 'reportCode'),

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/HoldingPerformanceReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/HoldingPerformanceReportOptionsRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use DateTimeImmutable;
+
+final class HoldingPerformanceReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        $periodFrom = $this->query('period_from');
+
+        return [
+            'as_of' => [
+                'required',
+                'string',
+                static function (string $attribute, mixed $value, callable $fail): void {
+                    if (ReportAsOfParser::parse($value) === null) {
+                        $fail(trans_message('reports.errors.report_request_invalid'));
+                    }
+                },
+            ],
+            'period_from' => ['nullable', 'string', 'date_format:Y-m-d'],
+            'period_to' => [
+                'nullable',
+                'string',
+                'date_format:Y-m-d',
+                static function (string $attribute, mixed $value, callable $fail) use ($periodFrom): void {
+                    if (is_string($periodFrom) && is_string($value) && $value < $periodFrom) {
+                        $fail(trans_message('reports.errors.report_request_invalid'));
+                    }
+                },
+            ],
+            ...$this->forbiddenClientFieldsRules(),
+            'current_organization_id' => ['prohibited'],
+            'holding_organization_ids' => ['prohibited'],
+            'organization_ids' => ['prohibited'],
+            'project_id' => ['prohibited'],
+            'current_project_id' => ['prohibited'],
+            'project_ids' => ['prohibited'],
+            'scope' => ['prohibited'],
+            'actor_id' => ['prohibited'],
+        ];
+    }
+
+    protected function acceptedQueryFields(): array
+    {
+        return ['as_of', 'period_from', 'period_to'];
+    }
+
+    public function asOf(): DateTimeImmutable
+    {
+        $asOf = ReportAsOfParser::parse($this->validated('as_of'));
+        if ($asOf === null) {
+            throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => ['as_of']],
+            );
+        }
+
+        return $asOf;
+    }
+
+    public function periodFrom(): ?string
+    {
+        $value = $this->validated('period_from');
+
+        return is_string($value) ? $value : null;
+    }
+
+    public function periodTo(): ?string
+    {
+        $value = $this->validated('period_to');
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMatrix;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\HoldingPerformanceReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\IntercompanyContractFlowReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PortfolioLiquidityReportOptionsController;
@@ -108,6 +109,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'holding_performance')
             ->middleware($resourceAccess)
             ->name('holding-performance.runs.store');
+        Route::get('/holding-performance/options', HoldingPerformanceReportOptionsController::class)
+            ->defaults('reportCode', 'holding_performance')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('holding-performance.options');
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');

--- a/tests/Integration/Reporting/Waves23/HoldingPerformanceOptionsPostgresTest.php
+++ b/tests/Integration/Reporting/Waves23/HoldingPerformanceOptionsPostgresTest.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Reporting\Waves23;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAcceptedWorkEventVersion;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingPaymentTransactionEventVersion;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\AcceptedWorkHoldingFactProducer;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPaymentEventFactProducer;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceImmutableEventSource;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceOptionDimensionQuery;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceOptionsService;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\Models\Contractor;
+use App\Models\Organization;
+use App\Models\Project;
+use Carbon\CarbonImmutable;
+use DateTimeZone;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[Group('postgres')]
+final class HoldingPerformanceOptionsPostgresTest extends TestCase
+{
+    #[Test]
+    public function outermost_options_read_uses_a_valid_read_only_repeatable_read_transaction(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            self::markTestSkipped('PostgreSQL integration only.');
+        }
+
+        self::assertSame(0, DB::transactionLevel());
+        $scope = new ReportScope(
+            799999991,
+            [799999991],
+            [799999992],
+            [],
+            new DateTimeZone('Europe/Moscow'),
+        );
+        $options = $this->app->make(HoldingPerformanceOptionsService::class)->options(
+            $scope,
+            now()->toImmutable(),
+        );
+
+        self::assertFalse($options['available']);
+        self::assertSame(0, DB::transactionLevel());
+    }
+
+    #[Test]
+    public function options_include_late_event_dimensions_and_fail_closed_on_projection_gap(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            self::markTestSkipped('PostgreSQL integration only.');
+        }
+
+        DB::beginTransaction();
+
+        try {
+            $organization = Organization::withoutEvents(
+                static fn (): Organization => Organization::factory()->create(['name' => 'Холдинг для options']),
+            );
+            $project = Project::withoutEvents(
+                static fn (): Project => Project::factory()->for($organization)->create(['name' => 'Поздний проект']),
+            );
+            $contractor = Contractor::withoutEvents(static fn (): Contractor => Contractor::create([
+                'organization_id' => $organization->id,
+                'name' => 'Поздний подрядчик',
+                'contractor_type' => Contractor::TYPE_MANUAL,
+            ]));
+            $contractId = random_int(600000000, 699999999);
+            $allocationId = $contractId + 1;
+            $contextStartedAt = DB::table('holding_reporting_context_coverage')
+                ->whereIn('source_code', [
+                    'contract_dimensions',
+                    'organization_hierarchy',
+                    'allocation_dimensions',
+                    'allocation_amount_dimensions',
+                ])
+                ->max('coverage_started_at');
+            self::assertIsString($contextStartedAt);
+            $checkpointAt = CarbonImmutable::parse($contextStartedAt)
+                ->addSeconds(random_int(1000, 2000))
+                ->setMicrosecond(random_int(1, 999999));
+            DB::table('holding_payment_event_coverage_checkpoints')->insert([
+                'started_at' => $checkpointAt,
+                'source_max_transaction_id' => 0,
+                'source_count' => 0,
+                'captured_count' => 0,
+                'gap_count' => 0,
+                'content_hash' => hash('sha256', ''),
+            ]);
+
+            $timezone = new DateTimeZone('Europe/Moscow');
+            $coverageStartedAt = (new HoldingPerformanceImmutableEventSource)->coverageStartedAt(
+                CarbonImmutable::parse($contextStartedAt),
+                $timezone,
+            );
+            $lateObservedAt = CarbonImmutable::instance($coverageStartedAt)->addHours(2);
+            $recognizedAt = $lateObservedAt->addHour();
+            $asOf = $recognizedAt->addHour();
+            CarbonImmutable::setTestNow($asOf->addDay());
+
+            DB::table('holding_organization_hierarchy_events')->insert([
+                'organization_id' => $organization->id,
+                'parent_organization_id' => null,
+                'is_active' => true,
+                'hierarchy_level' => 0,
+                'hierarchy_path' => (string) $organization->id,
+                'observed_at' => $checkpointAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'options-hierarchy-'.$organization->id),
+            ]);
+            DB::table('holding_contract_dimension_events')->insert([
+                'contract_id' => $contractId,
+                'organization_id' => $organization->id,
+                'contractor_id' => $contractor->id,
+                'counterparty_organization_id' => null,
+                'contract_status' => 'active',
+                'work_type_category' => null,
+                'total_amount' => '1000.00',
+                'currency' => 'RUB',
+                'observed_at' => $lateObservedAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'options-contract-'.$contractId),
+            ]);
+            DB::table('holding_allocation_context_events')->insert([
+                'allocation_id' => $allocationId,
+                'contract_id' => $contractId,
+                'organization_id' => $organization->id,
+                'project_id' => $project->id,
+                'allocation_type' => 'percentage',
+                'allocated_amount' => null,
+                'allocated_percentage' => '100.0000',
+                'is_resolvable' => true,
+                'is_active' => true,
+                'observed_at' => $lateObservedAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'options-allocation-'.$allocationId),
+            ]);
+            DB::table('holding_accepted_work_event_versions')->insert([
+                'event_key' => 'options-late-event-'.str()->uuid(),
+                'performance_act_id' => $contractId + 2,
+                'contract_id' => $contractId,
+                'project_id' => $project->id,
+                'organization_id' => $organization->id,
+                'active' => true,
+                'amount' => '125.50',
+                'status' => 'approved',
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addMinute(),
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'options-late-event-'.$contractId),
+            ]);
+            DB::table('holding_payment_transaction_event_versions')->insert([
+                'transaction_id' => $contractId + 4,
+                'payment_document_id' => $contractId + 5,
+                'organization_id' => $organization->id,
+                'project_id' => $project->id,
+                'contract_id' => $contractId,
+                'document_organization_id' => $organization->id,
+                'document_project_id' => $project->id,
+                'contract_organization_id' => $organization->id,
+                'contract_project_id' => $project->id,
+                'amount' => '75.25',
+                'currency' => 'RUB',
+                'status' => 'completed',
+                'active' => true,
+                'recognized_at' => $recognizedAt,
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addMinutes(3),
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'options-payment-event-'.$contractId),
+            ]);
+
+            $scope = new ReportScope(
+                $organization->id,
+                [$organization->id],
+                [$project->id],
+                [],
+                $timezone,
+            );
+            $period = CarbonImmutable::instance($coverageStartedAt)
+                ->setTimezone($timezone)
+                ->toDateString();
+            $factCount = DB::table('holding_allocation_fact_versions')
+                ->where('organization_id', $organization->id)
+                ->count();
+            $gapCount = DB::table('holding_allocation_projection_gaps')
+                ->where('organization_id', $organization->id)
+                ->count();
+            $service = $this->app->make(HoldingPerformanceOptionsService::class);
+            DB::flushQueryLog();
+            DB::enableQueryLog();
+            $options = $service->options($scope, $asOf->toDateTimeImmutable(), $period, $period);
+            $singleEventQueryCount = count(DB::getQueryLog());
+            DB::disableQueryLog();
+
+            self::assertTrue($options['available']);
+            self::assertSame([['id' => $organization->id, 'name' => 'Холдинг для options']], $options['organizations']);
+            self::assertSame([['id' => $project->id, 'name' => 'Поздний проект']], $options['projects']);
+            self::assertSame([['id' => $contractor->id, 'name' => 'Поздний подрядчик']], $options['contractors']);
+            self::assertSame(['active'], array_column($options['contract_statuses'], 'id'));
+            self::assertSame(['RUB'], array_column($options['currencies'], 'id'));
+            self::assertSame($factCount, DB::table('holding_allocation_fact_versions')
+                ->where('organization_id', $organization->id)
+                ->count());
+            self::assertSame($gapCount, DB::table('holding_allocation_projection_gaps')
+                ->where('organization_id', $organization->id)
+                ->count());
+
+            $additionalEvents = [];
+            foreach (range(1, 24) as $offset) {
+                $additionalEvents[] = [
+                    'event_key' => 'options-scale-event-'.$offset.'-'.str()->uuid(),
+                    'performance_act_id' => $contractId + 10 + $offset,
+                    'contract_id' => $contractId,
+                    'project_id' => $project->id,
+                    'organization_id' => $organization->id,
+                    'active' => true,
+                    'amount' => '1.00',
+                    'status' => 'approved',
+                    'occurred_at' => $recognizedAt,
+                    'recorded_at' => $recognizedAt->addMinutes(10 + $offset),
+                    'history_complete' => true,
+                    'source_hash' => hash('sha256', 'options-scale-event-'.$contractId.'-'.$offset),
+                ];
+            }
+            DB::table('holding_accepted_work_event_versions')->insert($additionalEvents);
+            DB::flushQueryLog();
+            DB::enableQueryLog();
+            $scaledOptions = $service->options($scope, $asOf->toDateTimeImmutable(), $period, $period);
+            $manyEventQueryCount = count(DB::getQueryLog());
+            DB::disableQueryLog();
+
+            self::assertTrue($scaledOptions['available']);
+            self::assertSame($singleEventQueryCount, $manyEventQueryCount);
+
+            $inactiveContractor = Contractor::withoutEvents(static fn (): Contractor => Contractor::create([
+                'organization_id' => $organization->id,
+                'name' => 'Подрядчик неактивной версии',
+                'contractor_type' => Contractor::TYPE_MANUAL,
+            ]));
+            $inactiveContractId = $contractId + 1000;
+            $inactiveAllocationId = $inactiveContractId + 1;
+            DB::table('holding_contract_dimension_events')->insert([
+                'contract_id' => $inactiveContractId,
+                'organization_id' => $organization->id,
+                'contractor_id' => $inactiveContractor->id,
+                'counterparty_organization_id' => null,
+                'contract_status' => 'completed',
+                'work_type_category' => null,
+                'total_amount' => '500.00',
+                'currency' => 'USD',
+                'observed_at' => $lateObservedAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'inactive-contract-'.$inactiveContractId),
+            ]);
+            DB::table('holding_allocation_context_events')->insert([
+                'allocation_id' => $inactiveAllocationId,
+                'contract_id' => $inactiveContractId,
+                'organization_id' => $organization->id,
+                'project_id' => $project->id,
+                'allocation_type' => 'percentage',
+                'allocated_amount' => null,
+                'allocated_percentage' => '100.0000',
+                'is_resolvable' => true,
+                'is_active' => true,
+                'observed_at' => $lateObservedAt,
+                'is_deleted' => false,
+                'evidence_hash' => hash('sha256', 'inactive-allocation-'.$inactiveAllocationId),
+            ]);
+
+            $tieRecordedAt = $recognizedAt->addMinutes(40);
+            $inactiveActId = $inactiveContractId + 2;
+            $activeActVersionId = DB::table('holding_accepted_work_event_versions')->insertGetId([
+                'event_key' => 'options-active-tie-'.str()->uuid(),
+                'performance_act_id' => $inactiveActId,
+                'contract_id' => $inactiveContractId,
+                'project_id' => $project->id,
+                'organization_id' => $organization->id,
+                'active' => true,
+                'amount' => '50.00',
+                'status' => 'approved',
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $tieRecordedAt,
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'options-active-tie-'.$inactiveActId),
+            ]);
+            $inactiveActVersionId = DB::table('holding_accepted_work_event_versions')->insertGetId([
+                'event_key' => 'options-inactive-tie-'.str()->uuid(),
+                'performance_act_id' => $inactiveActId,
+                'contract_id' => $inactiveContractId,
+                'project_id' => $project->id,
+                'organization_id' => $organization->id,
+                'active' => false,
+                'amount' => '50.00',
+                'status' => 'approved',
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $tieRecordedAt,
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'options-inactive-tie-'.$inactiveActId),
+            ]);
+
+            $inactiveTransactionId = $inactiveContractId + 3;
+            $activePaymentVersionId = DB::table('holding_payment_transaction_event_versions')->insertGetId([
+                'transaction_id' => $inactiveTransactionId,
+                'payment_document_id' => $inactiveContractId + 4,
+                'organization_id' => $organization->id,
+                'project_id' => $project->id,
+                'contract_id' => $inactiveContractId,
+                'document_organization_id' => $organization->id,
+                'document_project_id' => $project->id,
+                'contract_organization_id' => $organization->id,
+                'contract_project_id' => $project->id,
+                'amount' => '20.00',
+                'currency' => 'USD',
+                'status' => 'completed',
+                'active' => true,
+                'recognized_at' => $recognizedAt,
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $tieRecordedAt,
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'options-active-payment-tie-'.$inactiveTransactionId),
+            ]);
+            $inactivePaymentVersionId = DB::table('holding_payment_transaction_event_versions')->insertGetId([
+                'transaction_id' => $inactiveTransactionId,
+                'payment_document_id' => $inactiveContractId + 4,
+                'organization_id' => $organization->id,
+                'project_id' => $project->id,
+                'contract_id' => $inactiveContractId,
+                'document_organization_id' => $organization->id,
+                'document_project_id' => $project->id,
+                'contract_organization_id' => $organization->id,
+                'contract_project_id' => $project->id,
+                'amount' => '20.00',
+                'currency' => 'USD',
+                'status' => 'completed',
+                'active' => false,
+                'recognized_at' => $recognizedAt,
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $tieRecordedAt,
+                'history_complete' => true,
+                'source_hash' => hash('sha256', 'options-inactive-payment-tie-'.$inactiveTransactionId),
+            ]);
+
+            self::assertGreaterThan($activeActVersionId, $inactiveActVersionId);
+            self::assertGreaterThan($activePaymentVersionId, $inactivePaymentVersionId);
+            $recordedCutoff = now()->toImmutable();
+            $events = $this->app->make(HoldingPerformanceImmutableEventSource::class);
+            $acceptedLatest = $events->acceptedWorkVersions(
+                [$organization->id],
+                [$project->id],
+                $coverageStartedAt,
+                $asOf,
+                $recordedCutoff,
+            )->first(static fn (mixed $event): bool => $event instanceof HoldingAcceptedWorkEventVersion
+                && (int) $event->performance_act_id === $inactiveActId);
+            $paymentLatest = $events->paymentVersions(
+                [$organization->id],
+                [$project->id],
+                $coverageStartedAt,
+                $asOf,
+                $recordedCutoff,
+            )->first(static fn (mixed $event): bool => $event instanceof HoldingPaymentTransactionEventVersion
+                && (int) $event->transaction_id === $inactiveTransactionId);
+
+            self::assertInstanceOf(HoldingAcceptedWorkEventVersion::class, $acceptedLatest);
+            self::assertSame($inactiveActVersionId, (int) $acceptedLatest->getKey());
+            self::assertFalse((bool) $acceptedLatest->active);
+            $acceptedProducer = $this->app->make(AcceptedWorkHoldingFactProducer::class);
+            self::assertTrue($acceptedProducer->canProjectEvent($acceptedLatest, $organization->id));
+            self::assertNull($acceptedProducer->previewEvent($acceptedLatest));
+
+            self::assertInstanceOf(HoldingPaymentTransactionEventVersion::class, $paymentLatest);
+            self::assertSame($inactivePaymentVersionId, (int) $paymentLatest->getKey());
+            self::assertFalse((bool) $paymentLatest->active);
+            $paymentProducer = $this->app->make(HoldingPaymentEventFactProducer::class);
+            self::assertTrue($paymentProducer->canProject($paymentLatest, $organization->id));
+            self::assertNull($paymentProducer->previewEvent($paymentLatest));
+
+            $batchDimensions = $this->app->make(HoldingPerformanceOptionDimensionQuery::class)->resolve(
+                $organization->id,
+                [$organization->id],
+                [$project->id],
+                $coverageStartedAt,
+                $asOf,
+                $recordedCutoff,
+            );
+            self::assertTrue($batchDimensions['complete']);
+            self::assertContains(
+                $contractor->id,
+                array_column($batchDimensions['dimensions'], 'contractor_id'),
+            );
+            self::assertContains('active', array_column($batchDimensions['dimensions'], 'contract_status'));
+            self::assertContains('RUB', array_column($batchDimensions['dimensions'], 'currency'));
+            self::assertNotContains(
+                $inactiveContractor->id,
+                array_column($batchDimensions['dimensions'], 'contractor_id'),
+            );
+            self::assertNotContains(
+                'completed',
+                array_column($batchDimensions['dimensions'], 'contract_status'),
+            );
+            self::assertNotContains('USD', array_column($batchDimensions['dimensions'], 'currency'));
+
+            DB::table('holding_accepted_work_event_versions')->insert([
+                'event_key' => 'options-gap-event-'.str()->uuid(),
+                'performance_act_id' => $contractId + 3,
+                'contract_id' => $contractId,
+                'project_id' => $project->id,
+                'organization_id' => $organization->id,
+                'active' => true,
+                'amount' => '10.00',
+                'status' => 'approved',
+                'occurred_at' => $recognizedAt,
+                'recorded_at' => $recognizedAt->addMinutes(2),
+                'history_complete' => false,
+                'source_hash' => hash('sha256', 'options-gap-event-'.$contractId),
+            ]);
+            $unavailable = $service->options($scope, $asOf->toDateTimeImmutable(), $period, $period);
+
+            self::assertFalse($unavailable['available']);
+            self::assertSame('source_incomplete', $unavailable['reason']);
+            self::assertSame([], $unavailable['organizations']);
+            self::assertSame($factCount, DB::table('holding_allocation_fact_versions')
+                ->where('organization_id', $organization->id)
+                ->count());
+            self::assertSame($gapCount, DB::table('holding_allocation_projection_gaps')
+                ->where('organization_id', $organization->id)
+                ->count());
+        } finally {
+            CarbonImmutable::setTestNow();
+            DB::rollBack();
+        }
+    }
+}

--- a/tests/Unit/Reporting/HoldingPerformanceOptionsContractTest.php
+++ b/tests/Unit/Reporting/HoldingPerformanceOptionsContractTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceOptionsService;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceOptionDimensionQuery;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\HoldingPerformanceReportOptionsRequest;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use Illuminate\Support\Facades\Validator;
+use ReflectionClass;
+use Tests\TestCase;
+
+final class HoldingPerformanceOptionsContractTest extends TestCase
+{
+    public function test_routes_use_the_dedicated_holding_contract_and_server_scope(): void
+    {
+        $routes = file_get_contents(base_path('app/BusinessModules/Core/Reporting/routes.php'));
+        $middleware = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php',
+        ));
+
+        self::assertIsString($routes);
+        self::assertStringContainsString("Route::get('/holding-performance/options'", $routes);
+        self::assertStringContainsString("->defaults('reportCode', 'holding_performance')", $routes);
+        self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
+        self::assertIsString($middleware);
+        self::assertStringContainsString("'admin.reports.holding-performance.options'", $middleware);
+    }
+
+    public function test_options_use_the_runtime_opening_checkpoint_and_only_server_scope_references(): void
+    {
+        $source = file_get_contents((new ReflectionClass(HoldingPerformanceOptionsService::class))->getFileName());
+        $dimensionQuery = file_get_contents(
+            (new ReflectionClass(HoldingPerformanceOptionDimensionQuery::class))->getFileName(),
+        );
+        $controller = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Controllers/HoldingPerformanceReportOptionsController.php',
+        ));
+
+        self::assertIsString($source);
+        self::assertStringContainsString('$this->events->coverageStartedAt(', $source);
+        self::assertStringContainsString('$this->connection->transactionLevel() > 0', $source);
+        self::assertStringContainsString('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY', $source);
+        self::assertStringContainsString('$this->optionsWithinStableView(', $source);
+        self::assertStringContainsString('$this->events->assertPeriodCovered(', $source);
+        self::assertStringContainsString('$this->sources->openingBoundary($query)', $source);
+        self::assertStringContainsString(
+            '$this->sources->assembleOpeningState($scope, $query, $openingBoundary)',
+            $source,
+        );
+        self::assertStringContainsString('$batch->hierarchy->organizationIds', $source);
+        self::assertStringContainsString('$scope->projectIds', $source);
+        self::assertStringContainsString('$this->optionDimensions->resolve(', $source);
+        self::assertStringContainsString("! \$eventDimensions['complete']", $source);
+        self::assertStringContainsString('$this->eventFallsWithinPeriod(', $source);
+        self::assertStringNotContainsString('->persist(', $source);
+        self::assertStringNotContainsString('->recordGap(', $source);
+        self::assertStringNotContainsString('->synchronize(', $source);
+        self::assertStringContainsString("->table('contractors')", $source);
+        self::assertStringContainsString("->whereIn('organization_id', \$organizationIds)", $source);
+        self::assertStringContainsString('ContractStatusEnum::tryFrom($code)', $source);
+        self::assertStringContainsString('CurrencyCode::options()', $source);
+        self::assertStringNotContainsString("input('organization_id')", $source);
+        self::assertStringNotContainsString("input('project_id')", $source);
+
+        self::assertIsString($dimensionQuery);
+        self::assertStringContainsString("->leftJoinLateral(\$hierarchy, 'event_hierarchy')", $dimensionQuery);
+        self::assertStringContainsString("->leftJoinLateral(\$hierarchyState, 'hierarchy_state')", $dimensionQuery);
+        self::assertStringContainsString("->leftJoinLateral(\$dimension, 'event_dimension')", $dimensionQuery);
+        self::assertStringContainsString("->leftJoinLateral(\$allocation, 'event_allocation')", $dimensionQuery);
+        self::assertStringContainsString('holding_accepted_work_event_versions as ', $dimensionQuery);
+        self::assertStringContainsString('holding_payment_transaction_event_versions as ', $dimensionQuery);
+
+        self::assertIsString($controller);
+        self::assertStringContainsString(
+            '->createRun($request, HoldingPerformanceCandidateContract::CODE)',
+            $controller,
+        );
+        self::assertStringContainsString('$context->scope', $controller);
+        self::assertStringNotContainsString("input('organization_id')", $controller);
+        self::assertStringNotContainsString("input('project_id')", $controller);
+    }
+
+    public function test_options_reject_client_context_and_accept_only_exact_business_dates(): void
+    {
+        $request = new HoldingPerformanceReportOptionsRequest;
+        $rules = $request->rules();
+
+        foreach ([
+            'organization_id',
+            'current_organization_id',
+            'holding_organization_ids',
+            'organization_ids',
+            'project_id',
+            'current_project_id',
+            'project_ids',
+            'user_id',
+            'actor_id',
+            'scope',
+            'permissions',
+        ] as $field) {
+            self::assertContains('prohibited', $rules[$field]);
+        }
+        self::assertSame(['required', 'string'], array_slice($rules['as_of'], 0, 2));
+        self::assertSame(['nullable', 'string', 'date_format:Y-m-d'], $rules['period_from']);
+        self::assertSame(
+            ['nullable', 'string', 'date_format:Y-m-d'],
+            array_slice($rules['period_to'], 0, 3),
+        );
+        self::assertNotNull(ReportAsOfParser::parse('2026-08-05T14:15:16.123456+03:00'));
+        self::assertNull(ReportAsOfParser::parse('2026-08-05'));
+    }
+
+    public function test_validator_rejects_every_client_owned_context_field(): void
+    {
+        $request = new HoldingPerformanceReportOptionsRequest;
+        $payload = [
+            'as_of' => '2026-08-05T14:15:16.123456+03:00',
+            'organization_id' => 38,
+            'current_organization_id' => 38,
+            'holding_organization_ids' => [38],
+            'organization_ids' => [38],
+            'project_id' => 91,
+            'current_project_id' => 91,
+            'project_ids' => [91],
+            'user_id' => 17,
+            'actor_id' => 17,
+            'scope' => ['organization_id' => 38],
+            'permissions' => ['multi-organization.reports.kpi'],
+        ];
+        $validator = Validator::make($payload, $request->rules());
+
+        self::assertTrue($validator->fails());
+        foreach (array_keys($payload) as $field) {
+            if ($field !== 'as_of') {
+                self::assertArrayHasKey($field, $validator->errors()->toArray());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Что изменено
- добавлен отдельный server-scoped endpoint параметров R02 holding_performance
- organization/project/user/scope берутся только из authorization context; клиентская подмена запрещена
- параметры строятся из opening state и immutable accepted/payment history
- point-in-time dimensions читаются двумя bounded PostgreSQL lateral queries без N+1
- добавлены read-only repeatable-read transaction, состояния unavailable и реальные русские labels
- добавлены PostgreSQL regressions для late dimensions, query-count, active→inactive и tie-break (recorded_at, id)

## Проверки
- php -l: 9/9 изменённых PHP-файлов
- git diff --cached --check
- независимое review: CLEAN
- PHPUnit/PHPStan локально недоступны: vendor/autoload.php и vendor/bin отсутствуют; ожидаются в CI

Runtime/formula fingerprint R02 не менялся: релиз содержит только options/API и тесты.