### PR TITLE
fix: исправлен checkpoint платежей отчёта холдинга

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
@@ -44,7 +44,7 @@ final readonly class HoldingPerformanceCandidateContract
     public const FORMULA_VERSION = 'holding_performance.v1';
     public const SOURCE_SCHEMA_VERSION = 'holding_allocation_facts.v2';
     public const FORMULA_HASH = '59c4e2d23349656ae8948679fcea4dc59da5be20792b865afb17da2b9a667f20';
-    public const SOURCE_HASH = 'b93427f0607561fc20896e566b21a209d8b7a5cfbf04afae84500fee66f5f22c';
+    public const SOURCE_HASH = '95144d292c56689d11ea6cf18c72d3abb2982a99e9a5981763bf94a61234b4ac';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceImmutableEventSource.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceImmutableEventSource.php
@@ -208,8 +208,9 @@ final readonly class HoldingPerformanceImmutableEventSource
             return false;
         }
 
+        $startedAt = $checkpoint->started_at->format('Y-m-d H:i:s.uP');
         $evidence = HoldingPaymentTransactionEventVersion::query()
-            ->where('recorded_at', $checkpoint->started_at)
+            ->where('recorded_at', $startedAt)
             ->selectRaw('COUNT(*) AS source_count')
             ->selectRaw('COUNT(*) FILTER (WHERE history_complete) AS captured_count')
             ->selectRaw('COUNT(*) FILTER (WHERE NOT history_complete) AS gap_count')

--- a/database/migrations/2026_08_05_035000_repair_holding_payment_checkpoint_precision.php
+++ b/database/migrations/2026_08_05_035000_repair_holding_payment_checkpoint_precision.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(
+            'LOCK TABLE contracts, payment_documents, payment_transactions IN SHARE ROW EXCLUSIVE MODE',
+        );
+        DB::statement(
+            'ALTER TABLE holding_payment_event_coverage_checkpoints '
+            .'ALTER COLUMN started_at TYPE timestamptz(6) USING started_at::timestamptz(6)',
+        );
+        DB::statement(
+            'ALTER TABLE holding_payment_transaction_event_versions '
+            .'ALTER COLUMN recognized_at TYPE timestamptz(6) USING recognized_at::timestamptz(6), '
+            .'ALTER COLUMN occurred_at TYPE timestamptz(6) USING occurred_at::timestamptz(6), '
+            .'ALTER COLUMN recorded_at TYPE timestamptz(6) USING recorded_at::timestamptz(6)',
+        );
+
+        DB::unprepared(<<<'SQL'
+DO $$
+DECLARE
+    checkpoint_at timestamptz(6) := clock_timestamp()::timestamptz(6);
+    captured_source_count bigint;
+    checkpoint_event_count bigint;
+BEGIN
+    INSERT INTO holding_payment_transaction_event_versions (
+        transaction_id,
+        payment_document_id,
+        organization_id,
+        project_id,
+        contract_id,
+        document_organization_id,
+        document_project_id,
+        contract_organization_id,
+        contract_project_id,
+        amount,
+        currency,
+        status,
+        active,
+        recognized_at,
+        occurred_at,
+        recorded_at,
+        history_complete,
+        source_hash
+    )
+    SELECT
+        source.transaction_id,
+        source.payment_document_id,
+        source.organization_id,
+        source.project_id,
+        source.contract_id,
+        source.document_organization_id,
+        source.document_project_id,
+        source.contract_organization_id,
+        source.contract_project_id,
+        source.amount,
+        source.currency,
+        source.status,
+        true,
+        source.recognized_at,
+        checkpoint_at,
+        checkpoint_at,
+        source.history_complete,
+        encode(sha256(convert_to(jsonb_build_object(
+            'transaction_id', source.transaction_id,
+            'payment_document_id', source.payment_document_id,
+            'organization_id', source.organization_id,
+            'project_id', source.project_id,
+            'contract_id', source.contract_id,
+            'document_organization_id', source.document_organization_id,
+            'document_project_id', source.document_project_id,
+            'contract_organization_id', source.contract_organization_id,
+            'contract_project_id', source.contract_project_id,
+            'amount', source.amount,
+            'currency', source.currency,
+            'status', source.status,
+            'active', true,
+            'recognized_at', source.recognized_at,
+            'occurred_at', checkpoint_at,
+            'history_complete', source.history_complete
+        )::text, 'UTF8')), 'hex')
+    FROM (
+        SELECT
+            transaction_row.id AS transaction_id,
+            transaction_row.payment_document_id,
+            transaction_row.organization_id,
+            transaction_row.project_id,
+            document_row.invoiceable_id AS contract_id,
+            document_row.organization_id AS document_organization_id,
+            document_row.project_id AS document_project_id,
+            contract_row.organization_id AS contract_organization_id,
+            contract_row.project_id AS contract_project_id,
+            transaction_row.amount,
+            NULLIF(upper(btrim(transaction_row.currency)), '') AS currency,
+            transaction_row.status,
+            CASE
+                WHEN COALESCE(
+                    transaction_row.value_date,
+                    transaction_row.transaction_date,
+                    transaction_row.created_at::date
+                ) IS NULL THEN NULL
+                ELSE timezone('UTC', COALESCE(
+                    transaction_row.value_date,
+                    transaction_row.transaction_date,
+                    transaction_row.created_at::date
+                )::timestamp)
+            END AS recognized_at,
+            transaction_row.project_id IS NOT NULL
+                AND document_row.invoiceable_id IS NOT NULL
+                AND document_row.organization_id IS NOT NULL
+                AND document_row.project_id IS NOT NULL
+                AND contract_row.organization_id IS NOT NULL
+                AND contract_row.project_id IS NOT NULL
+                AND transaction_row.organization_id = document_row.organization_id
+                AND transaction_row.organization_id = contract_row.organization_id
+                AND transaction_row.project_id = document_row.project_id
+                AND transaction_row.project_id = contract_row.project_id
+                AND transaction_row.amount IS NOT NULL
+                AND NULLIF(upper(btrim(transaction_row.currency)), '') IS NOT NULL
+                AND char_length(NULLIF(upper(btrim(transaction_row.currency)), '')) = 3
+                AND COALESCE(
+                    transaction_row.value_date,
+                    transaction_row.transaction_date,
+                    transaction_row.created_at::date
+                ) IS NOT NULL AS history_complete
+        FROM payment_transactions AS transaction_row
+        INNER JOIN payment_documents AS document_row
+            ON document_row.id = transaction_row.payment_document_id
+        LEFT JOIN contracts AS contract_row
+            ON contract_row.id = document_row.invoiceable_id
+        WHERE transaction_row.status IN ('completed', 'refunded')
+          AND document_row.invoiceable_type = 'App\Models\Contract'
+    ) AS source;
+
+    GET DIAGNOSTICS captured_source_count = ROW_COUNT;
+
+    SELECT COUNT(*)
+    INTO checkpoint_event_count
+    FROM holding_payment_transaction_event_versions
+    WHERE recorded_at = checkpoint_at;
+
+    IF checkpoint_event_count <> captured_source_count THEN
+        RAISE EXCEPTION 'holding payment checkpoint precision mismatch';
+    END IF;
+
+    INSERT INTO holding_payment_event_coverage_checkpoints (
+        started_at,
+        source_max_transaction_id,
+        source_count,
+        captured_count,
+        gap_count,
+        content_hash
+    )
+    SELECT
+        checkpoint_at,
+        COALESCE(MAX(transaction_id), 0),
+        COUNT(*),
+        COUNT(*) FILTER (WHERE history_complete),
+        COUNT(*) FILTER (WHERE NOT history_complete),
+        encode(sha256(convert_to(COALESCE(
+            string_agg(source_hash, '|' ORDER BY transaction_id, id),
+            ''
+        ), 'UTF8')), 'hex')
+    FROM holding_payment_transaction_event_versions
+    WHERE recorded_at = checkpoint_at;
+END
+$$
+SQL);
+    }
+
+    public function down(): void
+    {
+        throw new \RuntimeException(
+            'Holding payment checkpoint precision repair is irreversible because its evidence is append-only.',
+        );
+    }
+};

--- a/tests/Integration/Reporting/Waves23/HoldingPaymentCheckpointPrecisionPostgresTest.php
+++ b/tests/Integration/Reporting/Waves23/HoldingPaymentCheckpointPrecisionPostgresTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Reporting\Waves23;
+
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceImmutableEventSource;
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[Group('postgres')]
+final class HoldingPaymentCheckpointPrecisionPostgresTest extends TestCase
+{
+    #[Test]
+    public function runtime_checkpoint_validation_preserves_microsecond_binding(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            self::markTestSkipped('PostgreSQL integration only.');
+        }
+
+        DB::beginTransaction();
+
+        try {
+            $transactionId = random_int(800_000_000, 899_999_999);
+            $startedAt = '2026-08-05 10:00:00.654321+00';
+            $sourceHash = hash('sha256', 'microsecond-checkpoint-event');
+            DB::table('holding_payment_transaction_event_versions')->insert([
+                'transaction_id' => $transactionId,
+                'payment_document_id' => $transactionId + 1,
+                'organization_id' => $transactionId + 2,
+                'project_id' => $transactionId + 3,
+                'contract_id' => $transactionId + 4,
+                'document_organization_id' => $transactionId + 2,
+                'document_project_id' => $transactionId + 3,
+                'contract_organization_id' => $transactionId + 2,
+                'contract_project_id' => $transactionId + 3,
+                'amount' => '10.00',
+                'currency' => 'RUB',
+                'status' => 'completed',
+                'active' => true,
+                'recognized_at' => '2026-08-05 00:00:00+00',
+                'occurred_at' => $startedAt,
+                'recorded_at' => $startedAt,
+                'history_complete' => true,
+                'source_hash' => $sourceHash,
+            ]);
+            DB::table('holding_payment_event_coverage_checkpoints')->insert([
+                'started_at' => $startedAt,
+                'source_max_transaction_id' => $transactionId,
+                'source_count' => 1,
+                'captured_count' => 1,
+                'gap_count' => 0,
+                'content_hash' => hash('sha256', $sourceHash),
+            ]);
+
+            $coverageStartedAt = (new HoldingPerformanceImmutableEventSource)->coverageStartedAt(
+                new DateTimeImmutable('2026-08-05 00:00:00+00'),
+                new DateTimeZone('UTC'),
+            );
+
+            self::assertSame(
+                '2026-08-06 00:00:00.000000+00:00',
+                $coverageStartedAt->format('Y-m-d H:i:s.uP'),
+            );
+        } finally {
+            DB::rollBack();
+        }
+    }
+
+    #[Test]
+    public function checkpoint_and_event_capture_preserve_distinct_microseconds(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            self::markTestSkipped('PostgreSQL integration only.');
+        }
+
+        DB::beginTransaction();
+
+        try {
+            $transactionId = random_int(700_000_000, 799_999_999);
+            $recordedAt = [
+                '2026-08-05 10:00:00.123456+00',
+                '2026-08-05 10:00:00.123457+00',
+            ];
+
+            foreach ($recordedAt as $index => $timestamp) {
+                DB::table('holding_payment_transaction_event_versions')->insert([
+                    'transaction_id' => $transactionId,
+                    'payment_document_id' => $transactionId + 1,
+                    'organization_id' => $transactionId + 2,
+                    'project_id' => $transactionId + 3,
+                    'contract_id' => $transactionId + 4,
+                    'document_organization_id' => $transactionId + 2,
+                    'document_project_id' => $transactionId + 3,
+                    'contract_organization_id' => $transactionId + 2,
+                    'contract_project_id' => $transactionId + 3,
+                    'amount' => '10.00',
+                    'currency' => 'RUB',
+                    'status' => 'completed',
+                    'active' => $index === 0,
+                    'recognized_at' => '2026-08-05 00:00:00+00',
+                    'occurred_at' => $timestamp,
+                    'recorded_at' => $timestamp,
+                    'history_complete' => true,
+                    'source_hash' => hash('sha256', 'precision-event-'.$index),
+                ]);
+            }
+
+            $storedEvents = DB::table('holding_payment_transaction_event_versions')
+                ->where('transaction_id', $transactionId)
+                ->orderBy('id')
+                ->pluck('recorded_at')
+                ->map(static fn (mixed $value): string => (new DateTimeImmutable((string) $value))
+                    ->setTimezone(new DateTimeZone('UTC'))
+                    ->format('Y-m-d H:i:s.uP'))
+                ->all();
+
+            self::assertSame([
+                '2026-08-05 10:00:00.123456+00:00',
+                '2026-08-05 10:00:00.123457+00:00',
+            ], $storedEvents);
+
+            DB::table('holding_payment_event_coverage_checkpoints')->insert([
+                'started_at' => '2026-08-05 10:00:00.123458+00',
+                'source_max_transaction_id' => $transactionId,
+                'source_count' => 0,
+                'captured_count' => 0,
+                'gap_count' => 0,
+                'content_hash' => hash('sha256', ''),
+            ]);
+            $storedCheckpoint = DB::table('holding_payment_event_coverage_checkpoints')
+                ->latest('id')
+                ->value('started_at');
+
+            self::assertSame(
+                '2026-08-05 10:00:00.123458+00:00',
+                (new DateTimeImmutable((string) $storedCheckpoint))
+                    ->setTimezone(new DateTimeZone('UTC'))
+                    ->format('Y-m-d H:i:s.uP'),
+            );
+        } finally {
+            DB::rollBack();
+        }
+    }
+}


### PR DESCRIPTION
Root cause: timestamp-колонки evidence/checkpoint имели точность до секунды, а первичный checkpoint сравнивался с clock_timestamp с микросекундами и фиксировал 0 строк. Исправление повышает точность до timestamptz(6), атомарно дописывает честный append-only checkpoint из текущих payment sources и fail-closed проверяет число захваченных строк. Runtime validator передаёт точный timestamp строкой с микросекундами, fingerprint R02 обновлён. Добавлены PostgreSQL-регрессии round-trip и runtime validation. Локально: php -l 4 файлов и git diff --check успешно; PHPUnit/PHPStan недоступны, потому что vendor отсутствует. Independent review: CLEAN.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Increased timestamp precision to 6 decimal places for holding payment event tables in PostgreSQL.</li>
<li>Added a database migration to alter column types to timestamptz(6) for improved precision.</li>
<li>Updated HoldingPerformanceImmutableEventSource to format timestamps with microsecond precision when querying events.</li>
<li>Added an integration test to verify PostgreSQL timestamp precision handling.</li>
<li>Updated SOURCE_HASH in HoldingPerformanceCandidateContract.</li>
</ul></div>