### PR TITLE
refactor[backend]: создан единый шлюз файлового хранилища

### DIFF
--- a/app/Services/Storage/DTO/CurrentStoredFile.php
+++ b/app/Services/Storage/DTO/CurrentStoredFile.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage\DTO;
+
+use InvalidArgumentException;
+
+final readonly class CurrentStoredFile
+{
+    public function __construct(
+        public string $key,
+        public string $etag,
+        public int $sizeBytes,
+        public string $sha256,
+        public string $mime,
+    ) {
+        if (
+            preg_match('#^org-[1-9][0-9]*/[^\\\\\x00-\x1F\x7F]+$#D', $key) !== 1
+            || strlen($key) > 1024
+            || str_contains($key, '://')
+            || preg_match('#(?:^|/)\.\.(?:/|$)#', $key) === 1
+            || ! self::isSafeString($etag)
+            || $sizeBytes < 1
+            || preg_match('/^[a-f0-9]{64}$/', $sha256) !== 1
+            || ! self::isSafeString($mime)
+        ) {
+            throw new InvalidArgumentException('stored_file_identity_invalid');
+        }
+    }
+
+    private static function isSafeString(string $value): bool
+    {
+        return $value !== ''
+            && strlen($value) <= 255
+            && preg_match('/[\x00-\x1F\x7F]/', $value) !== 1;
+    }
+}

--- a/app/Services/Storage/FileService.php
+++ b/app/Services/Storage/FileService.php
@@ -5,6 +5,7 @@ namespace App\Services\Storage;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\Models\Organization;
 use App\Services\Logging\LoggingService;
+use App\Services\Storage\DTO\CurrentStoredFile;
 use App\Services\Storage\DTO\MultipartPart;
 use App\Services\Storage\DTO\MultipartUpload;
 use App\Services\Storage\DTO\StoredFile;
@@ -42,6 +43,8 @@ class FileService
 
     private const S3_REQUEST_TIMEOUT_SECONDS = 60.0;
 
+    private const MAX_TEMPORARY_URL_TTL_SECONDS = 3600;
+
     protected LoggingService $logging;
 
     public function __construct(LoggingService $logging)
@@ -56,6 +59,72 @@ class FileService
     {
         // Используем единый общий S3 бакет для всех организаций
         return Storage::disk('s3');
+    }
+
+    public function putPrivate(
+        string $key,
+        mixed $contents,
+        string $mime,
+        string $sha256,
+    ): CurrentStoredFile {
+        $this->assertOrganizationPath($key);
+        $this->assertSafeStorageString($mime, 255, 'storage_object_invalid');
+        if (preg_match('/^[a-f0-9]{64}$/', $sha256) !== 1) {
+            throw new \InvalidArgumentException('storage_object_checksum_invalid');
+        }
+        [$sizeBytes, $calculatedChecksum] = $this->describeCurrentContents($contents);
+        if (! hash_equals($sha256, $calculatedChecksum)) {
+            throw new \InvalidArgumentException('storage_object_checksum_mismatch');
+        }
+
+        $result = $this->s3Client()->putObject([
+            'Bucket' => $this->reportBucket(),
+            'Key' => $key,
+            'Body' => $contents,
+            'ACL' => 'private',
+            'ContentType' => $mime,
+            'Metadata' => ['sha256' => $sha256],
+            'IfNoneMatch' => '*',
+            '@http' => $this->s3HttpOptions(),
+        ]);
+        $etag = is_string($result['ETag'] ?? null)
+            ? trim($result['ETag'], " \t\n\r\0\x0B\"")
+            : '';
+        if ($etag === '') {
+            throw new \RuntimeException('s3_object_identity_invalid');
+        }
+
+        return new CurrentStoredFile($key, $etag, $sizeBytes, $sha256, $mime);
+    }
+
+    public function temporaryDownloadUrl(string $key, int $ttlSeconds): string
+    {
+        $this->assertOrganizationPath($key);
+        if ($ttlSeconds < 1 || $ttlSeconds > self::MAX_TEMPORARY_URL_TTL_SECONDS) {
+            throw new \InvalidArgumentException('storage_temporary_url_ttl_invalid');
+        }
+
+        $url = $this->disk()->temporaryUrl(
+            $key,
+            new DateTimeImmutable("+{$ttlSeconds} seconds"),
+        );
+        if (
+            ! is_string($url)
+            || filter_var($url, FILTER_VALIDATE_URL) === false
+            || parse_url($url, PHP_URL_SCHEME) !== 'https'
+        ) {
+            throw new \RuntimeException('storage_temporary_url_invalid');
+        }
+
+        return $url;
+    }
+
+    public function deleteCurrent(string $key): void
+    {
+        $this->assertOrganizationPath($key);
+        if ($this->disk()->delete($key) !== true) {
+            throw new \RuntimeException('storage_object_delete_failed');
+        }
     }
 
     public function startMultipart(
@@ -607,6 +676,44 @@ class FileService
         }
 
         return (int) $matches[1];
+    }
+
+    /** @return array{0: int, 1: string} */
+    private function describeCurrentContents(mixed $contents): array
+    {
+        if (is_string($contents)) {
+            if ($contents === '') {
+                throw new \InvalidArgumentException('storage_object_empty');
+            }
+
+            return [strlen($contents), hash('sha256', $contents)];
+        }
+
+        if (! is_resource($contents) || get_resource_type($contents) !== 'stream') {
+            throw new \InvalidArgumentException('storage_object_contents_invalid');
+        }
+
+        $metadata = stream_get_meta_data($contents);
+        $position = ftell($contents);
+        if (($metadata['seekable'] ?? false) !== true || $position === false) {
+            throw new \InvalidArgumentException('storage_object_contents_invalid');
+        }
+
+        $hash = hash_init('sha256');
+        $sizeBytes = 0;
+        while (! feof($contents)) {
+            $chunk = fread($contents, 1024 * 1024);
+            if ($chunk === false) {
+                throw new \InvalidArgumentException('storage_object_contents_invalid');
+            }
+            $sizeBytes += strlen($chunk);
+            hash_update($hash, $chunk);
+        }
+        if (fseek($contents, $position) !== 0 || $sizeBytes < 1) {
+            throw new \InvalidArgumentException('storage_object_contents_invalid');
+        }
+
+        return [$sizeBytes, hash_final($hash)];
     }
 
     private function assertSafeStorageString(string $value, int $maxLength, string $error): void

--- a/app/Services/Storage/OrganizationStoragePath.php
+++ b/app/Services/Storage/OrganizationStoragePath.php
@@ -6,6 +6,60 @@ namespace App\Services\Storage;
 
 final class OrganizationStoragePath
 {
+    private const DOMAINS = [
+        'acts',
+        'design-models',
+        'estimates',
+        'legal-archive',
+        'quality-control',
+        'reports',
+        'temporary',
+    ];
+
+    public static function forDomain(
+        int $organizationId,
+        string $domain,
+        string $scope,
+        string $objectId,
+        string $extension,
+    ): string {
+        if (
+            $organizationId < 1
+            || ! in_array($domain, self::DOMAINS, true)
+            || ! self::isValidScope($scope)
+            || ! self::isValidSegment($objectId)
+            || preg_match('/^[a-z0-9]{1,16}$/', $extension) !== 1
+        ) {
+            throw new \InvalidArgumentException('organization_storage_path_invalid');
+        }
+
+        return self::build($organizationId, $domain, $scope, $objectId, $extension);
+    }
+
+    public static function personal(
+        int $organizationId,
+        int $userId,
+        string $objectId,
+        string $extension,
+    ): string {
+        if (
+            $organizationId < 1
+            || $userId < 1
+            || ! self::isValidSegment($objectId)
+            || preg_match('/^[a-z0-9]{1,16}$/', $extension) !== 1
+        ) {
+            throw new \InvalidArgumentException('organization_storage_path_invalid');
+        }
+
+        return self::build(
+            $organizationId,
+            'personal-files',
+            "user-{$userId}",
+            $objectId,
+            $extension,
+        );
+    }
+
     public static function forOrganization(int|string $organizationId, string $path): string
     {
         $organizationPrefix = self::organizationPrefix($organizationId);
@@ -49,7 +103,7 @@ final class OrganizationStoragePath
 
     public static function legacyReportsDirectory(int|string $organizationId): string
     {
-        return 'reports/' . (string) $organizationId;
+        return 'reports/'.(string) $organizationId;
     }
 
     public static function displayPath(int|string|null $organizationId, string $path): string
@@ -77,11 +131,46 @@ final class OrganizationStoragePath
 
     private static function organizationPrefix(int|string $organizationId): string
     {
-        return 'org-' . (string) $organizationId;
+        return 'org-'.(string) $organizationId;
     }
 
     private static function normalizeSeparators(string $path): string
     {
         return trim(str_replace('\\', '/', $path), '/');
+    }
+
+    private static function isValidScope(string $scope): bool
+    {
+        if ($scope === '' || strlen($scope) > 512 || str_contains($scope, '\\')) {
+            return false;
+        }
+
+        $segments = explode('/', $scope);
+        if (count($segments) > 16) {
+            return false;
+        }
+
+        foreach ($segments as $segment) {
+            if (! self::isValidSegment($segment)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function isValidSegment(string $segment): bool
+    {
+        return preg_match('/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/', $segment) === 1;
+    }
+
+    private static function build(
+        int $organizationId,
+        string $domain,
+        string $scope,
+        string $objectId,
+        string $extension,
+    ): string {
+        return "org-{$organizationId}/{$domain}/{$scope}/{$objectId}.{$extension}";
     }
 }

--- a/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
+++ b/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
@@ -150,7 +150,7 @@ APP_ENV=testing vendor/bin/phpstan analyse config/filesystems.php app/Services/S
 
 Expected: PASS без предупреждений новой логики.
 
-- [ ] **Step 8: Commit, PR, merge и deploy**
+- [x] **Step 8: Commit, PR, merge и deploy**
 
 ```bash
 git add -A
@@ -171,16 +171,18 @@ gh pr merge feat/timeweb-s3-foundation -R kamilgaraev/proexpert --merge --delete
 
 **Files:**
 - Modify: `app/Services/Storage/OrganizationStoragePath.php`
-- Modify: `app/Services/Storage/DTO/StoredFile.php`
+- Create: `app/Services/Storage/DTO/CurrentStoredFile.php`
 - Modify: `app/Services/Storage/FileService.php`
 - Modify: `tests/Unit/Storage/OrganizationStoragePathTest.php`
 - Create: `tests/Unit/Storage/FileServiceCurrentObjectTest.php`
 
 **Interfaces:**
 - Consumes: единый Timeweb-диск из Task 1.
-- Produces: `OrganizationStoragePath::forDomain(int $organizationId, string $domain, string $scope, string $objectId, string $extension): string`; `OrganizationStoragePath::personal(int $organizationId, int $userId, string $objectId, string $extension): string`; `FileService::putPrivate(string $key, mixed $contents, string $mime, string $sha256): StoredFile`; `temporaryDownloadUrl(string $key, int $ttlSeconds): string`; `deleteCurrent(string $key): void`.
+- Produces: `OrganizationStoragePath::forDomain(int $organizationId, string $domain, string $scope, string $objectId, string $extension): string`; `OrganizationStoragePath::personal(int $organizationId, int $userId, string $objectId, string $extension): string`; `FileService::putPrivate(string $key, mixed $contents, string $mime, string $sha256): CurrentStoredFile`; `temporaryDownloadUrl(string $key, int $ttlSeconds): string`; `deleteCurrent(string $key): void`.
 
-- [ ] **Step 1: Расширить failing-тест путей**
+`CurrentStoredFile` намеренно не содержит S3 `VersionId`. Существующий versioned `StoredFile` остаётся изолированным только в старом контуре отчётов до его полного удаления в Task 6.
+
+- [x] **Step 1: Расширить failing-тест путей**
 
 Добавить проверки точных результатов:
 
@@ -197,17 +199,17 @@ self::assertSame(
 
 Также отклонить organization/user `0`, `..`, слеш в object id, неизвестный domain и расширение с точкой.
 
-- [ ] **Step 2: Проверить RED и реализовать value object**
+- [x] **Step 2: Проверить RED и реализовать value object**
 
 Run: `php artisan test tests/Unit/Storage/OrganizationStoragePathTest.php --stop-on-failure`
 
 Expected сначала FAIL, после минимальной реализации PASS.
 
-- [ ] **Step 3: Написать failing-тест актуального объекта**
+- [x] **Step 3: Написать failing-тест актуального объекта**
 
 Тест записывает объект в fake/recording storage, проверяет SHA-256, MIME, размер, приватность, ссылку без `VersionId` и удаление по ключу. Отдельно проверяет отклонение ключа вне `org-{id}/` и несовпадающий SHA-256.
 
-- [ ] **Step 4: Проверить RED, реализовать и проверить GREEN**
+- [x] **Step 4: Проверить RED, реализовать и проверить GREEN**
 
 Run:
 

--- a/tests/Unit/Storage/FileServiceCurrentObjectTest.php
+++ b/tests/Unit/Storage/FileServiceCurrentObjectTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Storage;
+
+use App\Models\Organization;
+use App\Services\Logging\LoggingService;
+use App\Services\Storage\DTO\CurrentStoredFile;
+use App\Services\Storage\FileService;
+use Aws\Result;
+use Aws\S3\S3ClientInterface;
+use Illuminate\Filesystem\FilesystemAdapter;
+use InvalidArgumentException;
+use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FileServiceCurrentObjectTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_it_writes_downloads_and_deletes_current_private_object_without_version_identity(): void
+    {
+        $contents = 'private-file-body';
+        $checksum = hash('sha256', $contents);
+        $key = 'org-42/reports/exports/01J4EXPORT/01J4OBJECT.pdf';
+        $captured = null;
+        $client = Mockery::mock(S3ClientInterface::class);
+        $client->shouldReceive('putObject')
+            ->once()
+            ->with(Mockery::on(static function (array $arguments) use (&$captured): bool {
+                $captured = $arguments;
+
+                return true;
+            }))
+            ->andReturn(new Result(['ETag' => '"etag-1"', 'VersionId' => 'internal-version']));
+        $disk = $this->recordingDisk();
+        $files = $this->service($client, $disk);
+
+        $stored = $files->putPrivate($key, $contents, 'application/pdf', $checksum);
+        $link = $files->temporaryDownloadUrl($key, 300);
+        $files->deleteCurrent($key);
+
+        self::assertInstanceOf(CurrentStoredFile::class, $stored);
+        self::assertSame($key, $stored->key);
+        self::assertSame(strlen($contents), $stored->sizeBytes);
+        self::assertSame($checksum, $stored->sha256);
+        self::assertSame('application/pdf', $stored->mime);
+        self::assertFalse(property_exists($stored, 'versionId'));
+        self::assertIsArray($captured);
+        self::assertSame('prohelper-storage', $captured['Bucket'] ?? null);
+        self::assertSame($key, $captured['Key'] ?? null);
+        self::assertSame($contents, $captured['Body'] ?? null);
+        self::assertSame('private', $captured['ACL'] ?? null);
+        self::assertSame('application/pdf', $captured['ContentType'] ?? null);
+        self::assertSame(['sha256' => $checksum], $captured['Metadata'] ?? null);
+        self::assertSame('*', $captured['IfNoneMatch'] ?? null);
+        self::assertStringNotContainsStringIgnoringCase('versionid', $link);
+        self::assertSame([$key], $disk->deletedKeys);
+    }
+
+    public function test_it_hashes_seekable_stream_and_restores_its_cursor_before_upload(): void
+    {
+        $contents = 'streamed-private-file';
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+        fwrite($stream, $contents);
+        rewind($stream);
+        $client = Mockery::mock(S3ClientInterface::class);
+        $client->shouldReceive('putObject')
+            ->once()
+            ->with(Mockery::on(static fn (array $arguments): bool => is_resource($arguments['Body'] ?? null)
+                && ftell($arguments['Body']) === 0))
+            ->andReturn(new Result(['ETag' => '"etag-stream"']));
+
+        $stored = $this->service($client, $this->recordingDisk())->putPrivate(
+            'org-42/legal-archive/01J4DOCUMENT/01J4OBJECT.pdf',
+            $stream,
+            'application/pdf',
+            hash('sha256', $contents),
+        );
+
+        self::assertSame(strlen($contents), $stored->sizeBytes);
+        self::assertSame(0, ftell($stream));
+        fclose($stream);
+    }
+
+    #[DataProvider('invalidWriteProvider')]
+    public function test_it_rejects_invalid_write_before_calling_s3(
+        string $key,
+        string $contents,
+        string $mime,
+        string $checksum,
+    ): void {
+        $client = Mockery::mock(S3ClientInterface::class);
+        $client->shouldNotReceive('putObject');
+        $files = $this->service($client, $this->recordingDisk());
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $files->putPrivate($key, $contents, $mime, $checksum);
+    }
+
+    public static function invalidWriteProvider(): iterable
+    {
+        yield 'outside organization' => [
+            'reports/exports/file.pdf',
+            'body',
+            'application/pdf',
+            hash('sha256', 'body'),
+        ];
+        yield 'checksum mismatch' => [
+            'org-42/reports/exports/file.pdf',
+            'body',
+            'application/pdf',
+            str_repeat('a', 64),
+        ];
+        yield 'empty body' => [
+            'org-42/reports/exports/file.pdf',
+            '',
+            'application/pdf',
+            hash('sha256', ''),
+        ];
+        yield 'unsafe mime' => [
+            'org-42/reports/exports/file.pdf',
+            'body',
+            "application/pdf\nunsafe",
+            hash('sha256', 'body'),
+        ];
+    }
+
+    private function service(S3ClientInterface $client, FilesystemAdapter $disk): FileService
+    {
+        $logging = new class extends LoggingService
+        {
+            public function __construct() {}
+        };
+
+        return new class($logging, $client, $disk) extends FileService
+        {
+            public function __construct(
+                LoggingService $logging,
+                private readonly S3ClientInterface $client,
+                private readonly FilesystemAdapter $adapter,
+            ) {
+                parent::__construct($logging);
+            }
+
+            public function disk(?Organization $organization = null): FilesystemAdapter
+            {
+                return $this->adapter;
+            }
+
+            protected function s3Client(): S3ClientInterface
+            {
+                return $this->client;
+            }
+        };
+    }
+
+    private function recordingDisk(): FilesystemAdapter
+    {
+        return new class extends FilesystemAdapter
+        {
+            /** @var list<string> */
+            public array $deletedKeys = [];
+
+            public function __construct() {}
+
+            public function getConfig(): array
+            {
+                return ['bucket' => 'prohelper-storage'];
+            }
+
+            public function temporaryUrl($path, $expiration, array $options = []): string
+            {
+                return 'https://download.example.test/'.rawurlencode((string) $path).'?expires=300';
+            }
+
+            public function delete($paths): bool
+            {
+                $this->deletedKeys[] = (string) $paths;
+
+                return true;
+            }
+        };
+    }
+}

--- a/tests/Unit/Storage/OrganizationStoragePathTest.php
+++ b/tests/Unit/Storage/OrganizationStoragePathTest.php
@@ -5,11 +5,70 @@ declare(strict_types=1);
 namespace Tests\Unit\Storage;
 
 use App\Services\Storage\OrganizationStoragePath;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class OrganizationStoragePathTest extends TestCase
+final class OrganizationStoragePathTest extends TestCase
 {
-    public function testAddsOrganizationPrefixToRelativePath(): void
+    public function test_builds_strict_domain_and_personal_paths(): void
+    {
+        self::assertSame(
+            'org-42/reports/exports/01J4EXPORT/01J4OBJECT.xlsx',
+            OrganizationStoragePath::forDomain(
+                42,
+                'reports',
+                'exports/01J4EXPORT',
+                '01J4OBJECT',
+                'xlsx',
+            ),
+        );
+        self::assertSame(
+            'org-42/personal-files/user-7/018f4a8a-0000-7000-8000-000000000001.pdf',
+            OrganizationStoragePath::personal(
+                42,
+                7,
+                '018f4a8a-0000-7000-8000-000000000001',
+                'pdf',
+            ),
+        );
+    }
+
+    #[DataProvider('invalidStrictPathProvider')]
+    public function test_rejects_invalid_strict_path(callable $build): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('organization_storage_path_invalid');
+
+        $build();
+    }
+
+    public static function invalidStrictPathProvider(): iterable
+    {
+        yield 'organization zero' => [
+            static fn (): string => OrganizationStoragePath::forDomain(0, 'reports', 'exports/01J4', '01J5', 'xlsx'),
+        ];
+        yield 'user zero' => [
+            static fn (): string => OrganizationStoragePath::personal(42, 0, '01J5', 'pdf'),
+        ];
+        yield 'unknown domain' => [
+            static fn (): string => OrganizationStoragePath::forDomain(42, 'cms', 'pages', '01J5', 'json'),
+        ];
+        yield 'personal domain bypass' => [
+            static fn (): string => OrganizationStoragePath::forDomain(42, 'personal-files', 'other-user', '01J5', 'pdf'),
+        ];
+        yield 'parent traversal' => [
+            static fn (): string => OrganizationStoragePath::forDomain(42, 'reports', '../exports', '01J5', 'xlsx'),
+        ];
+        yield 'slash in object id' => [
+            static fn (): string => OrganizationStoragePath::forDomain(42, 'reports', 'exports', '01J5/file', 'xlsx'),
+        ];
+        yield 'extension with dot' => [
+            static fn (): string => OrganizationStoragePath::forDomain(42, 'reports', 'exports', '01J5', '.xlsx'),
+        ];
+    }
+
+    public function test_adds_organization_prefix_to_relative_path(): void
     {
         $this->assertSame(
             'org-39/reports/project_profitability_report.pdf',
@@ -17,7 +76,7 @@ class OrganizationStoragePathTest extends TestCase
         );
     }
 
-    public function testDoesNotDuplicateExistingOrganizationPrefix(): void
+    public function test_does_not_duplicate_existing_organization_prefix(): void
     {
         $this->assertSame(
             'org-39/reports/project_profitability_report.pdf',
@@ -25,7 +84,7 @@ class OrganizationStoragePathTest extends TestCase
         );
     }
 
-    public function testNormalizesLegacyReportPath(): void
+    public function test_normalizes_legacy_report_path(): void
     {
         $this->assertSame(
             'org-39/reports/project_profitability_report.pdf',
@@ -33,7 +92,7 @@ class OrganizationStoragePathTest extends TestCase
         );
     }
 
-    public function testNormalizesLegacyImportPath(): void
+    public function test_normalizes_legacy_import_path(): void
     {
         $this->assertSame(
             'org-39/estimate-imports/source.xlsx',


### PR DESCRIPTION
## Что изменено
- добавлены строгие ключи `org-{organization_id}` для доменов хранения
- персональные ключи строятся только через `personal(...)` и всегда содержат `user-{user_id}`
- общий `forDomain(...)` не позволяет обойти обязательный user scope
- `FileService` получил единый приватный conditional put, временную download-ссылку и удаление актуального ключа
- новый current-object DTO содержит key, ETag, размер, MIME и SHA-256, но не S3 VersionId
- запись проверяет SHA-256 до сети, использует `If-None-Match: *` и private ACL

## Проверки
- PHPUnit: 21 тест, 55 assertions
- PHPStan по изменённому storage-коду: без ошибок
- Pint по новым/изменённым компактным файлам: без замечаний
- FileService syntax и `git diff --check`: успешно
- секреты в diff отсутствуют

## Деплой
Только существующий workflow `Deploy Backend to Production`; ручной деплой не используется.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a new DTO 'CurrentStoredFile' to encapsulate and validate file metadata for S3 storage operations.</li>
<li>Added 'putPrivate' method to 'FileService' to handle secure, private file uploads with mandatory SHA256 checksum verification.</li>
<li>Implemented 'OrganizationStoragePath' to standardize and validate S3 storage paths for organizations.</li>
<li>Added comprehensive unit tests for the new DTO and storage path validation logic.</li>
<li>Included a migration plan document for the upcoming Timeweb S3 migration.</li>
</ul></div>