### PR TITLE
feat: зафиксирована история расчётов по договорам

### DIFF
--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerHistoryBackfillService.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerHistoryBackfillService.php
@@ -8,7 +8,6 @@ use App\BusinessModules\Core\Payments\Models\PaymentDocument;
 use App\BusinessModules\Core\Payments\Models\PaymentTransaction;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\ContractManagement\Reporting\Models\ContractSettlementOwnerHistoryCheckpoint;
-use App\BusinessModules\Features\ContractManagement\Reporting\Models\ContractSettlementOwnerVersion;
 use App\Models\Contract;
 use App\Models\ContractPerformanceAct;
 use App\Models\ContractProjectAllocation;
@@ -28,6 +27,12 @@ final readonly class ContractSettlementOwnerHistoryBackfillService
         }
 
         return DB::transaction(function () use ($organizationId): ContractSettlementOwnerHistoryCheckpoint {
+            if (DB::getDriverName() === 'pgsql') {
+                DB::statement(
+                    'LOCK TABLE contracts, contract_project_allocations, contract_performance_acts, '
+                    .'payment_documents, payment_transactions IN SHARE ROW EXCLUSIVE MODE',
+                );
+            }
             $organization = DB::table('organizations')
                 ->where('id', $organizationId)
                 ->lockForUpdate()
@@ -42,6 +47,7 @@ final readonly class ContractSettlementOwnerHistoryBackfillService
                 return $existing;
             }
 
+            $completedAt = now();
             $queries = [
                 'contract' => Contract::query()->where('organization_id', $organizationId),
                 'contract_allocation' => ContractProjectAllocation::query()
@@ -60,8 +66,8 @@ final readonly class ContractSettlementOwnerHistoryBackfillService
             foreach ($queries as $type => $query) {
                 $counts[$type] = 0;
                 $query->orderBy('id')->chunkById(500, function ($owners) use (
-                    $organizationId,
                     $type,
+                    $completedAt,
                     &$counts,
                     &$identities,
                 ): void {
@@ -69,32 +75,25 @@ final readonly class ContractSettlementOwnerHistoryBackfillService
                         if (! $owner instanceof Model) {
                             throw new DomainException('contract_settlement_owner_history_invalid');
                         }
-                        $exists = ContractSettlementOwnerVersion::query()
-                            ->where('organization_id', $organizationId)
-                            ->where('owner_type', $type)
-                            ->where('owner_id', $owner->getKey())
-                            ->exists();
-                        if (! $exists) {
-                            $this->recorder->record($owner, 'upsert');
-                        }
+                        $version = $this->recorder->record($owner, 'upsert', $completedAt);
                         $counts[$type]++;
                         $identities[] = [
                             'type' => $type,
                             'id' => (string) $owner->getKey(),
-                            'updated_at' => $owner->updated_at?->format(DATE_ATOM),
+                            'version' => (int) $version->version,
+                            'hash' => (string) $version->owner_hash,
                         ];
                     }
                 });
             }
-            $completedAt = now();
 
             return ContractSettlementOwnerHistoryCheckpoint::query()->create([
                 'organization_id' => $organizationId,
-                'completed_at' => $completedAt,
+                'completed_at' => ContractSettlementOwnerTimestamp::database($completedAt),
                 'owner_counts' => $counts,
                 'source_hash' => hash('sha256', CanonicalJson::encode([
                     'organization_id' => $organizationId,
-                    'completed_at' => $completedAt->format(DATE_ATOM),
+                    'completed_at' => ContractSettlementOwnerTimestamp::canonical($completedAt),
                     'owners' => $identities,
                 ])),
             ]);

--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerSource.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerSource.php
@@ -520,16 +520,17 @@ final readonly class ContractSettlementOwnerSource
      */
     private function historicalOwners(ReportScope $scope, ReportQuery $query): array
     {
+        $asOf = ContractSettlementOwnerTimestamp::database($query->asOf);
         $checkpoint = ContractSettlementOwnerHistoryCheckpoint::query()
             ->where('organization_id', $scope->organizationId)
-            ->where('completed_at', '<=', $query->asOf)
+            ->where('completed_at', '<=', $asOf)
             ->first();
         if (! $checkpoint instanceof ContractSettlementOwnerHistoryCheckpoint) {
             throw new DomainException('contract_settlement_owner_history_checkpoint_missing');
         }
         $versions = ContractSettlementOwnerVersion::query()
             ->where('organization_id', $scope->organizationId)
-            ->where('occurred_at', '<=', $query->asOf)
+            ->where('occurred_at', '<=', $asOf)
             ->orderBy('owner_type')
             ->orderBy('owner_id')
             ->orderByDesc('version')

--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerTimestamp.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerTimestamp.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ContractManagement\Reporting;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+
+final class ContractSettlementOwnerTimestamp
+{
+    public const MODEL_FORMAT = 'Y-m-d H:i:s.uP';
+
+    private const CANONICAL_FORMAT = 'Y-m-d\TH:i:s.uP';
+
+    private const DATABASE_FORMAT = 'Y-m-d H:i:s.uP';
+
+    public static function canonical(DateTimeInterface $value): string
+    {
+        return self::utc($value)->format(self::CANONICAL_FORMAT);
+    }
+
+    public static function database(DateTimeInterface $value): string
+    {
+        return self::utc($value)->format(self::DATABASE_FORMAT);
+    }
+
+    private static function utc(DateTimeInterface $value): DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromInterface($value)->setTimezone(new DateTimeZone('UTC'));
+    }
+}

--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerVersionRecorder.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerVersionRecorder.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Features\ContractManagement\Reporting\Models\ContractSet
 use App\Models\Contract;
 use App\Models\ContractPerformanceAct;
 use App\Models\ContractProjectAllocation;
+use DateTimeInterface;
 use DomainException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -25,21 +26,25 @@ final readonly class ContractSettlementOwnerVersionRecorder
         PaymentTransaction::class => 'payment_transaction',
     ];
 
-    public function record(Model $owner, string $operation): void
+    public function record(
+        Model $owner,
+        string $operation,
+        ?DateTimeInterface $occurredAt = null,
+    ): ContractSettlementOwnerVersion
     {
         $ownerType = self::TYPES[$owner::class] ?? throw new DomainException('contract_settlement_owner_type_invalid');
         $organizationId = $this->organizationId($owner);
         $payload = $owner->attributesToArray();
-        $occurredAt = $owner->updated_at ?? now();
+        $occurredAt ??= now();
 
-        DB::transaction(function () use (
+        return DB::transaction(function () use (
             $owner,
             $ownerType,
             $organizationId,
             $payload,
             $operation,
             $occurredAt,
-        ): void {
+        ): ContractSettlementOwnerVersion {
             $organization = DB::table('organizations')
                 ->where('id', $organizationId)
                 ->lockForUpdate()
@@ -61,10 +66,10 @@ final readonly class ContractSettlementOwnerVersionRecorder
                 'owner_id' => (string) $owner->getKey(),
                 'version' => $version,
                 'operation' => $operation,
-                'occurred_at' => $occurredAt->format(DATE_ATOM),
+                'occurred_at' => ContractSettlementOwnerTimestamp::canonical($occurredAt),
                 'payload' => $payload,
             ];
-            ContractSettlementOwnerVersion::query()->create([
+            return ContractSettlementOwnerVersion::query()->create([
                 ...$identity,
                 'owner_hash' => hash('sha256', CanonicalJson::encode($identity)),
             ]);

--- a/app/BusinessModules/Features/ContractManagement/Reporting/Models/ContractSettlementOwnerHistoryCheckpoint.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/Models/ContractSettlementOwnerHistoryCheckpoint.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\ContractManagement\Reporting\Models;
 
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerTimestamp;
 use DomainException;
 use Illuminate\Database\Eloquent\Model;
 
 final class ContractSettlementOwnerHistoryCheckpoint extends Model
 {
     protected $guarded = [];
+
+    protected $dateFormat = ContractSettlementOwnerTimestamp::MODEL_FORMAT;
 
     protected $casts = [
         'completed_at' => 'immutable_datetime',

--- a/app/BusinessModules/Features/ContractManagement/Reporting/Models/ContractSettlementOwnerVersion.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/Models/ContractSettlementOwnerVersion.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\ContractManagement\Reporting\Models;
 
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerTimestamp;
 use Illuminate\Database\Eloquent\Model;
 
 final class ContractSettlementOwnerVersion extends Model
@@ -11,6 +12,8 @@ final class ContractSettlementOwnerVersion extends Model
     protected $table = 'contract_settlement_owner_versions';
 
     protected $guarded = [];
+
+    protected $dateFormat = ContractSettlementOwnerTimestamp::MODEL_FORMAT;
 
     protected $casts = [
         'payload' => 'array',

--- a/database/migrations/2026_08_05_040000_seed_contract_settlement_owner_history_foundation.php
+++ b/database/migrations/2026_08_05_040000_seed_contract_settlement_owner_history_foundation.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerHistoryBackfillService;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerTimestamp;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $evidence = DB::transaction(function (): array {
+            DB::statement(
+                'LOCK TABLE contracts, contract_project_allocations, contract_performance_acts, '
+                .'payment_documents, payment_transactions IN SHARE ROW EXCLUSIVE MODE',
+            );
+            DB::statement('LOCK TABLE organizations IN SHARE ROW EXCLUSIVE MODE');
+            DB::statement(
+                'ALTER TABLE contract_settlement_owner_versions '
+                .'ALTER COLUMN occurred_at TYPE timestamptz(6) USING occurred_at::timestamptz(6)',
+            );
+            DB::statement(
+                'ALTER TABLE contract_settlement_owner_history_checkpoints '
+                .'ALTER COLUMN completed_at TYPE timestamptz(6) USING completed_at::timestamptz(6)',
+            );
+
+            DB::unprepared(<<<'SQL'
+CREATE OR REPLACE FUNCTION most_seed_contract_settlement_owner_checkpoint_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    checkpoint_at timestamptz(6) := clock_timestamp()::timestamptz(6);
+    counts jsonb := jsonb_build_object(
+        'contract', 0,
+        'contract_allocation', 0,
+        'contract_performance_act', 0,
+        'payment_document', 0,
+        'payment_transaction', 0
+    );
+BEGIN
+    INSERT INTO contract_settlement_owner_history_checkpoints (
+        organization_id,
+        completed_at,
+        owner_counts,
+        source_hash,
+        created_at,
+        updated_at
+    ) VALUES (
+        NEW.id,
+        checkpoint_at,
+        counts,
+        encode(sha256(convert_to(jsonb_build_object(
+            'organization_id', NEW.id,
+            'completed_at', checkpoint_at,
+            'owners', jsonb_build_array()
+        )::text, 'UTF8')), 'hex'),
+        checkpoint_at,
+        checkpoint_at
+    )
+    ON CONFLICT (organization_id) DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS most_seed_contract_settlement_owner_checkpoint_v1 ON organizations;
+CREATE TRIGGER most_seed_contract_settlement_owner_checkpoint_v1
+AFTER INSERT ON organizations
+FOR EACH ROW EXECUTE FUNCTION most_seed_contract_settlement_owner_checkpoint_v1();
+SQL);
+
+            $existingCheckpointCount = DB::table('contract_settlement_owner_history_checkpoints')->count();
+            if ($existingCheckpointCount !== 0) {
+                throw new RuntimeException('Contract settlement owner checkpoint already exists.');
+            }
+
+            $backfill = app(ContractSettlementOwnerHistoryBackfillService::class);
+            $checkpointCount = 0;
+            $ownerCounts = [
+                'contract' => 0,
+                'contract_allocation' => 0,
+                'contract_performance_act' => 0,
+                'payment_document' => 0,
+                'payment_transaction' => 0,
+            ];
+            $checkpointIdentities = [];
+
+            DB::table('organizations')
+                ->select('id')
+                ->orderBy('id')
+                ->chunkById(100, function ($organizations) use (
+                    $backfill,
+                    &$checkpointCount,
+                    &$ownerCounts,
+                    &$checkpointIdentities,
+                ): void {
+                    foreach ($organizations as $organization) {
+                        $checkpoint = $backfill->backfill((int) $organization->id);
+                        $counts = is_array($checkpoint->owner_counts) ? $checkpoint->owner_counts : [];
+                        $expectedVersionCount = 0;
+                        foreach (array_keys($ownerCounts) as $type) {
+                            $count = $counts[$type] ?? null;
+                            if (! is_int($count) || $count < 0) {
+                                throw new RuntimeException('Contract settlement owner count is invalid.');
+                            }
+                            $ownerCounts[$type] += $count;
+                            $expectedVersionCount += $count;
+                        }
+
+                        $capturedVersionCount = DB::table('contract_settlement_owner_versions')
+                            ->where('organization_id', (int) $organization->id)
+                            ->where(
+                                'occurred_at',
+                                ContractSettlementOwnerTimestamp::database($checkpoint->completed_at),
+                            )
+                            ->count();
+                        if ($capturedVersionCount !== $expectedVersionCount) {
+                            throw new RuntimeException('Contract settlement owner checkpoint coverage mismatch.');
+                        }
+                        if (! is_string($checkpoint->source_hash) || strlen($checkpoint->source_hash) !== 64) {
+                            throw new RuntimeException('Contract settlement owner checkpoint hash is invalid.');
+                        }
+
+                        $checkpointCount++;
+                        $checkpointIdentities[] = (int) $organization->id.':'.$checkpoint->source_hash;
+                    }
+                });
+
+            $organizationCount = DB::table('organizations')->count();
+            if ($checkpointCount !== $organizationCount) {
+                throw new RuntimeException('Contract settlement owner checkpoint organization coverage mismatch.');
+            }
+            if (DB::table('contract_settlement_owner_history_checkpoints')->count() !== $organizationCount) {
+                throw new RuntimeException('Contract settlement owner checkpoint persistence mismatch.');
+            }
+
+            return [
+                'checkpoint_count' => $checkpointCount,
+                'owner_counts' => $ownerCounts,
+                'content_hash' => hash('sha256', implode('|', $checkpointIdentities)),
+            ];
+        });
+
+        Log::info('report_contract_settlement_owner_history_foundation_completed', $evidence);
+    }
+
+    public function down(): void
+    {
+        throw new RuntimeException(
+            'Contract settlement owner history foundation is irreversible because its evidence is append-only.',
+        );
+    }
+};

--- a/tests/Architecture/Reporting/FinanceOwnerReportingContractTest.php
+++ b/tests/Architecture/Reporting/FinanceOwnerReportingContractTest.php
@@ -21,7 +21,9 @@ use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Queries\
 use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services\ChangeClaimSnapshotMaterializer;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureProvider;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerSource;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerTimestamp;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementQueryService;
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -275,6 +277,63 @@ final class FinanceOwnerReportingContractTest extends TestCase
         self::assertStringContainsString("DB::table('organizations')", $backfill);
         self::assertStringContainsString('->lockForUpdate()', $backfill);
         self::assertStringContainsString('ContractSettlementOwnerHistoryCheckpoint::query()->create', $backfill);
+    }
+
+    #[Test]
+    public function settlement_owner_foundation_pins_one_exact_boundary_and_covers_future_organizations(): void
+    {
+        $root = $this->root();
+        $migration = (string) file_get_contents(
+            $root.'/database/migrations/2026_08_05_040000_seed_contract_settlement_owner_history_foundation.php',
+        );
+        $backfill = (string) file_get_contents(
+            $root.'/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerHistoryBackfillService.php',
+        );
+        $recorder = (string) file_get_contents(
+            $root.'/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerVersionRecorder.php',
+        );
+        $source = (string) file_get_contents(
+            $root.'/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerSource.php',
+        );
+        $timestamp = (string) file_get_contents(
+            $root.'/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerTimestamp.php',
+        );
+        $versionModel = (string) file_get_contents(
+            $root.'/app/BusinessModules/Features/ContractManagement/Reporting/Models/ContractSettlementOwnerVersion.php',
+        );
+        $checkpointModel = (string) file_get_contents(
+            $root.'/app/BusinessModules/Features/ContractManagement/Reporting/Models/ContractSettlementOwnerHistoryCheckpoint.php',
+        );
+
+        self::assertStringContainsString(
+            'LOCK TABLE contracts, contract_project_allocations, contract_performance_acts, '
+            .'payment_documents, payment_transactions IN SHARE ROW EXCLUSIVE MODE',
+            $migration,
+        );
+        self::assertStringContainsString('timestamptz(6)', $migration);
+        self::assertStringContainsString('most_seed_contract_settlement_owner_checkpoint_v1', $migration);
+        self::assertStringContainsString('AFTER INSERT ON organizations', $migration);
+        self::assertStringContainsString('ContractSettlementOwnerHistoryBackfillService::class', $migration);
+        self::assertStringContainsString(
+            "\$this->recorder->record(\$owner, 'upsert', \$completedAt)",
+            $backfill,
+        );
+        self::assertStringContainsString("'version' => (int) \$version->version", $backfill);
+        self::assertStringContainsString("'hash' => (string) \$version->owner_hash", $backfill);
+        self::assertStringContainsString('?DateTimeInterface $occurredAt = null', $recorder);
+        self::assertStringContainsString(': ContractSettlementOwnerVersion', $recorder);
+        self::assertStringContainsString("'Y-m-d\\TH:i:s.uP'", $timestamp);
+        self::assertStringContainsString("'Y-m-d H:i:s.uP'", $timestamp);
+        self::assertStringContainsString('ContractSettlementOwnerTimestamp::canonical($occurredAt)', $recorder);
+        self::assertStringContainsString('ContractSettlementOwnerTimestamp::canonical($completedAt)', $backfill);
+        self::assertStringContainsString('ContractSettlementOwnerTimestamp::database($query->asOf)', $source);
+        self::assertStringContainsString('ContractSettlementOwnerTimestamp::MODEL_FORMAT', $versionModel);
+        self::assertStringContainsString('ContractSettlementOwnerTimestamp::MODEL_FORMAT', $checkpointModel);
+        self::assertStringNotContainsString('DATE_ATOM', $recorder);
+        self::assertStringNotContainsString('DATE_ATOM', $backfill);
+        $nonUtc = new DateTimeImmutable('2026-08-05T12:34:56.123456+03:00');
+        self::assertSame('2026-08-05T09:34:56.123456+00:00', ContractSettlementOwnerTimestamp::canonical($nonUtc));
+        self::assertSame('2026-08-05 09:34:56.123456+00:00', ContractSettlementOwnerTimestamp::database($nonUtc));
     }
 
     #[Test]

--- a/tests/Feature/Reporting/FinanceOwnerPostgresContractTest.php
+++ b/tests/Feature/Reporting/FinanceOwnerPostgresContractTest.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Reporting;
 
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerHistoryBackfillService;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerTimestamp;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerVersionRecorder;
+use App\BusinessModules\Features\ContractManagement\Reporting\Models\ContractSettlementOwnerHistoryCheckpoint;
+use App\BusinessModules\Features\ContractManagement\Reporting\Models\ContractSettlementOwnerVersion;
 use App\BusinessModules\Features\ChangeManagement\Models\ChangeRequest;
 use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DTO\ContingencyMovement;
 use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services\ContingencyLedgerService;
 use App\BusinessModules\Features\ChangeManagement\Services\ChangeManagementService;
+use App\Models\Contract;
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\User;
+use DateTimeImmutable;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Support\Reporting\PostgresProcessRaceHarness;
@@ -55,6 +63,260 @@ final class FinanceOwnerPostgresContractTest extends TestCase
                 ->first();
             self::assertNotNull($row, $table);
             self::assertStringContainsString('BEFORE UPDATE OR DELETE', (string) $row->definition);
+        }
+    }
+
+    #[Test]
+    public function contract_settlement_checkpoints_match_exact_owner_versions(): void
+    {
+        $mismatchCount = DB::scalar(<<<'SQL'
+SELECT COUNT(*)
+FROM (
+    SELECT
+        checkpoint.organization_id,
+        (
+            (checkpoint.owner_counts->>'contract')::bigint
+            + (checkpoint.owner_counts->>'contract_allocation')::bigint
+            + (checkpoint.owner_counts->>'contract_performance_act')::bigint
+            + (checkpoint.owner_counts->>'payment_document')::bigint
+            + (checkpoint.owner_counts->>'payment_transaction')::bigint
+        ) AS expected_count,
+        COUNT(version.id) AS captured_count
+    FROM contract_settlement_owner_history_checkpoints AS checkpoint
+    LEFT JOIN contract_settlement_owner_versions AS version
+        ON version.organization_id = checkpoint.organization_id
+       AND version.occurred_at = checkpoint.completed_at
+    GROUP BY checkpoint.id
+) AS coverage
+WHERE coverage.expected_count <> coverage.captured_count
+SQL);
+
+        self::assertSame(0, (int) $mismatchCount);
+        self::assertSame(6, (int) DB::scalar(<<<'SQL'
+SELECT datetime_precision
+FROM information_schema.columns
+WHERE table_schema = current_schema()
+  AND table_name = 'contract_settlement_owner_versions'
+  AND column_name = 'occurred_at'
+SQL));
+        self::assertSame(6, (int) DB::scalar(<<<'SQL'
+SELECT datetime_precision
+FROM information_schema.columns
+WHERE table_schema = current_schema()
+  AND table_name = 'contract_settlement_owner_history_checkpoints'
+  AND column_name = 'completed_at'
+SQL));
+    }
+
+    #[Test]
+    public function future_organization_checkpoint_and_owner_version_keep_exact_microseconds(): void
+    {
+        $organization = Organization::factory()->create();
+        $checkpoint = ContractSettlementOwnerHistoryCheckpoint::query()
+            ->where('organization_id', $organization->id)
+            ->sole();
+        $project = Project::factory()->create(['organization_id' => $organization->id]);
+        $now = now();
+        $contractorId = DB::table('contractors')->insertGetId([
+            'organization_id' => $organization->id,
+            'name' => 'PG checkpoint contractor',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $contractId = DB::table('contracts')->insertGetId([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'contractor_id' => $contractorId,
+            'number' => 'PG-CHECKPOINT-'.bin2hex(random_bytes(4)),
+            'date' => $now->toDateString(),
+            'total_amount' => '1000.00',
+            'currency' => 'RUB',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $contract = Contract::query()->findOrFail($contractId);
+        $exactAt = new DateTimeImmutable(
+            $checkpoint->completed_at->addSecond()->format('Y-m-d\TH:i:s').'.123456+00:00',
+        );
+        $version = app(ContractSettlementOwnerVersionRecorder::class)->record(
+            $contract,
+            'upsert',
+            $exactAt,
+        );
+
+        self::assertSame(
+            $exactAt->format('Y-m-d H:i:s.u'),
+            DB::scalar(
+                "SELECT to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.US') "
+                .'FROM contract_settlement_owner_versions WHERE id = ?',
+                [$version->id],
+            ),
+        );
+        $before = new DateTimeImmutable(
+            $exactAt->format('Y-m-d\TH:i:s').'.123455+00:00',
+        );
+        self::assertSame(0, DB::table('contract_settlement_owner_versions')
+            ->where('organization_id', $organization->id)
+            ->where('owner_type', 'contract')
+            ->where('owner_id', (string) $contractId)
+            ->where('occurred_at', '<=', ContractSettlementOwnerTimestamp::database($before))
+            ->count());
+        self::assertSame(1, DB::table('contract_settlement_owner_versions')
+            ->where('organization_id', $organization->id)
+            ->where('owner_type', 'contract')
+            ->where('owner_id', (string) $contractId)
+            ->where('occurred_at', '<=', ContractSettlementOwnerTimestamp::database($exactAt))
+            ->count());
+
+        $versionCount = DB::table('contract_settlement_owner_versions')
+            ->where('organization_id', $organization->id)
+            ->count();
+        $replayed = app(ContractSettlementOwnerHistoryBackfillService::class)->backfill((int) $organization->id);
+        self::assertSame($checkpoint->id, $replayed->id);
+        self::assertSame($versionCount, DB::table('contract_settlement_owner_versions')
+            ->where('organization_id', $organization->id)
+            ->count());
+    }
+
+    #[Test]
+    public function owner_history_foundation_migration_backfills_non_empty_sources_exactly_once(): void
+    {
+        $schema = 'report_r12_'.bin2hex(random_bytes(6));
+        DB::statement('CREATE SCHEMA '.$schema);
+
+        try {
+            DB::statement('SET search_path TO '.$schema);
+            $this->createContractSettlementFoundationSchema();
+            $ownerTimestamp = '2026-08-05 12:00:00.000000+00:00';
+            DB::table('organizations')->insert([
+                'id' => 1,
+                'created_at' => $ownerTimestamp,
+                'updated_at' => $ownerTimestamp,
+            ]);
+            DB::table('contracts')->insert([
+                'id' => 11,
+                'organization_id' => 1,
+                'is_onboarding_demo' => false,
+                'created_at' => $ownerTimestamp,
+                'updated_at' => $ownerTimestamp,
+            ]);
+            DB::table('contract_project_allocations')->insert([
+                'id' => 21,
+                'contract_id' => 11,
+                'created_at' => $ownerTimestamp,
+                'updated_at' => $ownerTimestamp,
+            ]);
+            DB::table('contract_performance_acts')->insert([
+                'id' => 31,
+                'contract_id' => 11,
+                'created_at' => $ownerTimestamp,
+                'updated_at' => $ownerTimestamp,
+            ]);
+            DB::table('payment_documents')->insert([
+                'id' => 41,
+                'organization_id' => 1,
+                'invoiceable_type' => null,
+                'invoiceable_id' => null,
+                'created_at' => $ownerTimestamp,
+                'updated_at' => $ownerTimestamp,
+            ]);
+            DB::table('payment_transactions')->insert([
+                'id' => 51,
+                'payment_document_id' => 41,
+                'organization_id' => 1,
+                'created_at' => $ownerTimestamp,
+                'updated_at' => $ownerTimestamp,
+            ]);
+
+            $migration = require base_path(
+                'database/migrations/2026_08_05_040000_seed_contract_settlement_owner_history_foundation.php',
+            );
+            $migration->up();
+
+            $checkpoint = ContractSettlementOwnerHistoryCheckpoint::query()->sole();
+            $types = [
+                'contract',
+                'contract_allocation',
+                'contract_performance_act',
+                'payment_document',
+                'payment_transaction',
+            ];
+            foreach ($types as $type) {
+                self::assertSame(1, $checkpoint->owner_counts[$type] ?? null, $type);
+            }
+            $checkpointTimestamp = ContractSettlementOwnerTimestamp::canonical($checkpoint->completed_at);
+            $identities = [];
+            foreach ($types as $type) {
+                $versions = ContractSettlementOwnerVersion::query()
+                    ->where('organization_id', 1)
+                    ->where('owner_type', $type)
+                    ->orderBy('owner_id')
+                    ->get();
+                self::assertCount(1, $versions, $type);
+                foreach ($versions as $version) {
+                    self::assertSame($checkpointTimestamp, ContractSettlementOwnerTimestamp::canonical(
+                        $version->occurred_at,
+                    ));
+                    $identity = [
+                        'organization_id' => 1,
+                        'owner_type' => $type,
+                        'owner_id' => (string) $version->owner_id,
+                        'version' => (int) $version->version,
+                        'operation' => 'upsert',
+                        'occurred_at' => $checkpointTimestamp,
+                        'payload' => $version->payload,
+                    ];
+                    self::assertSame(
+                        hash('sha256', CanonicalJson::encode($identity)),
+                        $version->owner_hash,
+                        $type,
+                    );
+                    $identities[] = [
+                        'type' => $type,
+                        'id' => (string) $version->owner_id,
+                        'version' => (int) $version->version,
+                        'hash' => (string) $version->owner_hash,
+                    ];
+                }
+            }
+            self::assertSame(5, ContractSettlementOwnerVersion::query()->count());
+            self::assertSame(hash('sha256', CanonicalJson::encode([
+                'organization_id' => 1,
+                'completed_at' => $checkpointTimestamp,
+                'owners' => $identities,
+            ])), $checkpoint->source_hash);
+            self::assertSame(0, ContractSettlementOwnerVersion::query()
+                ->where('occurred_at', '<=', ContractSettlementOwnerTimestamp::database(
+                    $checkpoint->completed_at->subMicrosecond(),
+                ))
+                ->count());
+            self::assertSame(5, ContractSettlementOwnerVersion::query()
+                ->where('occurred_at', '<=', ContractSettlementOwnerTimestamp::database(
+                    $checkpoint->completed_at,
+                ))
+                ->count());
+
+            try {
+                $migration->up();
+                self::fail('The foundation migration accepted a second checkpoint.');
+            } catch (\RuntimeException $exception) {
+                self::assertStringContainsString('checkpoint already exists', $exception->getMessage());
+            }
+            self::assertSame(1, ContractSettlementOwnerHistoryCheckpoint::query()->count());
+            self::assertSame(5, ContractSettlementOwnerVersion::query()->count());
+            self::assertSame(1, (int) DB::scalar(<<<'SQL'
+SELECT COUNT(*)
+FROM pg_trigger AS trigger
+INNER JOIN pg_class AS relation ON relation.oid = trigger.tgrelid
+INNER JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+WHERE relation.relname = 'organizations'
+  AND namespace.nspname = current_schema()
+  AND trigger.tgname = 'most_seed_contract_settlement_owner_checkpoint_v1'
+  AND NOT trigger.tgisinternal
+SQL));
+        } finally {
+            DB::statement('RESET search_path');
+            DB::statement('DROP SCHEMA IF EXISTS '.$schema.' CASCADE');
         }
     }
 
@@ -356,5 +618,78 @@ final class FinanceOwnerPostgresContractTest extends TestCase
                 DB::rollBack();
             }
         }
+    }
+
+    private function createContractSettlementFoundationSchema(): void
+    {
+        DB::unprepared(<<<'SQL'
+CREATE TABLE organizations (
+    id bigint PRIMARY KEY,
+    created_at timestamptz(0),
+    updated_at timestamptz(0)
+);
+CREATE TABLE contracts (
+    id bigint PRIMARY KEY,
+    organization_id bigint NOT NULL,
+    is_onboarding_demo boolean NOT NULL DEFAULT false,
+    deleted_at timestamptz(0),
+    created_at timestamptz(0),
+    updated_at timestamptz(0)
+);
+CREATE TABLE contract_project_allocations (
+    id bigint PRIMARY KEY,
+    contract_id bigint NOT NULL,
+    deleted_at timestamptz(0),
+    created_at timestamptz(0),
+    updated_at timestamptz(0)
+);
+CREATE TABLE contract_performance_acts (
+    id bigint PRIMARY KEY,
+    contract_id bigint NOT NULL,
+    created_at timestamptz(0),
+    updated_at timestamptz(0)
+);
+CREATE TABLE payment_documents (
+    id bigint PRIMARY KEY,
+    organization_id bigint NOT NULL,
+    invoiceable_type text,
+    invoiceable_id bigint,
+    deleted_at timestamptz(0),
+    created_at timestamptz(0),
+    updated_at timestamptz(0)
+);
+CREATE TABLE payment_transactions (
+    id bigint PRIMARY KEY,
+    payment_document_id bigint NOT NULL,
+    organization_id bigint NOT NULL,
+    created_at timestamptz(0),
+    updated_at timestamptz(0)
+);
+CREATE TABLE contract_settlement_owner_versions (
+    id bigserial PRIMARY KEY,
+    organization_id bigint NOT NULL,
+    owner_type varchar(48) NOT NULL,
+    owner_id varchar(96) NOT NULL,
+    version integer NOT NULL,
+    operation varchar(16) NOT NULL,
+    occurred_at timestamptz(0) NOT NULL,
+    payload jsonb NOT NULL,
+    owner_hash char(64) NOT NULL,
+    created_at timestamptz(0),
+    updated_at timestamptz(0),
+    CONSTRAINT contract_settlement_owner_version_unique
+        UNIQUE (organization_id, owner_type, owner_id, version)
+);
+CREATE TABLE contract_settlement_owner_history_checkpoints (
+    id bigserial PRIMARY KEY,
+    organization_id bigint NOT NULL,
+    completed_at timestamptz(0) NOT NULL,
+    owner_counts jsonb NOT NULL,
+    source_hash char(64) NOT NULL,
+    created_at timestamptz(0),
+    updated_at timestamptz(0),
+    CONSTRAINT contract_settlement_owner_checkpoint_unique UNIQUE (organization_id)
+);
+SQL);
     }
 }


### PR DESCRIPTION
## Что изменено
- добавлен точный UTC/microsecond-контракт времени owner-history R12
- initial backfill фиксирует все пять owner-типов на одной неизменяемой границе и проверяет counts/hash
- новые организации автоматически получают пустой checkpoint; прошлое до checkpoint не реконструируется
- добавлены статический и изолированный PostgreSQL-контракты, включая non-UTC и повтор миграции

## Проверки
- php -l: 9 затронутых PHP-файлов
- git diff --check
- ручная проверка UTC +03:00 -> +00:00 с сохранением микросекунд
- независимое review: замечания по precision/timezone и PG harness устранены
- PHPUnit/PHPStan локально не запускались: vendor отсутствует; обязательны в CI

## Границы
- отчёт R12 не публикуется этим PR
- миграции локально не запускались

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a table lock for PostgreSQL in the backfill service to ensure data consistency during history backfilling.</li>
<li>Refactored the backfill process to record versions directly instead of checking for existence, improving efficiency.</li>
<li>Introduced a new ContractSettlementOwnerTimestamp utility to standardize timestamp handling for database and canonical formats.</li>
<li>Updated checkpoint and source hash generation to use the new timestamp utility, ensuring consistent reporting data.</li>
<li>Added architecture and feature tests to validate the new reporting contract and PostgreSQL-specific behavior.</li>
</ul></div>