### PR TITLE
fix[backend]: исправлено создание сервиса отчётов

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,7 +36,6 @@ use App\Observers\ScheduleTaskIntervalObserver;
 use App\Observers\ScheduleTaskObserver;
 use App\Observers\TaskDependencyObserver;
 use App\Observers\TaskResourceObserver;
-use App\Services\Export\ExcelExporterService;
 use App\Services\FileService;
 use App\Services\Landing\ChildOrganizationUserService;
 use App\Services\RateCoefficient\RateCoefficientService;
@@ -176,11 +175,6 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(FileService::class, function ($app) {
             return new FileService($app->make(\Illuminate\Contracts\Filesystem\Factory::class));
         });
-        // Регистрируем ExcelExporterService как singleton
-        $this->app->singleton(ExcelExporterService::class, function ($app) {
-            return new ExcelExporterService($app->make(\App\Services\Logging\LoggingService::class));
-        });
-
         // Регистрируем MaterialReportService как singleton
         $this->app->singleton(MaterialReportService::class, function ($app) {
             return new MaterialReportService($app->make(RateCoefficientService::class));

--- a/tests/Unit/Storage/PersonalStorageArchitectureTest.php
+++ b/tests/Unit/Storage/PersonalStorageArchitectureTest.php
@@ -90,4 +90,13 @@ final class PersonalStorageArchitectureTest extends TestCase
             __DIR__.'/../../../app/Console/Commands/CleanupPersonalFilesCommand.php',
         );
     }
+
+    public function test_excel_exporter_is_resolved_with_its_current_dependencies(): void
+    {
+        $provider = file_get_contents(__DIR__.'/../../../app/Providers/AppServiceProvider.php');
+
+        self::assertIsString($provider);
+        self::assertStringNotContainsString('singleton(ExcelExporterService::class', $provider);
+        self::assertStringNotContainsString('new ExcelExporterService(', $provider);
+    }
 }


### PR DESCRIPTION
После перехода персональных отчётов на PersonalFileService старый ручной singleton создавал ExcelExporterService с неполным набором зависимостей. Удалена устаревшая фабрика: Laravel теперь автоматически разрешает актуальный конструктор. Добавлен регрессионный архитектурный тест.

Проверки: PHPUnit 6/6 (50 assertions), PHPStan без ошибок, Pint и php -l чисты.