### PR TITLE
refactor[backend]: AI-отчёты переведены на единое S3-хранилище

### DIFF
--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateContractPaymentsReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateContractPaymentsReportTool.php
@@ -3,24 +3,21 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateContractPaymentsReportTool implements AIToolInterface
 {
     use ReportDateHelper;
 
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -60,6 +57,10 @@ class GenerateContractPaymentsReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $period = (string) ($arguments['period'] ?? 'за этот месяц');
         $dates = $this->extractPeriodFromArguments($arguments, $period);
 
@@ -86,23 +87,13 @@ class GenerateContractPaymentsReportTool implements AIToolInterface
             $content = ob_get_clean();
 
             $filename = 'contract_payments_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет по контрактам и платежам успешно сгенерирован',
                 'period' => $period,
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateContractPaymentsReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateContractorSettlementsReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateContractorSettlementsReportTool.php
@@ -3,24 +3,21 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateContractorSettlementsReportTool implements AIToolInterface
 {
     use ReportDateHelper;
 
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -60,6 +57,10 @@ class GenerateContractorSettlementsReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $period = (string) ($arguments['period'] ?? 'за этот месяц');
         $dates = $this->extractPeriodFromArguments($arguments, $period);
 
@@ -86,23 +87,13 @@ class GenerateContractorSettlementsReportTool implements AIToolInterface
             $content = ob_get_clean();
 
             $filename = 'contractor_settlements_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет по взаиморасчетам с подрядчиками успешно сгенерирован',
                 'period' => $period,
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateContractorSettlementsReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateMaterialMovementsReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateMaterialMovementsReportTool.php
@@ -3,24 +3,21 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateMaterialMovementsReportTool implements AIToolInterface
 {
     use ReportDateHelper;
 
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -60,6 +57,10 @@ class GenerateMaterialMovementsReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $period = (string) ($arguments['period'] ?? 'за этот месяц');
         $dates = $this->extractPeriodFromArguments($arguments, $period);
 
@@ -86,23 +87,13 @@ class GenerateMaterialMovementsReportTool implements AIToolInterface
             $content = ob_get_clean();
 
             $filename = 'material_movements_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет по движению материалов успешно сгенерирован',
                 'period' => $period,
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateMaterialMovementsReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateOperationalPdfReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateOperationalPdfReportTool.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantOperationalReportEnricher;
-use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantOperationalReportService;
 use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantOperationalReportPeriodFilter;
-use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantReportComposerInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantOperationalReportService;
 use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantReportCatalog;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantReportComposerInterface;
 use App\Models\Organization;
 use App\Models\User;
-use App\Services\Storage\FileService;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -25,7 +25,7 @@ final class GenerateOperationalPdfReportTool implements AIToolInterface
         private readonly AssistantReportCatalog $reportCatalog,
         private readonly AssistantReportComposerInterface $reportComposer,
         private readonly AssistantOperationalReportEnricher $reportEnricher,
-        private readonly FileService $fileService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
         private readonly AssistantOperationalReportPeriodFilter $periodFilter = new AssistantOperationalReportPeriodFilter
     ) {}
 
@@ -71,6 +71,13 @@ final class GenerateOperationalPdfReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return [
+                'status' => 'error',
+                'message' => trans_message('errors.unauthenticated'),
+            ];
+        }
+
         $reportType = $this->normalizeReportType($arguments['report_type'] ?? null);
         $period = $this->periodFilter->resolve($arguments);
 
@@ -104,29 +111,14 @@ final class GenerateOperationalPdfReportTool implements AIToolInterface
             ]);
 
             $filename = $reportType.'_report_'.time().'.pdf';
-            $path = $this->fileService->putContent($pdf->output(), 'reports', $filename, 'private', $organization);
-
-            if (! is_string($path)) {
-                throw new \RuntimeException('Не удалось сохранить отчет.');
-            }
-
-            $expiresAt = now()->addHours(24);
-            $url = $this->fileService->temporaryUrl($path, 1440, $organization);
-
-            if (! is_string($url) || $url === '') {
-                throw new \RuntimeException('Не удалось сформировать ссылку на отчет.');
-            }
+            $stored = $this->reportStorage->storePdf($pdf->output(), $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет «'.$definition->label.'» сформирован.',
                 'report_type' => $reportType,
                 'period' => $period['period'],
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (Throwable $throwable) {
             Log::error('AI Tool Error (GenerateOperationalPdfReportTool): '.$throwable->getMessage(), [
@@ -151,8 +143,8 @@ final class GenerateOperationalPdfReportTool implements AIToolInterface
     }
 
     /**
-     * @param array<string, mixed> $arguments
-     * @param array{period: string, date_from: string|null, date_to: string|null, is_explicit: bool} $period
+     * @param  array<string, mixed>  $arguments
+     * @param  array{period: string, date_from: string|null, date_to: string|null, is_explicit: bool}  $period
      * @return array<string, mixed>|null
      */
     private function composeRagReport(
@@ -188,7 +180,7 @@ final class GenerateOperationalPdfReportTool implements AIToolInterface
     }
 
     /**
-     * @param array<string, mixed> $arguments
+     * @param  array<string, mixed>  $arguments
      */
     private function query(array $arguments, string $label): string
     {

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateProfitabilityReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateProfitabilityReportTool.php
@@ -3,24 +3,21 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateProfitabilityReportTool implements AIToolInterface
 {
     use ReportDateHelper;
 
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -60,6 +57,10 @@ class GenerateProfitabilityReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $period = (string) ($arguments['period'] ?? 'за этот месяц');
         $dates = $this->extractPeriodFromArguments($arguments, $period);
 
@@ -87,23 +88,13 @@ class GenerateProfitabilityReportTool implements AIToolInterface
             $content = ob_get_clean();
 
             $filename = 'project_profitability_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет о рентабельности успешно сгенерирован',
                 'period' => $period,
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateProfitabilityReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateProjectTimelinesReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateProjectTimelinesReportTool.php
@@ -3,24 +3,21 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateProjectTimelinesReportTool implements AIToolInterface
 {
     use ReportDateHelper;
 
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -60,6 +57,10 @@ class GenerateProjectTimelinesReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $period = (string) ($arguments['period'] ?? 'за этот месяц');
         $dates = $this->extractPeriodFromArguments($arguments, $period);
 
@@ -86,23 +87,13 @@ class GenerateProjectTimelinesReportTool implements AIToolInterface
             $content = ob_get_clean();
 
             $filename = 'project_timelines_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет по графику работ успешно сформирован',
                 'period' => $period,
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateProjectTimelinesReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateRagPdfReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateRagPdfReportTool.php
@@ -93,6 +93,7 @@ final readonly class GenerateRagPdfReportTool implements AIToolInterface
                 'reports.operational-summary-pdf',
                 ['report' => $this->pdfReport($report, $organization, $user)],
                 $organization,
+                $user,
                 $this->filenamePrefix((string) $input['report_type'])
             );
         } catch (Throwable) {

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateTimeTrackingReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateTimeTrackingReportTool.php
@@ -3,24 +3,21 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateTimeTrackingReportTool implements AIToolInterface
 {
     use ReportDateHelper;
 
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -64,6 +61,10 @@ class GenerateTimeTrackingReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $period = (string) ($arguments['period'] ?? 'за этот месяц');
         $dates = $this->extractPeriodFromArguments($arguments, $period);
 
@@ -101,23 +102,13 @@ class GenerateTimeTrackingReportTool implements AIToolInterface
             }
 
             $filename = 'time_tracking_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет по учету времени успешно сгенерирован',
                 'period' => $period,
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateTimeTrackingReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateWarehouseStockReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateWarehouseStockReportTool.php
@@ -3,22 +3,19 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateWarehouseStockReportTool implements AIToolInterface
 {
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -46,6 +43,10 @@ class GenerateWarehouseStockReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $requestData = [
             'format' => 'pdf',
         ];
@@ -67,22 +68,12 @@ class GenerateWarehouseStockReportTool implements AIToolInterface
             $content = ob_get_clean();
 
             $filename = 'warehouse_stock_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет по остаткам на складах успешно сгенерирован',
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateWarehouseStockReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateWorkCompletionReportTool.php
+++ b/app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools/GenerateWorkCompletionReportTool.php
@@ -3,24 +3,21 @@
 namespace App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools;
 
 use App\BusinessModules\Features\AIAssistant\Contracts\AIToolInterface;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
-use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class GenerateWorkCompletionReportTool implements AIToolInterface
 {
     use ReportDateHelper;
 
-    protected ReportService $reportService;
-
-    public function __construct(ReportService $reportService)
-    {
-        $this->reportService = $reportService;
-    }
+    public function __construct(
+        protected ReportService $reportService,
+        private readonly AssistantGeneratedReportStorage $reportStorage,
+    ) {}
 
     public function getName(): string
     {
@@ -60,6 +57,10 @@ class GenerateWorkCompletionReportTool implements AIToolInterface
 
     public function execute(array $arguments, ?User $user, Organization $organization): array|string
     {
+        if (! $user instanceof User) {
+            return ['status' => 'error', 'message' => trans_message('errors.unauthenticated')];
+        }
+
         $period = (string) ($arguments['period'] ?? 'за этот месяц');
         $dates = $this->extractPeriodFromArguments($arguments, $period);
 
@@ -86,23 +87,13 @@ class GenerateWorkCompletionReportTool implements AIToolInterface
             $content = ob_get_clean();
 
             $filename = 'work_completion_report_'.time().'.pdf';
-            $path = OrganizationStoragePath::forOrganization($organization->id, "reports/{$filename}");
-
-            if (Storage::disk('s3')->put($path, $content) !== true) {
-                throw new \RuntimeException('Не удалось сохранить отчет в S3.');
-            }
-            $expiresAt = now()->addHours(24);
-            $url = Storage::disk('s3')->temporaryUrl($path, $expiresAt);
+            $stored = $this->reportStorage->storePdf((string) $content, $filename, $organization, $user);
 
             return [
                 'status' => 'success',
                 'message' => 'Отчет по выполненным работам успешно сгенерирован',
                 'period' => $period,
-                'pdf_url' => $url,
-                'filename' => $filename,
-                'storage_disk' => 's3',
-                'storage_path' => $path,
-                'expires_at' => $expiresAt->toIso8601String(),
+                ...$stored,
             ];
         } catch (\Exception $e) {
             Log::error('AI Tool Error (GenerateWorkCompletionReportTool): '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);

--- a/app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantGeneratedReportStorage.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantGeneratedReportStorage.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\AIAssistant\Services\Reports;
+
+use App\Models\Organization;
+use App\Models\User;
+use App\Services\Storage\FileService;
+use App\Services\Storage\PersonalFileService;
+use RuntimeException;
+
+class AssistantGeneratedReportStorage
+{
+    private const DIRECTORY = 'reports/assistant';
+
+    public function __construct(
+        private readonly PersonalFileService $personalFiles,
+        private readonly FileService $files,
+    ) {}
+
+    /**
+     * @return array{pdf_url: string, filename: string, storage_disk: string, storage_path: string, expires_at: null, size: int}
+     */
+    public function storePdf(
+        string $content,
+        string $filename,
+        Organization $organization,
+        User $user,
+    ): array {
+        $stream = fopen('php://temp', 'w+b');
+        if (! is_resource($stream)) {
+            throw new RuntimeException('assistant_report_stream_failed');
+        }
+
+        try {
+            if (fwrite($stream, $content) !== strlen($content) || rewind($stream) !== true) {
+                throw new RuntimeException('assistant_report_stream_failed');
+            }
+
+            $personalFile = $this->personalFiles->storeStream(
+                (int) $organization->id,
+                (int) $user->id,
+                $stream,
+                basename($filename),
+                'application/pdf',
+                self::DIRECTORY,
+            );
+        } finally {
+            fclose($stream);
+        }
+
+        $storageKey = (string) $personalFile->storage_key;
+
+        return [
+            'pdf_url' => $this->files->temporaryDownloadUrl(
+                $storageKey,
+                (int) config('filesystems.s3.download_ttl_seconds'),
+            ),
+            'filename' => (string) $personalFile->original_name,
+            'storage_disk' => 's3',
+            'storage_path' => $storageKey,
+            'expires_at' => null,
+            'size' => (int) $personalFile->size,
+        ];
+    }
+}

--- a/app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantReportFileService.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantReportFileService.php
@@ -10,7 +10,6 @@ use App\Models\Organization;
 use App\Models\ReportFile;
 use App\Models\User;
 use App\Services\Storage\FileService;
-use Carbon\CarbonInterface;
 use Illuminate\Support\Str;
 
 final readonly class AssistantReportFileService
@@ -28,7 +27,7 @@ final readonly class AssistantReportFileService
     ) {}
 
     /**
-     * @param array<string, mixed> $arguments
+     * @param  array<string, mixed>  $arguments
      * @return array<int, array<string, mixed>>
      */
     public function artifactsFromToolResult(
@@ -48,8 +47,8 @@ final readonly class AssistantReportFileService
     }
 
     /**
-     * @param array<string, mixed> $data
-     * @param array<string, mixed> $arguments
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $arguments
      */
     private function artifactFromArray(
         string $toolName,
@@ -58,10 +57,18 @@ final readonly class AssistantReportFileService
         ?User $user,
         array $arguments
     ): ?AssistantReportArtifact {
+        if (! $user instanceof User) {
+            return null;
+        }
+
         $storageDisk = $this->optionalString($data['storage_disk'] ?? null);
         $storagePath = $this->optionalString($data['storage_path'] ?? null);
 
-        if ($storageDisk !== 's3' || $storagePath === null || ! $this->belongsToOrganizationReports($storagePath, $organization)) {
+        if (
+            $storageDisk !== 's3'
+            || $storagePath === null
+            || ! $this->belongsToOrganizationReports($storagePath, $organization, $user)
+        ) {
             return null;
         }
 
@@ -71,15 +78,13 @@ final readonly class AssistantReportFileService
         }
 
         $filename = $this->filename($data, $storagePath);
-        $expiresAt = $this->expiresAt($data);
+        $expiresAt = null;
         $definition = $this->definitionForArtifact($toolName, $data, $arguments);
         $type = self::URL_KEYS[$urlKey] ?? $definition?->artifactType ?? 'file';
-        $downloadUrl = $this->fileService->temporaryUrl($storagePath, 24 * 60, $organization)
-            ?? $this->optionalString($data[$urlKey] ?? null);
-
-        if ($downloadUrl === null || $downloadUrl === '') {
-            return null;
-        }
+        $downloadUrl = $this->fileService->temporaryDownloadUrl(
+            $storagePath,
+            (int) config('filesystems.s3.download_ttl_seconds'),
+        );
 
         $reportFile = ReportFile::query()->updateOrCreate(
             [
@@ -91,8 +96,8 @@ final readonly class AssistantReportFileService
                 'filename' => $filename,
                 'name' => $filename,
                 'size' => $this->optionalInt($data['size'] ?? null) ?? 0,
-                'expires_at' => $expiresAt,
-                'user_id' => $user?->id,
+                'expires_at' => null,
+                'user_id' => $user->id,
             ]
         );
 
@@ -111,8 +116,8 @@ final readonly class AssistantReportFileService
     }
 
     /**
-     * @param array<string, mixed> $data
-     * @param array<string, mixed> $arguments
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $arguments
      */
     private function definitionForArtifact(string $toolName, array $data, array $arguments): ?AssistantReportDefinition
     {
@@ -131,7 +136,7 @@ final readonly class AssistantReportFileService
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      */
     private function firstUrlKey(array $data): ?string
     {
@@ -144,13 +149,16 @@ final readonly class AssistantReportFileService
         return null;
     }
 
-    private function belongsToOrganizationReports(string $path, Organization $organization): bool
+    private function belongsToOrganizationReports(string $path, Organization $organization, User $user): bool
     {
-        return str_starts_with($path, 'org-'.((int) $organization->id).'/reports/');
+        return str_starts_with(
+            $path,
+            'org-'.((int) $organization->id).'/personal-files/user-'.((int) $user->id).'/',
+        );
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param  array<string, mixed>  $data
      */
     private function filename(array $data, string $storagePath): string
     {
@@ -165,21 +173,7 @@ final readonly class AssistantReportFileService
     }
 
     /**
-     * @param array<string, mixed> $data
-     */
-    private function expiresAt(array $data): ?string
-    {
-        $value = $data['expires_at'] ?? null;
-
-        if ($value instanceof CarbonInterface) {
-            return $value->toIso8601String();
-        }
-
-        return $this->optionalString($value);
-    }
-
-    /**
-     * @param array<string, mixed> $arguments
+     * @param  array<string, mixed>  $arguments
      * @return array<string, mixed>
      */
     private function filters(array $arguments): array

--- a/app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantReportPdfWriterInterface.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantReportPdfWriterInterface.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\AIAssistant\Services\Reports;
 
 use App\Models\Organization;
+use App\Models\User;
 
 interface AssistantReportPdfWriterInterface
 {
     /**
-     * @param array<string, mixed> $data
-     * @return array{pdf_url: string, filename: string, storage_disk: string, storage_path: string, expires_at: string, size: int}
+     * @param  array<string, mixed>  $data
+     * @return array{pdf_url: string, filename: string, storage_disk: string, storage_path: string, expires_at: null, size: int}
      */
-    public function store(string $view, array $data, Organization $organization, string $filenamePrefix): array;
+    public function store(
+        string $view,
+        array $data,
+        Organization $organization,
+        User $user,
+        string $filenamePrefix,
+    ): array;
 }

--- a/app/BusinessModules/Features/AIAssistant/Services/Reports/DompdfAssistantReportPdfWriter.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Reports/DompdfAssistantReportPdfWriter.php
@@ -5,18 +5,22 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\AIAssistant\Services\Reports;
 
 use App\Models\Organization;
-use App\Services\Storage\FileService;
+use App\Models\User;
 use Barryvdh\DomPDF\Facade\Pdf;
-use RuntimeException;
 
 final readonly class DompdfAssistantReportPdfWriter implements AssistantReportPdfWriterInterface
 {
     public function __construct(
-        private FileService $fileService
+        private AssistantGeneratedReportStorage $reportStorage,
     ) {}
 
-    public function store(string $view, array $data, Organization $organization, string $filenamePrefix): array
-    {
+    public function store(
+        string $view,
+        array $data,
+        Organization $organization,
+        User $user,
+        string $filenamePrefix,
+    ): array {
         $pdf = Pdf::loadView($view, $data);
         $pdf->setPaper('a4', 'portrait');
         $pdf->setOptions([
@@ -27,27 +31,8 @@ final readonly class DompdfAssistantReportPdfWriter implements AssistantReportPd
 
         $content = $pdf->output();
         $filename = $this->filename($filenamePrefix);
-        $path = $this->fileService->putContent($content, 'reports', $filename, 'private', $organization);
 
-        if (! is_string($path)) {
-            throw new RuntimeException('Не удалось сохранить отчет.');
-        }
-
-        $expiresAt = now()->addHours(24);
-        $url = $this->fileService->temporaryUrl($path, 1440, $organization);
-
-        if (! is_string($url) || $url === '') {
-            throw new RuntimeException('Не удалось сформировать ссылку на отчет.');
-        }
-
-        return [
-            'pdf_url' => $url,
-            'filename' => $filename,
-            'storage_disk' => 's3',
-            'storage_path' => $path,
-            'expires_at' => $expiresAt->toIso8601String(),
-            'size' => strlen($content),
-        ];
+        return $this->reportStorage->storePdf($content, $filename, $organization, $user);
     }
 
     private function filename(string $filenamePrefix): string

--- a/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
+++ b/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
@@ -279,11 +279,13 @@ APP_ENV=testing vendor/bin/phpstan analyse app/Http/Controllers/Api/V1/Admin/Per
 
 DB-backed feature-тесты обновлены, но локально не запускаются по правилам workspace; их применит штатный CI/deploy. Миграция проверяется только синтаксически и не запускается вручную.
 
-- [ ] **Step 6: Commit, PR, merge и deploy**
+- [x] **Step 6: Commit, PR, merge и deploy**
 
 Commit: `refactor[backend]: файлы привязаны к организации и пользователю`.
 
 После deploy проверить создание/выдачу/удаление нового временного файла через прикладной smoke без сохранения секрета.
+
+Выполнено в PR #238 (`274ced1d8456b9eb787de75f6238f9262ae69496`), штатный deploy `31055973102` завершён успешно. Исправление DI для `ExcelExporterService` доставлено PR #239 (`276ab2a6cefeb95cf5987253dd332716c9a9e951`), deploy `31056538177` успешен; production SHA совпал, профильных ошибок в последних 500 строках лога нет.
 
 ---
 
@@ -303,6 +305,22 @@ Commit: `refactor[backend]: файлы привязаны к организац�
 **Interfaces:**
 - Consumes: `OrganizationStoragePath` и текущие-object методы `FileService`.
 - Produces: все актуальные домены передают только организационный ключ и не выбирают S3-диск или бакет.
+
+#### Task 3B.1: AI-отчёты
+
+**PR:** `refactor/timeweb-s3-ai-reports`
+
+- [x] **Step 1: Написать failing архитектурные и доменные тесты**
+- [x] **Step 2: Проверить RED**
+- [x] **Step 3: Перевести AI-отчёты на `PersonalFileService` и текущие-object методы `FileService`**
+- [x] **Step 4: Проверить GREEN и отсутствие прямого доступа к S3**
+- [ ] **Step 5: Commit, PR, merge и deploy**
+
+AI-отчёты сохраняются бессрочно по ключу `org-{organization_id}/personal-files/user-{user_id}/{uuid}.pdf`; временной является только download URL. Прямые вызовы `Storage::disk('s3')`, старый каталог `org-{id}/reports` и выбор диска удалены из генераторов.
+
+#### Task 3B.2: Остальные доменные вызовы
+
+**PR:** `refactor/timeweb-s3-domain-callers`
 
 - [ ] **Step 1: Написать failing архитектурные и доменные тесты**
 - [ ] **Step 2: Проверить RED**

--- a/tests/Unit/AIAssistant/Reports/AssistantReportFileServiceTest.php
+++ b/tests/Unit/AIAssistant/Reports/AssistantReportFileServiceTest.php
@@ -21,12 +21,13 @@ final class AssistantReportFileServiceTest extends TestCase
     {
         $organization = Organization::factory()->create();
         $user = User::factory()->create(['current_organization_id' => $organization->id]);
-        $path = 'org-'.$organization->id.'/reports/timeline.pdf';
+        $path = 'org-'.$organization->id.'/personal-files/user-'.$user->id.'/01989f5c-27f3-7ab8-9e34-5d436c15a004.pdf';
+        config()->set('filesystems.s3.download_ttl_seconds', 900);
         $fileService = Mockery::mock(FileService::class);
         $fileService
-            ->shouldReceive('temporaryUrl')
+            ->shouldReceive('temporaryDownloadUrl')
             ->once()
-            ->with($path, 1440, Mockery::on(static fn (Organization $value): bool => (int) $value->id === (int) $organization->id))
+            ->with($path, 900)
             ->andReturn('https://files.example.test/timeline.pdf');
 
         $service = new AssistantReportFileService($fileService);
@@ -39,7 +40,6 @@ final class AssistantReportFileServiceTest extends TestCase
                 'filename' => 'timeline.pdf',
                 'storage_disk' => 's3',
                 'storage_path' => $path,
-                'expires_at' => '2026-05-21T12:00:00+03:00',
             ],
             $organization,
             $user,
@@ -54,6 +54,7 @@ final class AssistantReportFileServiceTest extends TestCase
         $this->assertSame('pdf', $artifacts[0]['type']);
         $this->assertSame('https://files.example.test/timeline.pdf', $artifacts[0]['download_url']);
         $this->assertSame($path, $artifacts[0]['storage_path']);
+        $this->assertNull($artifacts[0]['expires_at']);
         $this->assertSame('project_timelines', $artifacts[0]['report_type']);
         $this->assertSame(12, $artifacts[0]['filters']['project_id']);
         $this->assertDatabaseHas('report_files', [
@@ -62,14 +63,16 @@ final class AssistantReportFileServiceTest extends TestCase
             'filename' => 'timeline.pdf',
             'type' => 'reports',
             'user_id' => $user->id,
+            'expires_at' => null,
         ]);
     }
 
     public function test_rejects_artifact_without_organization_report_storage_evidence(): void
     {
         $organization = Organization::factory()->create();
+        $user = User::factory()->create(['current_organization_id' => $organization->id]);
         $fileService = Mockery::mock(FileService::class);
-        $fileService->shouldNotReceive('temporaryUrl');
+        $fileService->shouldNotReceive('temporaryDownloadUrl');
 
         $service = new AssistantReportFileService($fileService);
 
@@ -80,10 +83,10 @@ final class AssistantReportFileServiceTest extends TestCase
                 'pdf_url' => 'https://storage.example.test/timeline.pdf',
                 'filename' => 'timeline.pdf',
                 'storage_disk' => 's3',
-                'storage_path' => 'org-999/reports/timeline.pdf',
+                'storage_path' => 'org-999/personal-files/user-'.$user->id.'/timeline.pdf',
             ],
             $organization,
-            null,
+            $user,
             []
         );
 

--- a/tests/Unit/AIAssistant/Reports/GenerateContractPaymentsReportToolTest.php
+++ b/tests/Unit/AIAssistant/Reports/GenerateContractPaymentsReportToolTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit\AIAssistant\Reports;
 
 use App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools\GenerateContractPaymentsReportTool;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Facades\Storage;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -21,7 +20,6 @@ final class GenerateContractPaymentsReportToolTest extends TestCase
     protected function tearDown(): void
     {
         Carbon::setTestNow();
-        Facade::clearResolvedInstance('filesystem');
         Mockery::close();
 
         parent::tearDown();
@@ -53,21 +51,26 @@ final class GenerateContractPaymentsReportToolTest extends TestCase
                 echo '%PDF-contract-payments';
             }));
 
-        $disk = Mockery::mock();
-        $disk
-            ->shouldReceive('put')
+        $reportStorage = Mockery::mock(AssistantGeneratedReportStorage::class);
+        $reportStorage
+            ->shouldReceive('storePdf')
             ->once()
-            ->with(Mockery::pattern('/^org-77\/reports\/contract_payments_report_\d+\.pdf$/'), '%PDF-contract-payments')
-            ->andReturn(true);
-        $disk
-            ->shouldReceive('temporaryUrl')
-            ->once()
-            ->with(Mockery::type('string'), Mockery::type(\DateTimeInterface::class))
-            ->andReturn('https://storage.example.test/contract-payments.pdf');
+            ->with(
+                '%PDF-contract-payments',
+                Mockery::pattern('/^contract_payments_report_\d+\.pdf$/'),
+                $organization,
+                $user,
+            )
+            ->andReturn([
+                'pdf_url' => 'https://storage.example.test/contract-payments.pdf',
+                'filename' => 'contract-payments.pdf',
+                'storage_disk' => 's3',
+                'storage_path' => 'org-77/personal-files/user-12/report.pdf',
+                'expires_at' => null,
+                'size' => 22,
+            ]);
 
-        Storage::shouldReceive('disk')->twice()->with('s3')->andReturn($disk);
-
-        $result = (new GenerateContractPaymentsReportTool($reportService))->execute([
+        $result = (new GenerateContractPaymentsReportTool($reportService, $reportStorage))->execute([
             'period' => 'с начала проекта по сегодняшний день',
             'date_to' => '2026-05-04',
             'project_id' => 56,
@@ -75,6 +78,7 @@ final class GenerateContractPaymentsReportToolTest extends TestCase
 
         $this->assertSame('success', $result['status']);
         $this->assertSame('https://storage.example.test/contract-payments.pdf', $result['pdf_url']);
-        $this->assertSame('org-77/reports/'.$result['filename'], $result['storage_path']);
+        $this->assertSame('org-77/personal-files/user-12/report.pdf', $result['storage_path']);
+        $this->assertNull($result['expires_at']);
     }
 }

--- a/tests/Unit/AIAssistant/Reports/GenerateRagPdfReportToolTest.php
+++ b/tests/Unit/AIAssistant/Reports/GenerateRagPdfReportToolTest.php
@@ -66,8 +66,10 @@ final class GenerateRagPdfReportToolTest extends TestCase
         $this->assertSame('Проект находится в работе, есть риск задержки поставки.', $writer->data['report']['key_findings'][0]);
         $this->assertSame('Факты', $writer->data['report']['summary_cards'][1]['label']);
         $this->assertSame('Действия', $writer->data['report']['summary_cards'][3]['label']);
+        $this->assertSame(7, $writer->userId);
         $this->assertSame('s3', $result['storage_disk']);
-        $this->assertStringStartsWith('org-72/reports/', $result['storage_path']);
+        $this->assertStringStartsWith('org-72/personal-files/user-7/', $result['storage_path']);
+        $this->assertNull($result['expires_at']);
     }
 
     public function test_does_not_create_pdf_when_rag_sources_are_missing(): void
@@ -141,23 +143,31 @@ final class FakeAssistantReportPdfWriter implements AssistantReportPdfWriterInte
 
     public ?string $view = null;
 
+    public ?int $userId = null;
+
     /**
      * @var array<string, mixed>
      */
     public array $data = [];
 
-    public function store(string $view, array $data, Organization $organization, string $filenamePrefix): array
-    {
+    public function store(
+        string $view,
+        array $data,
+        Organization $organization,
+        User $user,
+        string $filenamePrefix,
+    ): array {
         $this->stored = true;
         $this->view = $view;
         $this->data = $data;
+        $this->userId = (int) $user->id;
 
         return [
-            'pdf_url' => 'https://storage.example.test/org-72/reports/'.$filenamePrefix.'.pdf',
+            'pdf_url' => 'https://storage.example.test/org-72/personal-files/user-7/'.$filenamePrefix.'.pdf',
             'filename' => $filenamePrefix.'.pdf',
             'storage_disk' => 's3',
-            'storage_path' => 'org-72/reports/'.$filenamePrefix.'.pdf',
-            'expires_at' => '2026-07-02T12:00:00+03:00',
+            'storage_path' => 'org-72/personal-files/user-7/'.$filenamePrefix.'.pdf',
+            'expires_at' => null,
             'size' => 1234,
         ];
     }

--- a/tests/Unit/AIAssistant/Reports/GenerateWarehouseStockReportToolTest.php
+++ b/tests/Unit/AIAssistant/Reports/GenerateWarehouseStockReportToolTest.php
@@ -5,21 +5,32 @@ declare(strict_types=1);
 namespace Tests\Unit\AIAssistant\Reports;
 
 use App\BusinessModules\Features\AIAssistant\Actions\Reports\Tools\GenerateWarehouseStockReportTool;
+use App\BusinessModules\Features\AIAssistant\Services\Reports\AssistantGeneratedReportStorage;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Report\ReportService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Storage;
 use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Tests\TestCase;
 
 final class GenerateWarehouseStockReportToolTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
     public function test_requests_stock_report_without_asset_type_restriction(): void
     {
-        $organization = Organization::factory()->make(['id' => 77]);
-        $user = User::factory()->make(['id' => 12, 'current_organization_id' => 77]);
+        $organization = new Organization;
+        $organization->id = 77;
+
+        $user = new User;
+        $user->id = 12;
+        $user->current_organization_id = 77;
         $reportService = Mockery::mock(ReportService::class);
 
         $reportService
@@ -34,21 +45,26 @@ final class GenerateWarehouseStockReportToolTest extends TestCase
                 echo '%PDF';
             }));
 
-        $disk = Mockery::mock();
-        $disk
-            ->shouldReceive('put')
+        $reportStorage = Mockery::mock(AssistantGeneratedReportStorage::class);
+        $reportStorage
+            ->shouldReceive('storePdf')
             ->once()
-            ->with(Mockery::pattern('/^org-77\/reports\/warehouse_stock_report_\d+\.pdf$/'), '%PDF')
-            ->andReturn(true);
-        $disk
-            ->shouldReceive('temporaryUrl')
-            ->once()
-            ->with(Mockery::type('string'), Mockery::type(\DateTimeInterface::class))
-            ->andReturn('https://storage.example.test/report.pdf');
+            ->with(
+                '%PDF',
+                Mockery::pattern('/^warehouse_stock_report_\d+\.pdf$/'),
+                $organization,
+                $user,
+            )
+            ->andReturn([
+                'pdf_url' => 'https://storage.example.test/report.pdf',
+                'filename' => 'warehouse-stock.pdf',
+                'storage_disk' => 's3',
+                'storage_path' => 'org-77/personal-files/user-12/report.pdf',
+                'expires_at' => null,
+                'size' => 4,
+            ]);
 
-        Storage::shouldReceive('disk')->twice()->with('s3')->andReturn($disk);
-
-        $result = (new GenerateWarehouseStockReportTool($reportService))->execute([], $user, $organization);
+        $result = (new GenerateWarehouseStockReportTool($reportService, $reportStorage))->execute([], $user, $organization);
 
         $this->assertSame('success', $result['status']);
         $this->assertSame('https://storage.example.test/report.pdf', $result['pdf_url']);

--- a/tests/Unit/Storage/AssistantReportStorageArchitectureTest.php
+++ b/tests/Unit/Storage/AssistantReportStorageArchitectureTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Storage;
+
+use PHPUnit\Framework\TestCase;
+
+final class AssistantReportStorageArchitectureTest extends TestCase
+{
+    public function test_generated_reports_use_personal_storage_gateway(): void
+    {
+        $service = file_get_contents(
+            __DIR__.'/../../../app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantGeneratedReportStorage.php',
+        );
+
+        self::assertIsString($service);
+        self::assertStringContainsString('PersonalFileService', $service);
+        self::assertStringContainsString('storeStream(', $service);
+        self::assertStringContainsString('temporaryDownloadUrl(', $service);
+        self::assertStringContainsString("'expires_at' => null", $service);
+        self::assertStringNotContainsString('Storage::', $service);
+        self::assertStringNotContainsString('->disk(', $service);
+    }
+
+    public function test_report_tools_do_not_access_s3_directly(): void
+    {
+        $directory = __DIR__.'/../../../app/BusinessModules/Features/AIAssistant/Actions/Reports/Tools';
+        $files = glob($directory.'/Generate*ReportTool.php');
+
+        self::assertIsArray($files);
+        self::assertNotEmpty($files);
+
+        foreach ($files as $file) {
+            $source = file_get_contents($file);
+
+            self::assertIsString($source);
+            self::assertStringNotContainsString('Storage::', $source, $file);
+            self::assertStringNotContainsString('OrganizationStoragePath::', $source, $file);
+        }
+    }
+
+    public function test_pdf_writer_requires_the_report_owner(): void
+    {
+        $interface = file_get_contents(
+            __DIR__.'/../../../app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantReportPdfWriterInterface.php',
+        );
+        $writer = file_get_contents(
+            __DIR__.'/../../../app/BusinessModules/Features/AIAssistant/Services/Reports/DompdfAssistantReportPdfWriter.php',
+        );
+
+        self::assertIsString($interface);
+        self::assertIsString($writer);
+        self::assertStringContainsString('User $user', $interface);
+        self::assertStringContainsString('AssistantGeneratedReportStorage', $writer);
+        self::assertStringNotContainsString('putContent(', $writer);
+        self::assertStringNotContainsString('temporaryUrl(', $writer);
+    }
+
+    public function test_report_artifacts_are_current_objects_scoped_to_organization_and_user(): void
+    {
+        $service = file_get_contents(
+            __DIR__.'/../../../app/BusinessModules/Features/AIAssistant/Services/Reports/AssistantReportFileService.php',
+        );
+
+        self::assertIsString($service);
+        self::assertStringContainsString("'/personal-files/user-'", $service);
+        self::assertStringContainsString('temporaryDownloadUrl(', $service);
+        self::assertStringContainsString("'expires_at' => null", $service);
+        self::assertStringNotContainsString('temporaryUrl(', $service);
+    }
+}


### PR DESCRIPTION
## Что изменено
- все AI PDF-отчёты сохраняются через PersonalFileService в единый приватный бакет
- ключи отчётов привязаны к организации и владельцу: org-{organization_id}/personal-files/user-{user_id}/{uuid}.pdf
- прямые Storage::disk('s3'), старый org-{id}/reports и отдельная логика срока хранения удалены
- записи отчётов бессрочные; ограничен только срок подписанной ссылки
- контракт PDF writer теперь явно требует User

## Проверки
- PHPUnit: 8 тестов, 74 assertions
- PHPStan/Larastan: production-код и изменённые тесты без ошибок
- Pint: изменённые PHP-файлы
- архитектурный тест подтверждает отсутствие прямого S3-доступа в AI reports

## Деплой
После merge используется существующий штатный deploy. Новых workflow и инфраструктуры нет.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Removed the 'Contract Settlement Exposure' report from the core reporting infrastructure and registries.</li>
<li>Updated middleware and service provider configurations to reflect the removal of the report.</li>
<li>Deleted associated reporting services, binding factories, and registrar classes related to contract settlement exposure.</li>
<li>Updated and removed corresponding unit and architecture tests.</li>
</ul></div>