### PR TITLE
refactor[backend]: хранилище смет переведено на единый S3

### DIFF
--- a/app/BusinessModules/Features/BudgetEstimates/Jobs/GenerateEstimateSnapshotJob.php
+++ b/app/BusinessModules/Features/BudgetEstimates/Jobs/GenerateEstimateSnapshotJob.php
@@ -6,6 +6,7 @@ namespace App\BusinessModules\Features\BudgetEstimates\Jobs;
 
 use App\BusinessModules\Features\BudgetEstimates\Services\EstimateStructureSnapshotStorage;
 use App\Models\Estimate;
+use App\Services\Storage\OrganizationStoragePath;
 use App\Support\EstimatePositionOrder;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -14,6 +15,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class GenerateEstimateSnapshotJob implements ShouldQueue
 {
@@ -32,20 +34,20 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
     {
         try {
             $estimate = Estimate::find($this->estimateId);
-            
-            if (!$estimate) {
+
+            if (! $estimate) {
                 return;
             }
 
             Log::info("Starting snapshot generation for estimate {$this->estimateId}");
 
-            // 1. Извлекаем данные через Query Builder (Raw Arrays). 
+            // 1. Извлекаем данные через Query Builder (Raw Arrays).
             // Отказ от Eloquent Hydration дает ускорение на 1-2 порядка.
             $sections = DB::table('estimate_sections')
                 ->where('estimate_id', $this->estimateId)
                 ->orderBy('sort_order')
                 ->get()
-                ->map(fn($item) => (array) $item)
+                ->map(fn ($item) => (array) $item)
                 ->toArray();
 
             $items = EstimatePositionOrder::apply(
@@ -54,24 +56,24 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
             )
                 ->orderBy('id', 'asc')
                 ->get()
-                ->map(fn($item) => (array) $item)
+                ->map(fn ($item) => (array) $item)
                 ->toArray();
 
             $itemIds = array_column($items, 'id');
-            
+
             // Если позиций нет, нет смысла искать связи
             if (empty($itemIds)) {
                 $resourcesByItemId = [];
                 $totalsByItemId = [];
-                $worksByItemId = []; 
+                $worksByItemId = [];
                 $contractLinksByItemId = [];
             } else {
                 // Извлекаем связанные данные оптом
                 $resourcesChunks = DB::table('estimate_item_resources')
                     ->whereIn('estimate_item_id', $itemIds)
                     ->get()
-                    ->map(fn($r) => (array) $r);
-                
+                    ->map(fn ($r) => (array) $r);
+
                 $resourcesByItemId = [];
                 foreach ($resourcesChunks as $res) {
                     $resourcesByItemId[$res['estimate_item_id']][] = $res;
@@ -80,19 +82,19 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
                 $totalsChunks = DB::table('estimate_item_totals')
                     ->whereIn('estimate_item_id', $itemIds)
                     ->get()
-                    ->map(fn($t) => (array) $t);
-                    
+                    ->map(fn ($t) => (array) $t);
+
                 $totalsByItemId = [];
                 foreach ($totalsChunks as $tot) {
                     $totalsByItemId[$tot['estimate_item_id']][] = $tot;
                 }
-                
+
                 // Works can be loaded similarly if EstimateItem has 'works' relation
                 $worksChunks = DB::table('estimate_item_works')
                     ->whereIn('estimate_item_id', $itemIds)
                     ->get()
-                    ->map(fn($w) => (array) $w);
-                    
+                    ->map(fn ($w) => (array) $w);
+
                 $worksByItemId = [];
                 foreach ($worksChunks as $work) {
                     $worksByItemId[$work['estimate_item_id']][] = $work;
@@ -108,7 +110,7 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
                         'contracts.number as contract_number',
                         'contractors.name as contractor_name',
                     ])
-                    ->map(fn($link) => (array) $link);
+                    ->map(fn ($link) => (array) $link);
 
                 $contractLinksByItemId = [];
                 foreach ($contractLinks as $link) {
@@ -121,7 +123,7 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
             }
 
             $workTypes = DB::table('work_types')->pluck('name', 'id')->toArray();
-            
+
             $units = DB::table('measurement_units')->get(['id', 'short_name', 'name'])->keyBy('id');
 
             // 2. Сборка дерева O(N) в памяти ссылками
@@ -137,19 +139,19 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
                 $item['works'] = $worksByItemId[$item['id']] ?? [];
                 $item['contract_links'] = $contractLinksByItemId[$item['id']] ?? [];
                 $item['children'] = []; // В EstimateItemResource это 'children'
-                
+
                 // Append simple relations
-                $item['work_type'] = isset($item['work_type_id']) && isset($workTypes[$item['work_type_id']]) 
+                $item['work_type'] = isset($item['work_type_id']) && isset($workTypes[$item['work_type_id']])
                     ? ['id' => $item['work_type_id'], 'name' => $workTypes[$item['work_type_id']]] : null;
-                    
+
                 $unit = isset($item['measurement_unit_id']) ? $units->get($item['measurement_unit_id']) : null;
                 $item['measurement_unit'] = $unit ? [
-                    'id' => $unit->id, 
+                    'id' => $unit->id,
                     'short_name' => $unit->short_name,
-                    'name' => $unit->name
+                    'name' => $unit->name,
                 ] : null;
 
-                $itemsById[$item['id']] =& $item;
+                $itemsById[$item['id']] = &$item;
             }
 
             // Связываем items внутри других items (Sub-items)
@@ -157,15 +159,15 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
             $rootItemsWithoutSection = [];
 
             foreach ($items as &$item) {
-                if (!empty($item['parent_item_id'])) {
+                if (! empty($item['parent_item_id'])) {
                     if (isset($itemsById[$item['parent_item_id']])) {
-                        $itemsById[$item['parent_item_id']]['children'][] =& $item;
+                        $itemsById[$item['parent_item_id']]['children'][] = &$item;
                     }
                 } else {
-                    if (!empty($item['estimate_section_id'])) {
-                        $rootItemsWithSection[$item['estimate_section_id']][] =& $item;
+                    if (! empty($item['estimate_section_id'])) {
+                        $rootItemsWithSection[$item['estimate_section_id']][] = &$item;
                     } else {
-                        $rootItemsWithoutSection[] =& $item;
+                        $rootItemsWithoutSection[] = &$item;
                     }
                 }
             }
@@ -175,17 +177,17 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
                 $section['section_total_amount_with_vat'] = round((float) ($section['section_total_amount'] ?? 0) * $vatMultiplier, 2);
                 $section['items'] = $rootItemsWithSection[$section['id']] ?? [];
                 $section['children'] = [];
-                $sectionsById[$section['id']] =& $section;
+                $sectionsById[$section['id']] = &$section;
             }
 
             $tree = [];
             foreach ($sections as &$section) {
-                if (!empty($section['parent_section_id'])) {
+                if (! empty($section['parent_section_id'])) {
                     if (isset($sectionsById[$section['parent_section_id']])) {
-                        $sectionsById[$section['parent_section_id']]['children'][] =& $section;
+                        $sectionsById[$section['parent_section_id']]['children'][] = &$section;
                     }
                 } else {
-                    $tree[] =& $section;
+                    $tree[] = &$section;
                 }
             }
 
@@ -199,25 +201,18 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
             ];
 
             // 3. Сохранение в Storage
-            $versionTimestamp = now()->getTimestamp();
-            
             // Распределяем файлы по папкам организаций, как это делает FileService
-            $orgId = $estimate->organization_id;
-            $orgPrefix = $orgId ? "org-{$orgId}" : 'shared';
-            $fileName = "{$orgPrefix}/estimates/{$this->estimateId}/structure_snapshot_{$versionTimestamp}.json";
-            
-            // Запись огромного JSON
-            $snapshotJson = json_encode($payload, JSON_UNESCAPED_UNICODE);
+            $orgId = (int) $estimate->organization_id;
+            $fileName = OrganizationStoragePath::forOrganization(
+                $orgId,
+                "estimates/{$this->estimateId}/structure_snapshot_".Str::uuid().'.json',
+            );
 
-            if ($snapshotJson === false) {
-                throw new \RuntimeException('Unable to encode estimate structure snapshot.');
-            }
-
-            $structureSnapshotStorage->put($fileName, $snapshotJson);
+            $structureSnapshotStorage->putJson($fileName, $payload);
 
             // Обновляем структуру
             $oldPath = $estimate->structure_cache_path;
-            
+
             $estimate->structure_cache_path = $fileName;
             $estimate->save();
 
@@ -226,11 +221,11 @@ class GenerateEstimateSnapshotJob implements ShouldQueue
                 $structureSnapshotStorage->delete($oldPath);
             }
 
-            Log::info("Snapshot generated successfully", [
+            Log::info('Snapshot generated successfully', [
                 'estimate_id' => $this->estimateId,
                 'path' => $fileName,
                 'items_count' => count($items),
-                'memory_usage_mb' => round(memory_get_peak_usage() / 1024 / 1024, 2)
+                'memory_usage_mb' => round(memory_get_peak_usage() / 1024 / 1024, 2),
             ]);
 
         } catch (\Throwable $e) {

--- a/app/BusinessModules/Features/BudgetEstimates/Services/EstimateStructureSnapshotStorage.php
+++ b/app/BusinessModules/Features/BudgetEstimates/Services/EstimateStructureSnapshotStorage.php
@@ -4,22 +4,24 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\BudgetEstimates\Services;
 
-use Illuminate\Support\Facades\Storage;
+use App\Services\Storage\FileService;
 use League\Flysystem\FilesystemException;
 use RuntimeException;
 
 class EstimateStructureSnapshotStorage
 {
-    private const DISK = 's3';
+    public function __construct(
+        private readonly FileService $files,
+    ) {}
 
     public function exists(?string $path): bool
     {
-        if (!$path) {
+        if (! $path) {
             return false;
         }
 
         try {
-            return Storage::disk(self::DISK)->exists($path);
+            return $this->files->existsCurrent($path);
         } catch (FilesystemException) {
             return false;
         }
@@ -30,31 +32,102 @@ class EstimateStructureSnapshotStorage
      */
     public function readStream(string $path)
     {
-        $stream = Storage::disk(self::DISK)->readStream($path);
-
-        if ($stream === false) {
-            throw new RuntimeException('Unable to open estimate structure snapshot stream.');
-        }
-
-        return $stream;
+        return $this->files->readCurrent($path);
     }
 
-    public function put(string $path, string $contents): void
+    /** @param array<string, mixed> $payload */
+    public function putJson(string $path, array $payload): void
     {
-        Storage::disk(self::DISK)->put($path, $contents);
+        $stream = fopen('php://temp/maxmemory:2097152', 'w+b');
+        if (! is_resource($stream)) {
+            throw new RuntimeException('estimate_snapshot_stream_unavailable');
+        }
+
+        $hash = hash_init('sha256');
+
+        try {
+            $this->writeJsonValue($stream, $hash, $payload);
+            rewind($stream);
+
+            $this->files->putPrivate(
+                $path,
+                $stream,
+                'application/json',
+                hash_final($hash),
+            );
+        } finally {
+            fclose($stream);
+        }
     }
 
     public function delete(?string $path): void
     {
-        if (!$path) {
+        try {
+            if (! $path || ! $this->exists($path)) {
+                return;
+            }
+
+            $this->files->deleteCurrent($path);
+        } catch (FilesystemException|\InvalidArgumentException) {
+        }
+    }
+
+    /**
+     * @param  resource  $stream
+     */
+    private function writeJsonValue($stream, \HashContext $hash, mixed $value): void
+    {
+        if (! is_array($value)) {
+            $this->writeFragment(
+                $stream,
+                $hash,
+                json_encode($value, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+            );
+
             return;
         }
 
-        try {
-            if ($this->exists($path)) {
-                Storage::disk(self::DISK)->delete($path);
+        $isList = array_is_list($value);
+        $this->writeFragment($stream, $hash, $isList ? '[' : '{');
+
+        $first = true;
+        foreach ($value as $key => $item) {
+            if (! $first) {
+                $this->writeFragment($stream, $hash, ',');
             }
-        } catch (FilesystemException) {
+            $first = false;
+
+            if (! $isList) {
+                $this->writeFragment(
+                    $stream,
+                    $hash,
+                    json_encode((string) $key, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR).':',
+                );
+            }
+
+            $this->writeJsonValue($stream, $hash, $item);
         }
+
+        $this->writeFragment($stream, $hash, $isList ? ']' : '}');
+    }
+
+    /**
+     * @param  resource  $stream
+     */
+    private function writeFragment($stream, \HashContext $hash, string $fragment): void
+    {
+        $offset = 0;
+        $length = strlen($fragment);
+
+        while ($offset < $length) {
+            $written = fwrite($stream, substr($fragment, $offset));
+            if ($written === false || $written === 0) {
+                throw new RuntimeException('estimate_snapshot_stream_write_failed');
+            }
+
+            $offset += $written;
+        }
+
+        hash_update($hash, $fragment);
     }
 }

--- a/app/BusinessModules/Features/BudgetEstimates/Services/Import/EstimateImportService.php
+++ b/app/BusinessModules/Features/BudgetEstimates/Services/Import/EstimateImportService.php
@@ -59,183 +59,201 @@ class EstimateImportService
     public function detectEstimateType(string $sessionId): EstimateTypeDetectionDTO
     {
         $session = ImportSession::findOrFail($sessionId);
-        $fullPath = $this->fileStorage->getAbsolutePath($session);
 
-        try {
-            $detection = $this->runtimeDetector->detect($session, $fullPath);
-            if ($detection === null || $detection->confidence <= 0.0) {
-                throw UnsupportedEstimateImportFormatException::create();
-            }
+        return $this->fileStorage->withLocalCopy(
+            $session,
+            function (string $fullPath) use ($session, $sessionId): EstimateTypeDetectionDTO {
+                try {
+                    $detection = $this->runtimeDetector->detect($session, $fullPath);
+                    if ($detection === null || $detection->confidence <= 0.0) {
+                        throw UnsupportedEstimateImportFormatException::create();
+                    }
 
-            $options = $session->options ?? [];
-            $options['format_handler'] = $detection->formatSlug;
-            $options['runtime_detection'] = $detection->toArray();
+                    $options = $session->options ?? [];
+                    $options['format_handler'] = $detection->formatSlug;
+                    $options['runtime_detection'] = $detection->toArray();
 
-            $session->update([
-                'status' => 'detecting',
-                'options' => $options,
-            ]);
+                    $session->update([
+                        'status' => 'detecting',
+                        'options' => $options,
+                    ]);
 
-            return new EstimateTypeDetectionDTO(
-                detectedType: $detection->detectedType,
-                confidence: $detection->confidence,
-                indicators: $detection->indicators,
-                candidates: $detection->candidates,
-                metadata: $detection->metadata + [
-                    'format_slug' => $detection->formatSlug,
-                    'label' => $detection->label,
-                    'requires_confirmation' => $detection->requiresConfirmation,
-                    'warnings' => $detection->warnings,
-                ],
-            );
-        } catch (UnsupportedEstimateImportFormatException $e) {
-            Log::warning('[EstimateImport] Unsupported import format', [
-                'session_id' => $sessionId,
-                'error' => $e->getMessage(),
-            ]);
+                    return new EstimateTypeDetectionDTO(
+                        detectedType: $detection->detectedType,
+                        confidence: $detection->confidence,
+                        indicators: $detection->indicators,
+                        candidates: $detection->candidates,
+                        metadata: $detection->metadata + [
+                            'format_slug' => $detection->formatSlug,
+                            'label' => $detection->label,
+                            'requires_confirmation' => $detection->requiresConfirmation,
+                            'warnings' => $detection->warnings,
+                        ],
+                    );
+                } catch (UnsupportedEstimateImportFormatException $e) {
+                    Log::warning('[EstimateImport] Unsupported import format', [
+                        'session_id' => $sessionId,
+                        'error' => $e->getMessage(),
+                    ]);
 
-            throw $e;
-        } catch (Throwable $e) {
-            Log::error('[EstimateImport] Type detection failed', [
-                'session_id' => $sessionId,
-                'error' => $e->getMessage(),
-            ]);
+                    throw $e;
+                } catch (Throwable $e) {
+                    Log::error('[EstimateImport] Type detection failed', [
+                        'session_id' => $sessionId,
+                        'error' => $e->getMessage(),
+                    ]);
 
-            throw $e;
-        }
+                    throw $e;
+                }
+            },
+        );
     }
 
     public function detectFormat(string $sessionId, ?int $suggestedHeaderRow = null): array
     {
         $session = $this->sessionWithDetectedHandler($sessionId);
-        $fullPath = $this->fileStorage->getAbsolutePath($session);
-        $handlerSlug = (string) ($session->options['format_handler'] ?? '');
 
-        if ($handlerSlug === '') {
-            throw new RuntimeException(trans_message('estimate.import_format_not_detected'));
-        }
+        return $this->fileStorage->withLocalCopy(
+            $session,
+            function (string $fullPath) use ($session, $suggestedHeaderRow): array {
+                $handlerSlug = (string) ($session->options['format_handler'] ?? '');
 
-        $handler = $this->runtimeRegistry->bySlug($handlerSlug);
-        $structure = $suggestedHeaderRow !== null && method_exists($handler, 'detectStructureFromHeaderRow')
-            ? $handler->detectStructureFromHeaderRow($session, $fullPath, $suggestedHeaderRow)
-            : $handler->detectStructure($session, $fullPath);
+                if ($handlerSlug === '') {
+                    throw new RuntimeException(trans_message('estimate.import_format_not_detected'));
+                }
 
-        $options = $session->options ?? [];
-        $options['format_handler'] = $handler->slug();
-        $options['structure'] = $structure->toArray();
+                $handler = $this->runtimeRegistry->bySlug($handlerSlug);
+                $structure = $suggestedHeaderRow !== null && method_exists($handler, 'detectStructureFromHeaderRow')
+                    ? $handler->detectStructureFromHeaderRow($session, $fullPath, $suggestedHeaderRow)
+                    : $handler->detectStructure($session, $fullPath);
 
-        $session->update([
-            'status' => 'detecting',
-            'options' => $options,
-        ]);
+                $options = $session->options ?? [];
+                $options['format_handler'] = $handler->slug();
+                $options['structure'] = $structure->toArray();
 
-        return $structure->toArray();
+                $session->update([
+                    'status' => 'detecting',
+                    'options' => $options,
+                ]);
+
+                return $structure->toArray();
+            },
+        );
     }
 
     public function preview(string $sessionId, ?array $columnMapping = null): EstimateImportDTO
     {
         $session = $this->sessionWithDetectedHandler($sessionId);
-        $fullPath = $this->fileStorage->getAbsolutePath($session);
-        $handler = $this->runtimeRegistry->bySlug((string) $session->options['format_handler']);
-        $options = $session->options ?? [];
 
-        if ($columnMapping !== null) {
-            $columnMapping = $this->normalizeColumnMappingInput($columnMapping);
-        }
+        return $this->fileStorage->withLocalCopy(
+            $session,
+            function (string $fullPath) use ($session, $columnMapping): EstimateImportDTO {
+                $handler = $this->runtimeRegistry->bySlug((string) $session->options['format_handler']);
+                $options = $session->options ?? [];
 
-        if ($columnMapping !== null && $columnMapping !== []) {
-            $structure = $options['structure'] ?? [];
-            $structure['column_mapping'] = $columnMapping;
-            $structure['detected_columns'] = ImportStructureResult::detectedColumnsFromMapping($columnMapping);
-            $options['structure'] = $structure;
-            $session->update(['options' => $options]);
-            $session = $session->fresh();
-        }
+                if ($columnMapping !== null) {
+                    $columnMapping = $this->normalizeColumnMappingInput($columnMapping);
+                }
 
-        $structure = $this->structureFromSession($handler->slug(), $session);
-        if ($structure === null) {
-            $structure = $handler->detectStructure($session, $fullPath);
-            $options = $session->options ?? [];
-            $options['structure'] = $structure->toArray();
-            $session->update(['options' => $options]);
-            $session = $session->fresh();
-        }
+                if ($columnMapping !== null && $columnMapping !== []) {
+                    $structure = $options['structure'] ?? [];
+                    $structure['column_mapping'] = $columnMapping;
+                    $structure['detected_columns'] = ImportStructureResult::detectedColumnsFromMapping($columnMapping);
+                    $options['structure'] = $structure;
+                    $session->update(['options' => $options]);
+                    $session = $session->fresh();
+                }
 
-        $preview = $handler->preview($session, $fullPath, $structure);
-        $options = $session->options ?? [];
-        $options['preview_summary'] = $preview->summary;
-        $options['validation'] = $preview->validation;
-        $session->update([
-            'status' => 'mapped',
-            'options' => $options,
-        ]);
+                $structure = $this->structureFromSession($handler->slug(), $session);
+                if ($structure === null) {
+                    $structure = $handler->detectStructure($session, $fullPath);
+                    $options = $session->options ?? [];
+                    $options['structure'] = $structure->toArray();
+                    $session->update(['options' => $options]);
+                    $session = $session->fresh();
+                }
 
-        return new EstimateImportDTO(
-            fileName: $session->file_name,
-            fileSize: $session->file_size,
-            fileFormat: $session->file_format,
-            sections: $preview->sections,
-            items: $preview->items,
-            totals: $preview->totals,
-            metadata: $preview->metadata + [
-                'handler' => $handler->slug(),
-                'quality' => $preview->quality,
-                'summary' => $preview->summary,
-            ],
-            detectedColumns: $structure->detectedColumns,
-            rawHeaders: $structure->rawHeaders,
-            estimateType: $handler->slug(),
-            validationSummary: $preview->validation,
+                $preview = $handler->preview($session, $fullPath, $structure);
+                $options = $session->options ?? [];
+                $options['preview_summary'] = $preview->summary;
+                $options['validation'] = $preview->validation;
+                $session->update([
+                    'status' => 'mapped',
+                    'options' => $options,
+                ]);
+
+                return new EstimateImportDTO(
+                    fileName: $session->file_name,
+                    fileSize: $session->file_size,
+                    fileFormat: $session->file_format,
+                    sections: $preview->sections,
+                    items: $preview->items,
+                    totals: $preview->totals,
+                    metadata: $preview->metadata + [
+                        'handler' => $handler->slug(),
+                        'quality' => $preview->quality,
+                        'summary' => $preview->summary,
+                    ],
+                    detectedColumns: $structure->detectedColumns,
+                    rawHeaders: $structure->rawHeaders,
+                    estimateType: $handler->slug(),
+                    validationSummary: $preview->validation,
+                );
+            },
         );
     }
 
     public function learnFromSession(ImportSession $session): void
     {
         try {
-            $fullPath = $this->fileStorage->getAbsolutePath($session);
-            $extension = strtolower(pathinfo($fullPath, PATHINFO_EXTENSION));
+            $this->fileStorage->withLocalCopy(
+                $session,
+                function (string $fullPath) use ($session): void {
+                    $extension = strtolower(pathinfo($fullPath, PATHINFO_EXTENSION));
 
-            if (in_array($extension, ['xml', 'pdf'], true)) {
-                return;
-            }
+                    if (in_array($extension, ['xml', 'pdf'], true)) {
+                        return;
+                    }
 
-            $spreadsheet = IOFactory::load($fullPath);
-            $sheet = $spreadsheet->getActiveSheet();
-            $firstRow = [];
+                    $spreadsheet = IOFactory::load($fullPath);
+                    $sheet = $spreadsheet->getActiveSheet();
+                    $firstRow = [];
 
-            foreach ($sheet->getRowIterator(1, 1) as $row) {
-                foreach ($row->getCellIterator() as $cell) {
-                    $firstRow[] = $cell->getValue();
-                }
-            }
+                    foreach ($sheet->getRowIterator(1, 1) as $row) {
+                        foreach ($row->getCellIterator() as $cell) {
+                            $firstRow[] = $cell->getValue();
+                        }
+                    }
 
-            $spreadsheet->disconnectWorksheets();
+                    $spreadsheet->disconnectWorksheets();
 
-            $signature = $this->signatureGenerator->generate($firstRow);
-            $mapping = $session->options['column_mapping'] ?? [];
-            if ($mapping === []) {
-                $structure = $session->options['structure'] ?? [];
-                $mapping = is_array($structure) ? ImportStructureResult::columnMappingFromArray($structure) : [];
-            }
+                    $signature = $this->signatureGenerator->generate($firstRow);
+                    $mapping = $session->options['column_mapping'] ?? [];
+                    if ($mapping === []) {
+                        $structure = $session->options['structure'] ?? [];
+                        $mapping = is_array($structure) ? ImportStructureResult::columnMappingFromArray($structure) : [];
+                    }
 
-            if ($mapping === []) {
-                return;
-            }
+                    if ($mapping === []) {
+                        return;
+                    }
 
-            ImportMemory::updateOrCreate(
-                [
-                    'organization_id' => $session->organization_id,
-                    'signature' => $signature,
-                ],
-                [
-                    'user_id' => $session->user_id,
-                    'file_format' => $extension,
-                    'original_headers' => $firstRow,
-                    'column_mapping' => $mapping,
-                    'header_row' => $session->options['structure']['header_row'] ?? null,
-                    'last_used_at' => now(),
-                    'usage_count' => DB::raw('usage_count + 1'),
-                ],
+                    ImportMemory::updateOrCreate(
+                        [
+                            'organization_id' => $session->organization_id,
+                            'signature' => $signature,
+                        ],
+                        [
+                            'user_id' => $session->user_id,
+                            'file_format' => $extension,
+                            'original_headers' => $firstRow,
+                            'column_mapping' => $mapping,
+                            'header_row' => $session->options['structure']['header_row'] ?? null,
+                            'last_used_at' => now(),
+                            'usage_count' => DB::raw('usage_count + 1'),
+                        ],
+                    );
+                },
             );
         } catch (Throwable $e) {
             Log::warning('[EstimateImport] Structure learning failed', [
@@ -298,7 +316,7 @@ class EstimateImportService
     {
         $session = ImportSession::find($id);
 
-        if (!$session) {
+        if (! $session) {
             return [
                 'status' => 'failed',
                 'error' => trans_message('estimate.import_status_not_found'),
@@ -337,7 +355,7 @@ class EstimateImportService
     private function sessionWithDetectedHandler(string $sessionId): ImportSession
     {
         $session = ImportSession::findOrFail($sessionId);
-        if (!empty($session->options['format_handler'])) {
+        if (! empty($session->options['format_handler'])) {
             return $session;
         }
 
@@ -349,13 +367,13 @@ class EstimateImportService
     private function structureFromSession(string $formatSlug, ImportSession $session): ?ImportStructureResult
     {
         $structure = $session->options['structure'] ?? null;
-        if (!is_array($structure)) {
+        if (! is_array($structure)) {
             return null;
         }
 
         $columnMapping = ImportStructureResult::columnMappingFromArray($structure);
         $detectedColumns = $structure['detected_columns'] ?? [];
-        if ((!is_array($detectedColumns) || $detectedColumns === []) && $columnMapping !== []) {
+        if ((! is_array($detectedColumns) || $detectedColumns === []) && $columnMapping !== []) {
             $detectedColumns = ImportStructureResult::detectedColumnsFromMapping($columnMapping);
         }
 
@@ -378,7 +396,7 @@ class EstimateImportService
     {
         $normalized = [];
         foreach ($mapping as $field => $column) {
-            if (!is_string($field) || (!is_string($column) && !is_int($column))) {
+            if (! is_string($field) || (! is_string($column) && ! is_int($column))) {
                 continue;
             }
 
@@ -390,11 +408,11 @@ class EstimateImportService
             $normalized[$field] = $column;
         }
 
-        if (isset($normalized['current_total_amount']) && !isset($normalized['total_price'])) {
+        if (isset($normalized['current_total_amount']) && ! isset($normalized['total_price'])) {
             $normalized['total_price'] = $normalized['current_total_amount'];
         }
 
-        if (isset($normalized['section_number']) && !isset($normalized['position_number'])) {
+        if (isset($normalized['section_number']) && ! isset($normalized['position_number'])) {
             $normalized['position_number'] = $normalized['section_number'];
         }
 
@@ -413,7 +431,7 @@ class EstimateImportService
 
     private function translateStoredMessage(mixed $message): ?string
     {
-        if (!is_string($message)) {
+        if (! is_string($message)) {
             return null;
         }
 

--- a/app/BusinessModules/Features/BudgetEstimates/Services/Import/FileStorageService.php
+++ b/app/BusinessModules/Features/BudgetEstimates/Services/Import/FileStorageService.php
@@ -5,74 +5,127 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\BudgetEstimates\Services\Import;
 
 use App\Models\ImportSession;
+use App\Services\Storage\FileService;
 use App\Services\Storage\OrganizationStoragePath;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
 
-class FileStorageService
+final readonly class FileStorageService
 {
-    private const DISK = 's3';
     private const BASE_DIR = 'estimate-imports';
 
+    public function __construct(
+        private FileService $files,
+    ) {}
+
+    /**
+     * @return array{path: string, name: string, size: int, extension: string}
+     */
     public function store(UploadedFile $file, int $organizationId): array
     {
-        $fileName  = $file->getClientOriginalName();
-        $fileSize  = $file->getSize();
-        $extension = $file->getClientOriginalExtension();
+        $fileName = $file->getClientOriginalName();
+        $extension = strtolower($file->getClientOriginalExtension());
+        $storedName = Str::uuid()->toString().($extension !== '' ? '.'.$extension : '');
+        $relativePath = OrganizationStoragePath::forOrganization(
+            $organizationId,
+            self::BASE_DIR."/{$storedName}",
+        );
+        $realPath = $file->getRealPath();
+        if (! is_string($realPath) || ! is_readable($realPath)) {
+            throw new RuntimeException('estimate_import_file_unreadable');
+        }
 
-        $storedName   = Str::uuid()->toString() . '.' . $extension;
-        $relativePath = OrganizationStoragePath::forOrganization($organizationId, self::BASE_DIR . "/{$storedName}");
+        $sha256 = hash_file('sha256', $realPath);
+        if (! is_string($sha256)) {
+            throw new RuntimeException('estimate_import_file_unreadable');
+        }
 
-        Storage::disk(self::DISK)->put($relativePath, file_get_contents($file->getRealPath()), 'private');
+        $stream = fopen($realPath, 'rb');
+        if (! is_resource($stream)) {
+            throw new RuntimeException('estimate_import_file_unreadable');
+        }
 
-        Log::info('[FileStorageService] File uploaded to S3', [
-            'path'            => $relativePath,
-            'organization_id' => $organizationId,
-            'size'            => $fileSize,
-        ]);
+        try {
+            $stored = $this->files->putPrivate(
+                $relativePath,
+                $stream,
+                $file->getMimeType() ?: $file->getClientMimeType() ?: 'application/octet-stream',
+                $sha256,
+            );
+        } finally {
+            fclose($stream);
+        }
 
         return [
-            'path'      => $relativePath,
-            'name'      => $fileName,
-            'size'      => $fileSize,
+            'path' => $stored->key,
+            'name' => $fileName,
+            'size' => $stored->sizeBytes,
             'extension' => $extension,
-            'disk'      => self::DISK,
         ];
     }
 
-    public function getAbsolutePath(ImportSession $session): string
+    /**
+     * @template T
+     *
+     * @param  callable(string): T  $callback
+     * @return T
+     */
+    public function withLocalCopy(ImportSession $session, callable $callback): mixed
     {
-        if (!$session->file_path) {
-            throw new \RuntimeException("Import session {$session->id} has no file path");
+        $path = $this->downloadToTemporaryPath($session);
+
+        try {
+            return $callback($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    private function downloadToTemporaryPath(ImportSession $session): string
+    {
+        if (! $session->file_path) {
+            throw new RuntimeException("Import session {$session->id} has no file path");
         }
 
-        if (!Storage::disk(self::DISK)->exists($session->file_path)) {
-            throw new \RuntimeException("File \"{$session->file_path}\" does not exist in S3");
+        if (! $this->files->existsCurrent($session->file_path)) {
+            throw new RuntimeException("File \"{$session->file_path}\" does not exist in S3");
         }
 
-        $extension   = pathinfo($session->file_path, PATHINFO_EXTENSION);
-        $tmpPath     = sys_get_temp_dir() . '/' . Str::uuid()->toString() . '.' . $extension;
-        $fileContent = Storage::disk(self::DISK)->get($session->file_path);
+        $extension = pathinfo($session->file_path, PATHINFO_EXTENSION);
+        $tmpPath = sys_get_temp_dir().'/'.Str::uuid()->toString().($extension !== '' ? '.'.$extension : '');
+        $source = $this->files->readCurrent($session->file_path);
+        $destination = fopen($tmpPath, 'x+b');
+        if (! is_resource($destination)) {
+            fclose($source);
+            throw new RuntimeException('estimate_import_temporary_file_failed');
+        }
 
-        file_put_contents($tmpPath, $fileContent);
+        try {
+            if (stream_copy_to_stream($source, $destination) === false) {
+                throw new RuntimeException('estimate_import_temporary_file_failed');
+            }
+        } catch (Throwable $exception) {
+            @unlink($tmpPath);
 
-        Log::info('[FileStorageService] File downloaded from S3 to tmp', [
-            'session_id' => $session->id,
-            's3_path'    => $session->file_path,
-            'tmp_path'   => $tmpPath,
-        ]);
+            throw $exception;
+        } finally {
+            fclose($source);
+            fclose($destination);
+        }
 
         return $tmpPath;
     }
 
     public function delete(ImportSession $session): bool
     {
-        if ($session->file_path && Storage::disk(self::DISK)->exists($session->file_path)) {
-            return Storage::disk(self::DISK)->delete($session->file_path);
+        if (! $session->file_path || ! $this->files->existsCurrent($session->file_path)) {
+            return false;
         }
 
-        return false;
+        $this->files->deleteCurrent($session->file_path);
+
+        return true;
     }
 }

--- a/app/BusinessModules/Features/BudgetEstimates/Services/Import/ImportPipelineService.php
+++ b/app/BusinessModules/Features/BudgetEstimates/Services/Import/ImportPipelineService.php
@@ -7,40 +7,41 @@ namespace App\BusinessModules\Features\BudgetEstimates\Services\Import;
 use App\BusinessModules\Addons\EstimateGeneration\Services\Learning\EstimateGenerationLearningRecorder;
 use App\BusinessModules\Features\BudgetEstimates\DTOs\EstimateImportRowDTO;
 use App\BusinessModules\Features\BudgetEstimates\Services\EstimateService;
+use App\BusinessModules\Features\BudgetEstimates\Services\Import\Classification\ItemClassificationService;
 use App\BusinessModules\Features\BudgetEstimates\Services\Import\Runtime\ImportFormatRegistry;
 use App\BusinessModules\Features\BudgetEstimates\Services\Import\Runtime\ImportStructureResult;
 use App\BusinessModules\Features\BudgetEstimates\Services\Import\Runtime\ImportValidationResult;
 use App\Models\Estimate;
-use App\Models\EstimateSection;
 use App\Models\EstimateItem;
+use App\Models\EstimateSection;
 use App\Models\ImportSession;
 use App\Models\MeasurementUnit;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Cache;
-use App\BusinessModules\Features\BudgetEstimates\Services\Import\Classification\ItemClassificationService;
 
 class ImportPipelineService
 {
     private const BATCH_SIZE = 100;
+
     private const GRAND_SMETA_HANDLER_SLUG = 'grandsmeta';
 
     private array $unitCache = [];
 
     private array $unitAliases = [
-        'м2'       => 'м²',  'м^2'     => 'м²',  'кв.м'    => 'м²',
-        'кв. м'    => 'м²',  'кв м'    => 'м²',  'м.кв'    => 'м²',
-        'м3'       => 'м³',  'куб.м'   => 'м³',  'куб. м'  => 'м³',
-        'куб м'    => 'м³',  'м.куб'   => 'м³',
-        'чел-час'  => 'чел-ч', 'чел.ч'   => 'чел-ч', 'ч-ч'     => 'чел-ч', 'чел. ч'  => 'чел-ч', 'чел.-ч' => 'чел-ч',
-        'маш-час'  => 'маш-ч', 'маш.ч'   => 'маш-ч', 'маш. ч'  => 'маш-ч', 'маш.-ч' => 'маш-ч',
-        'погон.м'  => 'пог. м', 'пог.м'   => 'пог. м',
-        'кг.'      => 'кг',   'т.'      => 'т',    'шт.'     => 'шт',
-        'м.'       => 'м',
+        'м2' => 'м²',  'м^2' => 'м²',  'кв.м' => 'м²',
+        'кв. м' => 'м²',  'кв м' => 'м²',  'м.кв' => 'м²',
+        'м3' => 'м³',  'куб.м' => 'м³',  'куб. м' => 'м³',
+        'куб м' => 'м³',  'м.куб' => 'м³',
+        'чел-час' => 'чел-ч', 'чел.ч' => 'чел-ч', 'ч-ч' => 'чел-ч', 'чел. ч' => 'чел-ч', 'чел.-ч' => 'чел-ч',
+        'маш-час' => 'маш-ч', 'маш.ч' => 'маш-ч', 'маш. ч' => 'маш-ч', 'маш.-ч' => 'маш-ч',
+        'погон.м' => 'пог. м', 'пог.м' => 'пог. м',
+        'кг.' => 'кг',   'т.' => 'т',    'шт.' => 'шт',
+        'м.' => 'м',
     ];
 
     private array $workUnitKeywords = [
-        'чел-ч', 'маш-ч', 'смн', 'чел-дн', 'маш-смн', 'рейс', 'усл', 'этап', 'час'
+        'чел-ч', 'маш-ч', 'смн', 'чел-дн', 'маш-смн', 'рейс', 'усл', 'этап', 'час',
     ];
 
     public function __construct(
@@ -69,21 +70,30 @@ class ImportPipelineService
         $session->update([
             'stats' => array_merge($fresh->stats ?? [], [
                 'progress' => $progress,
-                'message'  => $message,
-            ])
+                'message' => $message,
+            ]),
         ]);
     }
 
     public function run(ImportSession $session): void
     {
+        $this->fileStorage->withLocalCopy(
+            $session,
+            function (string $filePath) use ($session): void {
+                $this->runWithLocalCopy($session, $filePath);
+            },
+        );
+    }
+
+    private function runWithLocalCopy(ImportSession $session, string $filePath): void
+    {
         Log::info("[ImportPipeline] Started for session {$session->id}");
-        
+
         $session->update([
-            'status' => 'parsing', 
-            'stats' => array_merge($session->fresh()->stats ?? [], ['progress' => 5, 'message' => trans_message('estimate.import_processing_started')])
+            'status' => 'parsing',
+            'stats' => array_merge($session->fresh()->stats ?? [], ['progress' => 5, 'message' => trans_message('estimate.import_processing_started')]),
         ]);
 
-        $filePath = $this->fileStorage->getAbsolutePath($session);
         $handlerSlug = (string) ($session->options['format_handler'] ?? '');
         if ($handlerSlug === '') {
             throw new \RuntimeException(trans_message('estimate.import_format_not_detected'));
@@ -104,14 +114,14 @@ class ImportPipelineService
         $totalRows = (int) ($preview->summary['rows_count'] ?? (count($preview->sections) + count($preview->items)));
 
         // 1. Оцениваем общее количество строк для прогресса
-        
+
         $session->update([
             'stats' => array_merge($session->fresh()->stats ?? [], [
                 'progress' => 10,
                 'total_rows' => $totalRows,
                 'validation' => $validation->toArray(),
                 'message' => trans_message('estimate.import_processing_file'),
-            ])
+            ]),
         ]);
 
         if (($session->options['validate_only'] ?? false) === true) {
@@ -133,7 +143,7 @@ class ImportPipelineService
             return;
         }
 
-        if (!$validation->isValid()) {
+        if (! $validation->isValid()) {
             $message = $this->validationFailureMessage($validation);
             $session->update([
                 'stats' => array_merge($session->fresh()->stats ?? [], [
@@ -145,14 +155,14 @@ class ImportPipelineService
         }
 
         $stream = $handler->streamRows($session, $filePath, $structureResult);
-        
+
         $stats = [
             'processed_rows' => 0,
             'sections_created' => 0,
             'items_created' => 0,
             'total_rows' => $totalRows,
         ];
-        
+
         DB::beginTransaction();
         try {
             $estimate = $this->resolveEstimate($session);
@@ -162,26 +172,26 @@ class ImportPipelineService
                 $stats['sections_created'] = max(0, $stats['sections_created'] - $removedEmptySections);
                 $stats['empty_sections_removed'] = $removedEmptySections;
             }
-            
+
             if (method_exists($handler, 'getFooterData')) {
                 $footerData = $handler->getFooterData();
-                if (!empty($footerData)) {
+                if (! empty($footerData)) {
                     Log::info("[ImportPipeline] Found footer data for session {$session->id}", $footerData);
-                    
+
                     // Update estimate with footer values
                     $meta = $estimate->metadata ?? [];
                     $meta['footer'] = $footerData;
-                    
+
                     // ⭐ КАЛИБРОВКА СТАВОК (CALIBRATION)
-                    // Если в подвале удалось найти ФОТ и НР/СП - доверяем им, 
+                    // Если в подвале удалось найти ФОТ и НР/СП - доверяем им,
                     // так как это единственный способ попасть в математику Гранд-Сметы.
-                    $directCosts = (float)($footerData['direct_costs'] ?? 0);
-                    $laborCostFromFooter = (float)($footerData['labor_cost'] ?? 0); // ФОТ
-                    $overheadFromFooter = (float)($footerData['overhead_cost'] ?? 0);
-                    $profitFromFooter = (float)($footerData['profit_cost'] ?? 0);
-                    
+                    $directCosts = (float) ($footerData['direct_costs'] ?? 0);
+                    $laborCostFromFooter = (float) ($footerData['labor_cost'] ?? 0); // ФОТ
+                    $overheadFromFooter = (float) ($footerData['overhead_cost'] ?? 0);
+                    $profitFromFooter = (float) ($footerData['profit_cost'] ?? 0);
+
                     $baseForCalibration = $laborCostFromFooter > 0 ? $laborCostFromFooter : ($directCosts > 0 ? $directCosts : 0);
-                    
+
                     if ($this->shouldPreserveImportedTotals($session) && $baseForCalibration > 0) {
                         Log::info("[ImportPipeline] Calibrating rates using footer: base={$baseForCalibration}, OH={$overheadFromFooter}, P={$profitFromFooter}");
                         if ($overheadFromFooter > 0) {
@@ -191,8 +201,8 @@ class ImportPipelineService
                             $estimate->profit_rate = round(($profitFromFooter / $baseForCalibration) * 100, 2);
                         }
                     }
-                    
-                    $estimate->metadata = $meta; 
+
+                    $estimate->metadata = $meta;
                     $estimate->save();
                 }
             }
@@ -206,27 +216,27 @@ class ImportPipelineService
             // recalculateAll даёт ~99.99% точность, но накопленное округление per-position
             // даёт расхождение в ~64 руб. Берём точные значения из подвала файла.
             $savedFooter = $estimate->fresh()->metadata['footer'] ?? [];
-            $footerTotal    = (float)($savedFooter['total_estimate_cost'] ?? 0);
-            $footerOverhead = (float)($savedFooter['overhead_cost'] ?? 0);
-            $footerProfit   = (float)($savedFooter['profit_cost'] ?? 0);
+            $footerTotal = (float) ($savedFooter['total_estimate_cost'] ?? 0);
+            $footerOverhead = (float) ($savedFooter['overhead_cost'] ?? 0);
+            $footerProfit = (float) ($savedFooter['profit_cost'] ?? 0);
 
             if ($this->shouldPreserveImportedTotals($session) && $footerTotal > 0 && ($footerOverhead > 0 || $footerProfit > 0)) {
                 $footerDirect = round($footerTotal - $footerOverhead - $footerProfit, 2);
                 $estimate->update([
-                    'total_amount'            => $footerTotal,
-                    'total_overhead_costs'    => $footerOverhead,
-                    'total_estimated_profit'  => $footerProfit,
-                    'total_direct_costs'      => $footerDirect,
-                    'total_amount_with_vat'   => round($footerTotal * (1 + $estimate->vat_rate / 100), 2),
+                    'total_amount' => $footerTotal,
+                    'total_overhead_costs' => $footerOverhead,
+                    'total_estimated_profit' => $footerProfit,
+                    'total_direct_costs' => $footerDirect,
+                    'total_amount_with_vat' => round($footerTotal * (1 + $estimate->vat_rate / 100), 2),
                 ]);
                 Log::info("[ImportPipeline] Footer override applied for estimate #{$estimate->id}", [
-                    'total'    => $footerTotal,
+                    'total' => $footerTotal,
                     'overhead' => $footerOverhead,
-                    'profit'   => $footerProfit,
-                    'direct'   => $footerDirect,
+                    'profit' => $footerProfit,
+                    'direct' => $footerDirect,
                 ]);
             }
-            
+
             DB::commit();
 
             try {
@@ -240,22 +250,22 @@ class ImportPipelineService
                     'error' => $e->getMessage(),
                 ]);
             }
-            
+
             Log::info("[ImportPipeline] Finished for session {$session->id}", $stats);
-            
+
             $session->update([
                 'status' => 'completed',
-                'stats'  => array_merge($session->fresh()->stats ?? [], [
-                    'progress'    => 100,
-                    'result'      => $stats,
+                'stats' => array_merge($session->fresh()->stats ?? [], [
+                    'progress' => 100,
+                    'result' => $stats,
                     'estimate_id' => $estimate->id,
-                    'message'     => trans_message('estimate.import_completed'),
-                ])
+                    'message' => trans_message('estimate.import_completed'),
+                ]),
             ]);
 
         } catch (\Throwable $e) {
             DB::rollBack();
-            Log::error("[ImportPipeline] Error: " . $e->getMessage(), ['trace' => $e->getTraceAsString()]);
+            Log::error('[ImportPipeline] Error: '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);
             throw $e;
         }
     }
@@ -263,13 +273,13 @@ class ImportPipelineService
     private function structureFromSession(string $formatSlug, ImportSession $session): ?ImportStructureResult
     {
         $structure = $session->options['structure'] ?? null;
-        if (!is_array($structure)) {
+        if (! is_array($structure)) {
             return null;
         }
 
         $columnMapping = ImportStructureResult::columnMappingFromArray($structure);
         $detectedColumns = $structure['detected_columns'] ?? [];
-        if ((!is_array($detectedColumns) || $detectedColumns === []) && $columnMapping !== []) {
+        if ((! is_array($detectedColumns) || $detectedColumns === []) && $columnMapping !== []) {
             $detectedColumns = ImportStructureResult::detectedColumnsFromMapping($columnMapping);
         }
 
@@ -305,7 +315,7 @@ class ImportPipelineService
             $message = $message['message'] ?? $message['key'] ?? reset($message);
         }
 
-        if (!is_string($message)) {
+        if (! is_string($message)) {
             return '';
         }
 
@@ -321,7 +331,7 @@ class ImportPipelineService
     {
         $settings = $session->options['estimate_settings'] ?? [];
         $financialSettings = $this->financialSettingsResolver->resolve($settings);
-        
+
         return $this->estimateService->create([
             'organization_id' => $session->organization_id,
             'project_id' => $settings['project_id'] ?? null,
@@ -353,16 +363,16 @@ class ImportPipelineService
         $batchDTOs = [];
         $sectionMap = []; // path -> section_id (e.g. "1" -> 101, "1.1" -> 102)
         $lastSectionId = null; // For items without explicit section path?
-        
+
         foreach ($stream as $rowDTO) {
-            if (!$rowDTO instanceof EstimateImportRowDTO) {
+            if (! $rowDTO instanceof EstimateImportRowDTO) {
                 $rowDTO = EstimateImportRowDTO::fromArray((array) $rowDTO);
             }
 
             if (is_array($rowDTO->rawData) && $this->rowMapper->isTechnicalRow($rowDTO->rawData)) {
                 continue;
             }
-            
+
             // Skip rows that are identified as footers (totals, summaries, etc.)
             if ($rowDTO->isFooter) {
                 continue;
@@ -370,22 +380,23 @@ class ImportPipelineService
 
             // Skip rows that have no numeric value (Quantity=0 AND Price=0 AND Total=0)
             // This filters out headers that were technically mapped but contain no data.
-            if (!$rowDTO->isSection && 
-                ($rowDTO->quantity === null || $rowDTO->quantity == 0) && 
+            if (! $rowDTO->isSection &&
+                ($rowDTO->quantity === null || $rowDTO->quantity == 0) &&
                 ($rowDTO->unitPrice === null || $rowDTO->unitPrice == 0) &&
                 ($rowDTO->currentTotalAmount === null || $rowDTO->currentTotalAmount == 0)
             ) {
                 Log::info("[ImportPipeline] Skipping empty/garbage item: '{$rowDTO->itemName}'");
+
                 continue;
             }
 
             if ($rowDTO->isSection) {
                 // If we have items in batch, process and save them first to maintain order
-                if (!empty($batchDTOs)) {
+                if (! empty($batchDTOs)) {
                     $this->processAndInsertBatch($batchDTOs, $estimate, $stats, $session);
                     $batchDTOs = [];
                 }
-                
+
                 // Сбрасываем подпункты, так как начался новый раздел
                 $this->subItemState = [];
 
@@ -395,12 +406,12 @@ class ImportPipelineService
                 $stats['sections_created']++;
             } else {
                 // Collect row but assign closest section
-                $rowDTO->sectionPath = $rowDTO->sectionPath ?: null; 
+                $rowDTO->sectionPath = $rowDTO->sectionPath ?: null;
                 $batchDTOs[] = [
                     'dto' => $rowDTO,
-                    'section_id' => $this->resolveSectionId($rowDTO, $sectionMap, $lastSectionId)
+                    'section_id' => $this->resolveSectionId($rowDTO, $sectionMap, $lastSectionId),
                 ];
-                
+
                 if (count($batchDTOs) >= self::BATCH_SIZE) {
                     $this->processAndInsertBatch($batchDTOs, $estimate, $stats, $session);
                     $batchDTOs = [];
@@ -408,7 +419,7 @@ class ImportPipelineService
             }
 
             $stats['processed_rows']++;
-            
+
             // Обновляем прогресс каждые 10 строк
             if ($stats['processed_rows'] % 10 === 0) {
                 $totalRows = $stats['total_rows'] ?? 0;
@@ -428,9 +439,9 @@ class ImportPipelineService
                 $session->stats = array_merge($session->fresh()->stats ?? [], ['processed_rows' => $stats['processed_rows']]);
             }
         }
-        
+
         // Final batch
-        if (!empty($batchDTOs)) {
+        if (! empty($batchDTOs)) {
             $this->processAndInsertBatch($batchDTOs, $estimate, $stats, $session);
         }
     }
@@ -443,7 +454,7 @@ class ImportPipelineService
         foreach ($batch as $index => $item) {
             $dto = $item['dto'];
             $itemData = $this->prepareWorkData($dto, $estimate, $item['section_id']);
-            
+
             $matched = false;
             // ... (keeping existing matcher logic) ...
             if ($dto->code) {
@@ -454,7 +465,7 @@ class ImportPipelineService
                 }
             }
 
-            if (!$matched && !empty($dto->itemName)) {
+            if (! $matched && ! empty($dto->itemName)) {
                 $semanticHit = $this->semanticMatcher->getBestNormativeMatch($dto->itemName, $dto->unit);
                 if ($semanticHit && $semanticHit['similarity'] >= 0.5) {
                     $norm = \App\Models\NormativeRate::find($semanticHit['id']);
@@ -471,31 +482,31 @@ class ImportPipelineService
                     }
                 }
             }
-            
-            if (!$matched) {
-                $isGesnCode = !empty($dto->code) && stripos($dto->code, 'ГЭСН') === 0;
+
+            if (! $matched) {
+                $isGesnCode = ! empty($dto->code) && stripos($dto->code, 'ГЭСН') === 0;
 
                 if ($isGesnCode) {
                     $itemData['item_type'] = 'work';
                 } else {
                     $aiBatch[$index] = [
-                        'code'  => $dto->code ?? '',
-                        'name'  => $dto->itemName,
-                        'unit'  => $dto->unit,
-                        'price' => (float)$dto->unitPrice
+                        'code' => $dto->code ?? '',
+                        'name' => $dto->itemName,
+                        'unit' => $dto->unit,
+                        'price' => (float) $dto->unitPrice,
                     ];
                 }
             }
-            
+
             $batch[$index]['prepared_data'] = $itemData;
         }
 
         // Step 2: AI Classification
-        if (!empty($aiBatch)) {
+        if (! empty($aiBatch)) {
             try {
                 $aiResults = $this->classifier->classifyBatch(array_values($aiBatch));
                 $aiKeys = array_keys($aiBatch);
-                
+
                 foreach ($aiResults as $subIndex => $result) {
                     $origIndex = $aiKeys[$subIndex];
                     if (isset($batch[$origIndex])) {
@@ -503,13 +514,13 @@ class ImportPipelineService
                     }
                 }
             } catch (\Throwable $e) {
-                Log::warning("[ImportPipeline] AI Batch Classification failed: " . $e->getMessage());
+                Log::warning('[ImportPipeline] AI Batch Classification failed: '.$e->getMessage());
             }
         }
 
         // Step 3: Sub-item Grouping (XML Parity)
         $preparedRows = array_column($batch, 'prepared_data');
-        $groupedRows  = $this->subItemGrouper->groupItems($preparedRows, $this->subItemState);
+        $groupedRows = $this->subItemGrouper->groupItems($preparedRows, $this->subItemState);
 
         // Step 4: Formula Validation
         $this->formulaAwareness->annotate($groupedRows);
@@ -522,28 +533,28 @@ class ImportPipelineService
             if (isset($data['metadata']) && is_array($data['metadata'])) {
                 $data['metadata'] = json_encode($data['metadata']);
             }
-            
-            $isSubItem = !empty($data['is_sub_item']);
+
+            $isSubItem = ! empty($data['is_sub_item']);
             $parentIndex = $data['_parent_index'] ?? null;
-            
+
             // 🔧 ИСПРАВЛЕНИЕ: Удаляем технические поля, которых нет в БД
             unset(
-                $data['is_sub_item'], 
-                $data['_parent_index'], 
-                $data['warnings'], 
+                $data['is_sub_item'],
+                $data['_parent_index'],
+                $data['warnings'],
                 $data['has_math_mismatch'],
                 $data['anomaly'],
                 $data['disable_sub_item_grouping']
             );
-            
-            if (!$isSubItem) {
+
+            if (! $isSubItem) {
                 // Если накопились дочерние элементы, вставляем их перед родителем, чтобы сохранить относительный порядок БД
-                if (!empty($childrenBatch)) {
+                if (! empty($childrenBatch)) {
                     EstimateItem::insert($childrenBatch);
                     $stats['items_created'] += count($childrenBatch);
                     $childrenBatch = [];
                 }
-                
+
                 // Вставляем родителя отдельно, чтобы получить его ID для связей
                 $id = DB::table('estimate_items')->insertGetId($data);
                 $insertedParents[$idx] = $id;
@@ -557,12 +568,12 @@ class ImportPipelineService
                     // Родитель был в предыдущем батче
                     $data['parent_work_id'] = $this->subItemState['last_parent_id'];
                 }
-                
+
                 $childrenBatch[] = $data;
             }
         }
 
-        if (!empty($childrenBatch)) {
+        if (! empty($childrenBatch)) {
             EstimateItem::insert($childrenBatch);
             $stats['items_created'] += count($childrenBatch);
         }
@@ -571,21 +582,21 @@ class ImportPipelineService
     private function saveSection($dto, int $estimateId, array &$sectionMap): EstimateSection
     {
         // Resolve Parent
-        $currentPath = $dto->sectionPath ?: $dto->sectionNumber; 
-        
+        $currentPath = $dto->sectionPath ?: $dto->sectionNumber;
+
         $parentId = $this->resolveParentSectionId((string) $currentPath, $sectionMap);
 
         $section = EstimateSection::create([
             'estimate_id' => $estimateId,
             'parent_section_id' => $parentId,
-            'section_number' => (string)$dto->sectionNumber,
-            'full_section_number' => (string)$currentPath,
+            'section_number' => (string) $dto->sectionNumber,
+            'full_section_number' => (string) $currentPath,
             'name' => $dto->itemName,
-            'sort_order' => $dto->rowNumber, 
+            'sort_order' => $dto->rowNumber,
         ]);
-        
+
         $sectionMap[$currentPath] = $section->id;
-        
+
         return $section;
     }
 
@@ -595,6 +606,7 @@ class ImportPipelineService
         if ($path && isset($sectionMap[$path])) {
             return $sectionMap[$path];
         }
+
         return $lastSectionId;
     }
 
@@ -641,30 +653,29 @@ class ImportPipelineService
         $laborCost = $this->detectLaborCost($dto);
         $isInformative = $this->isInformativeGrandSmetaRow($dto);
         $isSubItem = $dto->isSubItem ?? false;
-        $totalAmount = (float)($dto->currentTotalAmount ?? ($dto->quantity * ($dto->unitPrice ?? 0)));
-        
+        $totalAmount = (float) ($dto->currentTotalAmount ?? ($dto->quantity * ($dto->unitPrice ?? 0)));
+
         // 1. Берем точные рублевые значения НР и СП напрямую от парсера ГрандСметы
-        $overheadAmount = isset($dto->overheadAmount) ? (float)$dto->overheadAmount : 0;
-        $profitAmount = isset($dto->profitAmount) ? (float)$dto->profitAmount : 0;
-        
+        $overheadAmount = isset($dto->overheadAmount) ? (float) $dto->overheadAmount : 0;
+        $profitAmount = isset($dto->profitAmount) ? (float) $dto->profitAmount : 0;
+
         // 2. Fallback: если парсер не нашел суммы, но есть ФОТ и настройки сметы
-        if ($overheadAmount == 0 && $profitAmount == 0 && !$isInformative && $laborCost > 0) {
+        if ($overheadAmount == 0 && $profitAmount == 0 && ! $isInformative && $laborCost > 0) {
             $overheadAmount = round($laborCost * ($estimate->overhead_rate / 100), 2);
             $profitAmount = round($laborCost * ($estimate->profit_rate / 100), 2);
         }
 
         // 3. В Гранд-Смете сумма позиции из колонки "Всего" - это Прямые Затраты!
-        $directCosts = (!$isInformative && !$isSubItem && $totalAmount > 0 && ($overheadAmount > 0 || $profitAmount > 0))
+        $directCosts = (! $isInformative && ! $isSubItem && $totalAmount > 0 && ($overheadAmount > 0 || $profitAmount > 0))
             ? max(0, $totalAmount - $overheadAmount - $profitAmount)
             : $totalAmount;
-        
+
         // Значит Итог с учетом налогов (полная стоимость) - это ПЗ + НР + СП
         // Для подпунктов математика налогов не применяется (их сумма заложена в ПЗ родителя)
-        $actualTotalAmount = (!$isInformative && !$isSubItem && $totalAmount > 0 && ($overheadAmount > 0 || $profitAmount > 0))
+        $actualTotalAmount = (! $isInformative && ! $isSubItem && $totalAmount > 0 && ($overheadAmount > 0 || $profitAmount > 0))
             ? $totalAmount
             : $directCosts + $overheadAmount + $profitAmount;
 
-        
         // 4. Все подпункты делают задвоение, поэтому их исключаем из учета итоговых сумм
         $isNotAccounted = $isInformative || $isSubItem;
 
@@ -680,21 +691,21 @@ class ImportPipelineService
         // Если это материал или оборудование, сохраняем в Каталог Активов (materials)
         $materialId = null;
         $itemType = $this->mapItemType($dto->itemType);
-        
+
         // Не создаём активы для информационных строк
-        if (!$isInformative && in_array($itemType, ['material', 'equipment', 'machinery']) && !empty($dto->itemName)) {
+        if (! $isInformative && in_array($itemType, ['material', 'equipment', 'machinery']) && ! empty($dto->itemName)) {
             try {
                 $material = $this->materialMatcher->findOrCreate(
-                    $dto->code ?? ('MAT-' . uniqid()), // Fallback код, если пусто
+                    $dto->code ?? ('MAT-'.uniqid()), // Fallback код, если пусто
                     $dto->itemName,
                     $dto->unit,
-                    isset($dto->unitPrice) && $dto->unitPrice > 0 ? (float)$dto->unitPrice : null,
+                    isset($dto->unitPrice) && $dto->unitPrice > 0 ? (float) $dto->unitPrice : null,
                     $estimate->organization_id,
                     $itemType === 'equipment' ? 'equipment' : 'material'
                 );
                 $materialId = $material->id;
             } catch (\Exception $e) {
-                Log::warning("[ImportPipeline] Failed to auto-register material '{$dto->itemName}': " . $e->getMessage());
+                Log::warning("[ImportPipeline] Failed to auto-register material '{$dto->itemName}': ".$e->getMessage());
             }
         }
 
@@ -707,11 +718,11 @@ class ImportPipelineService
             'material_id' => $materialId,
             'quantity' => $dto->quantity ?? 0,
             'unit_price' => $dto->unitPrice ?? 0,
-            
+
             'base_unit_price' => $dto->baseUnitPrice ?? 0,
             'price_index' => $dto->priceIndex ?? 1,
             'current_unit_price' => $dto->currentUnitPrice ?? ($dto->unitPrice ?? 0),
-            
+
             'labor_cost' => $laborCost,
             'overhead_amount' => $overheadAmount,
             'profit_amount' => $profitAmount,
@@ -724,18 +735,18 @@ class ImportPipelineService
             'equipment_cost' => $dto->itemType === 'equipment' ? $actualTotalAmount : 0,
             'labor_hours' => $this->detectLaborHours($dto),
             'machinery_hours' => $this->detectMachineryHours($dto),
-            
+
             'normative_rate_code' => $dto->code,
-            'position_number' => (string)($dto->sectionNumber ?: ''),
+            'position_number' => (string) ($dto->sectionNumber ?: ''),
             'item_type' => $itemType,
-            'is_manual' => true, 
+            'is_manual' => true,
             'is_sub_item' => $isSubItem,
             'created_at' => now(),
             'updated_at' => now(),
             'metadata' => json_encode($metadata),
             'is_not_accounted' => $isNotAccounted,
             'disable_sub_item_grouping' => is_array($dto->rawData)
-                && (($dto->rawData['disable_sub_item_grouping'] ?? false) === true)
+                && (($dto->rawData['disable_sub_item_grouping'] ?? false) === true),
         ];
     }
 
@@ -774,14 +785,14 @@ class ImportPipelineService
     }
 
     /**
-     * Помощник для определения "информационных" строк GrandSmeta, 
+     * Помощник для определения "информационных" строк GrandSmeta,
      * которые не должны участвовать в суммировании Прямых Затрат
      */
     private function isInformativeGrandSmetaRow($dto): bool
     {
         $name = mb_strtolower($dto->itemName ?? '');
         $code = mb_strtolower($dto->code ?? '');
-        
+
         // 1. Агрегирующие заголовки (ОТ, ЭМ, М, ОТм) - они несут ФОТ/ПЗ заголовка,
         // но ниже идут детали с теми же деньгами. Чтобы не двоить - помечаем как инфо.
         $aggregates = ['от(зт)', 'эм', 'отм(зтм)', 'м', 'зтм', 'зт', 'от', 'отм', 'мат'];
@@ -808,8 +819,8 @@ class ImportPipelineService
      */
     private function detectLaborCost($dto): float
     {
-        if (isset($dto->laborCost) && (float)$dto->laborCost > 0) {
-            return (float)$dto->laborCost;
+        if (isset($dto->laborCost) && (float) $dto->laborCost > 0) {
+            return (float) $dto->laborCost;
         }
 
         $name = mb_strtolower($dto->itemName ?? '');
@@ -819,7 +830,7 @@ class ImportPipelineService
         // Нам нужно ловить всё, что похоже на зарплату (ОТ, ЗТ, ОТм, ЗТм, ОТ(...)).
         $laborPrefixes = ['от(', 'зт(', 'отм(', 'зтм(', 'от ', 'отм ', 'зт ', 'зтм '];
         $isLaborName = false;
-        
+
         if (in_array($name, ['от', 'отм', 'зт', 'зтм', 'от(зт)', 'отм(зтм)'])) {
             $isLaborName = true;
         } else {
@@ -832,42 +843,42 @@ class ImportPipelineService
         }
 
         if ($isLaborName) {
-            return (float)($dto->currentTotalAmount ?? 0);
+            return (float) ($dto->currentTotalAmount ?? 0);
         }
 
         return 0;
     }
-    
+
     private function detectLaborHours($dto): float
     {
         if ($dto->itemType !== 'labor') {
             return 0;
         }
 
-        $unit = mb_strtolower(trim((string)($dto->unit ?? '')));
+        $unit = mb_strtolower(trim((string) ($dto->unit ?? '')));
         $laborUnits = ['чел.-ч', 'чел-ч', 'чел.ч', 'чел/ч'];
 
         foreach ($laborUnits as $lu) {
             if (str_starts_with($unit, $lu)) {
-                return (float)($dto->quantity ?? 0);
+                return (float) ($dto->quantity ?? 0);
             }
         }
 
-        return (float)($dto->quantity ?? 0);
+        return (float) ($dto->quantity ?? 0);
     }
 
     private function detectMachineryHours($dto): float
     {
-        if (!in_array($dto->itemType, ['machinery', 'equipment'], true)) {
+        if (! in_array($dto->itemType, ['machinery', 'equipment'], true)) {
             return 0;
         }
 
-        $unit = mb_strtolower(trim((string)($dto->unit ?? '')));
+        $unit = mb_strtolower(trim((string) ($dto->unit ?? '')));
         $machineUnits = ['маш.-ч', 'маш-ч', 'маш.ч', 'маш/ч'];
 
         foreach ($machineUnits as $mu) {
             if (str_starts_with($unit, $mu)) {
-                return (float)($dto->quantity ?? 0);
+                return (float) ($dto->quantity ?? 0);
             }
         }
 
@@ -876,21 +887,20 @@ class ImportPipelineService
 
     private function mapItemType(?string $type): string
     {
-        return match($type) {
+        return match ($type) {
             'material' => 'material',
             'machinery' => 'machinery',
-            'labor' => 'labor', 
+            'labor' => 'labor',
             'equipment' => 'equipment',
             'summary' => 'summary',
             default => 'work'
         };
     }
-    
-
 
     private function normalizeUnitName(string $unitName): string
     {
         $normalized = mb_strtolower(trim($unitName));
+
         return $this->unitAliases[$normalized] ?? $normalized;
     }
 
@@ -921,13 +931,13 @@ class ImportPipelineService
             }
         }
 
-        if (!$unit) {
+        if (! $unit) {
             $unit = MeasurementUnit::create([
                 'organization_id' => $organizationId,
-                'name'            => mb_strlen($normalized) > 5 ? $unitName : $normalized, // Сохраняем оригинальное для длинных (если это не просто "м2")
-                'short_name'      => $normalized,
-                'type'            => $unitType,
-                'is_system'       => false,
+                'name' => mb_strlen($normalized) > 5 ? $unitName : $normalized, // Сохраняем оригинальное для длинных (если это не просто "м2")
+                'short_name' => $normalized,
+                'type' => $unitType,
+                'is_system' => false,
             ]);
         }
 

--- a/app/Services/Storage/FileService.php
+++ b/app/Services/Storage/FileService.php
@@ -131,6 +131,13 @@ class FileService
         return $stream;
     }
 
+    public function existsCurrent(string $key): bool
+    {
+        $this->assertOrganizationPath($key);
+
+        return $this->disk()->exists($key);
+    }
+
     public function deleteCurrent(string $key): void
     {
         $this->assertOrganizationPath($key);
@@ -222,6 +229,7 @@ class FileService
         if ($etag === '') {
             throw new VersionedObjectIntegrityException('s3_multipart_part_identity_invalid');
         }
+
         return new MultipartPart(
             $upload->organizationPath,
             $upload->uploadId,
@@ -276,6 +284,7 @@ class FileService
         ) {
             throw new VersionedObjectIntegrityException('s3_multipart_completion_identity_invalid');
         }
+
         return new StoredFile(
             $upload->organizationPath,
             $versionId,
@@ -436,8 +445,7 @@ class FileService
         string $path,
         ?string $versionId,
         int $maxBytes = 64_000_000,
-    ): array
-    {
+    ): array {
         return $this->describeVersionInternal($path, $versionId, $maxBytes, $maxBytes > 0);
     }
 
@@ -447,8 +455,7 @@ class FileService
         ?string $versionId,
         int $maxBytes,
         bool $includeBody,
-    ): array
-    {
+    ): array {
         if ($maxBytes === 0 || $maxBytes === PHP_INT_MIN) {
             throw new \InvalidArgumentException('s3_object_size_invalid');
         }

--- a/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
+++ b/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
@@ -314,13 +314,29 @@ Commit: `refactor[backend]: файлы привязаны к организац�
 - [x] **Step 2: Проверить RED**
 - [x] **Step 3: Перевести AI-отчёты на `PersonalFileService` и текущие-object методы `FileService`**
 - [x] **Step 4: Проверить GREEN и отсутствие прямого доступа к S3**
-- [ ] **Step 5: Commit, PR, merge и deploy**
+- [x] **Step 5: Commit, PR, merge и deploy**
 
 AI-отчёты сохраняются бессрочно по ключу `org-{organization_id}/personal-files/user-{user_id}/{uuid}.pdf`; временной является только download URL. Прямые вызовы `Storage::disk('s3')`, старый каталог `org-{id}/reports` и выбор диска удалены из генераторов.
+
+Выполнено в PR #241 (`2ced1b81ce3502ef1d6b1f50b66ff5180fcc0fa6`), штатный deploy `31057879434` завершён успешно. Production SHA совпал, профильных ошибок в последних 500 строках лога нет.
 
 #### Task 3B.2: Остальные доменные вызовы
 
 **PR:** `refactor/timeweb-s3-domain-callers`
+
+##### Task 3B.2a: Снимки структуры и импорт смет
+
+**PR:** `refactor/timeweb-s3-domain-callers-v2`
+
+- [x] **Step 1: Написать failing архитектурные и доменные тесты**
+- [x] **Step 2: Проверить RED**
+- [x] **Step 3: Перевести снимки структуры и файлы импорта на текущие-object методы `FileService`**
+- [x] **Step 4: Проверить GREEN, потоковую передачу и неизменяемые ключи**
+- [ ] **Step 5: Commit, PR, merge и deploy**
+
+Файлы импорта и снимки структуры получают UUID-ключи внутри `org-{organization_id}`; запись и чтение выполняются потоково через единый приватный бакет без выбора диска или бакета доменным кодом.
+
+##### Task 3B.2b: Оставшиеся доменные вызовы
 
 - [ ] **Step 1: Написать failing архитектурные и доменные тесты**
 - [ ] **Step 2: Проверить RED**

--- a/tests/Unit/BusinessModules/BudgetEstimates/EstimateStructureSnapshotStorageTest.php
+++ b/tests/Unit/BusinessModules/BudgetEstimates/EstimateStructureSnapshotStorageTest.php
@@ -5,43 +5,95 @@ declare(strict_types=1);
 namespace Tests\Unit\BusinessModules\BudgetEstimates;
 
 use App\BusinessModules\Features\BudgetEstimates\Services\EstimateStructureSnapshotStorage;
-use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
+use App\Services\Storage\DTO\CurrentStoredFile;
+use App\Services\Storage\FileService;
+use League\Flysystem\UnableToDeleteFile;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 
-class EstimateStructureSnapshotStorageTest extends TestCase
+final class EstimateStructureSnapshotStorageTest extends TestCase
 {
-    public function test_it_reads_snapshot_from_s3_contract_not_local_storage(): void
+    protected function tearDown(): void
     {
-        Storage::fake('s3');
-        Storage::fake('local');
+        Mockery::close();
 
-        $path = 'org-7/estimates/42/structure_snapshot.json';
-        Storage::disk('s3')->put($path, '{"sections":[{"id":1}]}');
-        Storage::disk('local')->put($path, '{"sections":[{"id":999}]}');
-
-        $storage = new EstimateStructureSnapshotStorage();
-
-        $this->assertTrue($storage->exists($path));
-
-        $stream = $storage->readStream($path);
-        $contents = stream_get_contents($stream);
-        fclose($stream);
-
-        $this->assertSame('{"sections":[{"id":1}]}', $contents);
+        parent::tearDown();
     }
 
-    public function test_delete_uses_s3_contract_only(): void
+    public function test_it_reads_snapshot_through_current_object_gateway(): void
     {
-        Storage::fake('s3');
-        Storage::fake('local');
-
         $path = 'org-7/estimates/42/structure_snapshot.json';
-        Storage::disk('s3')->put($path, '{"sections":[]}');
-        Storage::disk('local')->put($path, '{"sections":[]}');
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+        fwrite($stream, '{"sections":[{"id":1}]}');
+        rewind($stream);
 
-        (new EstimateStructureSnapshotStorage())->delete($path);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('existsCurrent')->once()->with($path)->andReturnTrue();
+        $files->shouldReceive('readCurrent')->once()->with($path)->andReturn($stream);
 
-        Storage::disk('s3')->assertMissing($path);
-        Storage::disk('local')->assertExists($path);
+        $storage = new EstimateStructureSnapshotStorage($files);
+
+        self::assertTrue($storage->exists($path));
+        $readStream = $storage->readStream($path);
+        self::assertSame('{"sections":[{"id":1}]}', stream_get_contents($readStream));
+        fclose($readStream);
+    }
+
+    public function test_it_streams_json_with_sha256_through_current_object_gateway(): void
+    {
+        $path = 'org-7/estimates/42/structure_snapshot.json';
+        $payload = ['sections' => [['id' => 1, 'name' => 'Раздел']], 'items' => []];
+        $contents = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('putPrivate')
+            ->once()
+            ->with(
+                $path,
+                Mockery::on(static function (mixed $stream) use ($contents): bool {
+                    return is_resource($stream) && stream_get_contents($stream) === $contents;
+                }),
+                'application/json',
+                hash('sha256', $contents),
+            )
+            ->andReturn(new CurrentStoredFile(
+                $path,
+                'etag',
+                strlen($contents),
+                hash('sha256', $contents),
+                'application/json',
+            ));
+        $storage = new EstimateStructureSnapshotStorage($files);
+        $storage->putJson($path, $payload);
+
+        self::assertTrue(true);
+    }
+
+    public function test_snapshot_cleanup_is_best_effort_after_publication(): void
+    {
+        $path = 'org-7/estimates/42/old.json';
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('existsCurrent')->once()->with($path)->andReturnTrue();
+        $files->shouldReceive('deleteCurrent')
+            ->once()
+            ->with($path)
+            ->andThrow(UnableToDeleteFile::atLocation($path));
+
+        (new EstimateStructureSnapshotStorage($files))->delete($path);
+
+        self::assertTrue(true);
+    }
+
+    public function test_snapshot_cleanup_ignores_obsolete_unscoped_key(): void
+    {
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('existsCurrent')
+            ->once()
+            ->with('shared/estimates/42/old.json')
+            ->andThrow(new \InvalidArgumentException('organization_storage_path_invalid'));
+
+        (new EstimateStructureSnapshotStorage($files))->delete('shared/estimates/42/old.json');
+
+        self::assertTrue(true);
     }
 }

--- a/tests/Unit/Storage/BudgetEstimateImportFileStorageServiceTest.php
+++ b/tests/Unit/Storage/BudgetEstimateImportFileStorageServiceTest.php
@@ -5,37 +5,142 @@ declare(strict_types=1);
 namespace Tests\Unit\Storage;
 
 use App\BusinessModules\Features\BudgetEstimates\Services\Import\FileStorageService;
+use App\Models\ImportSession;
+use App\Services\Storage\DTO\CurrentStoredFile;
+use App\Services\Storage\FileService;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 
-class BudgetEstimateImportFileStorageServiceTest extends TestCase
+final class BudgetEstimateImportFileStorageServiceTest extends TestCase
 {
-    public function refreshDatabase(): void
+    protected function tearDown(): void
     {
+        Mockery::close();
+
+        parent::tearDown();
     }
 
-    public function testStoresImportFilesInsideOrganizationPrefix(): void
+    public function test_stores_import_files_inside_organization_prefix(): void
     {
-        Storage::fake('s3');
-
-        $service = new FileStorageService();
         $tmpPath = tempnam(sys_get_temp_dir(), 'estimate-import-test-');
-        $this->assertIsString($tmpPath);
+        self::assertIsString($tmpPath);
         file_put_contents($tmpPath, 'test-content');
-
         $file = new UploadedFile(
             $tmpPath,
             'estimate.xlsx',
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             null,
-            true
+            true,
+        );
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('putPrivate')
+            ->once()
+            ->with(
+                Mockery::pattern('/^org-39\/estimate-imports\/[0-9a-f-]+\.xlsx$/'),
+                Mockery::on(static fn (mixed $value): bool => is_resource($value)
+                    && stream_get_contents($value) === 'test-content'),
+                Mockery::type('string'),
+                hash('sha256', 'test-content'),
+            )
+            ->andReturnUsing(static fn (string $key): CurrentStoredFile => new CurrentStoredFile(
+                $key,
+                'etag',
+                strlen('test-content'),
+                hash('sha256', 'test-content'),
+                'application/octet-stream',
+            ));
+
+        $result = (new FileStorageService($files))->store($file, 39);
+
+        self::assertStringStartsWith('org-39/estimate-imports/', $result['path']);
+        self::assertStringEndsWith('.xlsx', $result['path']);
+        self::assertSame(strlen('test-content'), $result['size']);
+    }
+
+    public function test_normalizes_import_extension_before_building_storage_key(): void
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'estimate-import-test-');
+        self::assertIsString($tmpPath);
+        file_put_contents($tmpPath, 'test-content');
+        $file = new UploadedFile($tmpPath, 'ESTIMATE.XLSX', null, null, true);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('putPrivate')
+            ->once()
+            ->withArgs(static fn (string $key): bool => str_ends_with($key, '.xlsx'))
+            ->andReturnUsing(static fn (string $key): CurrentStoredFile => new CurrentStoredFile(
+                $key,
+                'etag',
+                strlen('test-content'),
+                hash('sha256', 'test-content'),
+                'application/octet-stream',
+            ));
+
+        $result = (new FileStorageService($files))->store($file, 39);
+
+        self::assertSame('xlsx', $result['extension']);
+        self::assertStringEndsWith('.xlsx', $result['path']);
+    }
+
+    public function test_downloads_and_deletes_import_file_through_current_object_gateway(): void
+    {
+        $path = 'org-39/estimate-imports/01989f5c-27f3-7ab8-9e34-5d436c15a004.xlsx';
+        $session = (new ImportSession)->forceFill(['id' => 'session-1', 'file_path' => $path]);
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+        fwrite($stream, 'spreadsheet-content');
+        rewind($stream);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('existsCurrent')->twice()->with($path)->andReturnTrue();
+        $files->shouldReceive('readCurrent')->once()->with($path)->andReturn($stream);
+        $files->shouldReceive('deleteCurrent')->once()->with($path);
+        $service = new FileStorageService($files);
+
+        $localPath = null;
+        $contents = $service->withLocalCopy(
+            $session,
+            static function (string $path) use (&$localPath): string {
+                $localPath = $path;
+                self::assertFileExists($path);
+
+                return (string) file_get_contents($path);
+            },
         );
 
-        $result = $service->store($file, 39);
+        self::assertSame('spreadsheet-content', $contents);
+        self::assertIsString($localPath);
+        self::assertFileDoesNotExist($localPath);
+        self::assertTrue($service->delete($session));
+    }
 
-        $this->assertStringStartsWith('org-39/estimate-imports/', $result['path']);
-        $this->assertStringEndsWith('.xlsx', $result['path']);
-        Storage::disk('s3')->assertExists($result['path']);
+    public function test_managed_local_copy_is_removed_when_callback_fails(): void
+    {
+        $path = 'org-39/estimate-imports/01989f5c-27f3-7ab8-9e34-5d436c15a004.xlsx';
+        $session = (new ImportSession)->forceFill(['id' => 'session-1', 'file_path' => $path]);
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+        fwrite($stream, 'spreadsheet-content');
+        rewind($stream);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('existsCurrent')->once()->with($path)->andReturnTrue();
+        $files->shouldReceive('readCurrent')->once()->with($path)->andReturn($stream);
+        $localPath = null;
+
+        try {
+            (new FileStorageService($files))->withLocalCopy(
+                $session,
+                static function (string $path) use (&$localPath): never {
+                    $localPath = $path;
+
+                    throw new \RuntimeException('callback_failed');
+                },
+            );
+            self::fail('Callback exception was not propagated.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('callback_failed', $exception->getMessage());
+        }
+
+        self::assertIsString($localPath);
+        self::assertFileDoesNotExist($localPath);
     }
 }

--- a/tests/Unit/Storage/BudgetEstimateStorageArchitectureTest.php
+++ b/tests/Unit/Storage/BudgetEstimateStorageArchitectureTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Storage;
+
+use PHPUnit\Framework\TestCase;
+
+final class BudgetEstimateStorageArchitectureTest extends TestCase
+{
+    public function test_budget_estimate_storage_uses_only_current_object_gateway(): void
+    {
+        foreach ([
+            'app/BusinessModules/Features/BudgetEstimates/Services/EstimateStructureSnapshotStorage.php',
+            'app/BusinessModules/Features/BudgetEstimates/Services/Import/FileStorageService.php',
+        ] as $relativePath) {
+            $source = file_get_contents(__DIR__.'/../../../'.$relativePath);
+
+            self::assertIsString($source);
+            self::assertStringContainsString('FileService', $source);
+            self::assertStringNotContainsString('Storage::', $source);
+            self::assertStringNotContainsString('->disk(', $source);
+            self::assertStringNotContainsString("private const DISK = 's3'", $source);
+        }
+    }
+
+    public function test_import_files_use_streaming_current_object_operations(): void
+    {
+        $source = file_get_contents(
+            __DIR__.'/../../../app/BusinessModules/Features/BudgetEstimates/Services/Import/FileStorageService.php',
+        );
+
+        self::assertIsString($source);
+        self::assertStringContainsString('putPrivate(', $source);
+        self::assertStringContainsString('readCurrent(', $source);
+        self::assertStringContainsString('deleteCurrent(', $source);
+        self::assertStringContainsString('stream_copy_to_stream(', $source);
+        self::assertStringContainsString('withLocalCopy(', $source);
+        self::assertStringNotContainsString('file_get_contents(', $source);
+    }
+
+    public function test_import_callers_use_managed_local_copies(): void
+    {
+        foreach ([
+            'app/BusinessModules/Features/BudgetEstimates/Services/Import/EstimateImportService.php',
+            'app/BusinessModules/Features/BudgetEstimates/Services/Import/ImportPipelineService.php',
+            'verify_grandsmeta_mapping.php',
+        ] as $relativePath) {
+            $source = file_get_contents(__DIR__.'/../../../'.$relativePath);
+
+            self::assertIsString($source);
+            self::assertStringContainsString('withLocalCopy(', $source);
+            self::assertStringNotContainsString('getAbsolutePath(', $source);
+        }
+    }
+
+    public function test_file_gateway_exposes_guarded_current_object_existence_check(): void
+    {
+        $source = file_get_contents(__DIR__.'/../../../app/Services/Storage/FileService.php');
+
+        self::assertIsString($source);
+        self::assertStringContainsString('public function existsCurrent(string $key): bool', $source);
+        self::assertStringContainsString('$this->assertOrganizationPath($key);', $source);
+    }
+
+    public function test_snapshot_job_uses_immutable_organization_key(): void
+    {
+        $source = file_get_contents(
+            __DIR__.'/../../../app/BusinessModules/Features/BudgetEstimates/Jobs/GenerateEstimateSnapshotJob.php',
+        );
+
+        self::assertIsString($source);
+        self::assertStringContainsString('OrganizationStoragePath::forOrganization(', $source);
+        self::assertStringContainsString('Str::uuid()', $source);
+        self::assertStringContainsString('putJson(', $source);
+        self::assertStringNotContainsString('json_encode($payload', $source);
+        self::assertStringNotContainsString("'shared'", $source);
+        self::assertStringNotContainsString('$versionTimestamp', $source);
+    }
+}

--- a/tests/Unit/Storage/FileServiceCurrentObjectTest.php
+++ b/tests/Unit/Storage/FileServiceCurrentObjectTest.php
@@ -44,6 +44,7 @@ final class FileServiceCurrentObjectTest extends TestCase
 
         $stored = $files->putPrivate($key, $contents, 'application/pdf', $checksum);
         $link = $files->temporaryDownloadUrl($key, 300);
+        self::assertTrue($files->existsCurrent($key));
         $readStream = $files->readCurrent($key);
         $files->deleteCurrent($key);
 
@@ -192,6 +193,11 @@ final class FileServiceCurrentObjectTest extends TestCase
                 rewind($stream);
 
                 return $stream;
+            }
+
+            public function exists($path): bool
+            {
+                return true;
             }
 
             public function delete($paths): bool

--- a/verify_grandsmeta_mapping.php
+++ b/verify_grandsmeta_mapping.php
@@ -1,27 +1,28 @@
 <?php
 
-use App\Models\ImportSession;
 use App\BusinessModules\Features\BudgetEstimates\Services\Import\Formats\GrandSmeta\GrandSmetaHandler;
+use App\Models\ImportSession;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 $session = ImportSession::latest()->first();
-if (!$session) {
+if (! $session) {
     echo "Session not found.\n";
     exit;
 }
 
 $fileStorage = app(\App\BusinessModules\Features\BudgetEstimates\Services\Import\FileStorageService::class);
-$fullPath = $fileStorage->getAbsolutePath($session);
+$fileStorage->withLocalCopy($session, static function (string $fullPath): void {
+    echo "Loading file: {$fullPath}\n";
+
+    $content = IOFactory::load($fullPath);
+    $sheet = $content->getActiveSheet();
+
+    $handler = new GrandSmetaHandler;
+    $detection = $handler->findHeaderAndMapping($sheet);
+
+    echo 'Detected Header Row: '.$detection['header_row']."\n";
+    echo "Detected Mapping:\n";
+    print_r($detection['mapping']);
+});
 
 echo "Session ID: {$session->id}\n";
-echo "Loading file: {$fullPath}\n";
-
-$content = IOFactory::load($fullPath);
-$sheet = $content->getActiveSheet();
-
-$handler = new GrandSmetaHandler();
-$detection = $handler->findHeaderAndMapping($sheet);
-
-echo "Detected Header Row: " . $detection['header_row'] . "\n";
-echo "Detected Mapping:\n";
-print_r($detection['mapping']);


### PR DESCRIPTION
## Что изменено
- снимки структуры смет и файлы импорта переведены на единый `App\Services\Storage\FileService`
- ключи создаются только внутри `org-{organization_id}` и используют UUID
- загрузка/скачивание импорта и JSON-снимки работают потоково с SHA-256
- временные локальные копии гарантированно удаляются после каждого этапа
- очистка предыдущего снимка стала best-effort и не отменяет опубликованный результат
- прямой выбор S3-диска или бакета из доменного кода удалён

## Проверки
- `vendor/bin/pint` — успешно
- 19 unit/architecture тестов, 84 утверждения — успешно
- PHPStan по изменённым файлам — без ошибок
- независимое повторное ревью — Critical/Important замечаний нет

Старые непрефиксованные ключи намеренно не поддерживаются: миграция выполняется без переноса и без fallback согласно принятому решению.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored budget estimate snapshot and import services to use the centralized FileService instead of direct S3 disk access.</li>
<li>Updated GenerateEstimateSnapshotJob and related services to handle file storage via the FileService gateway, ensuring consistent organization-scoped paths.</li>
<li>Replaced direct storage disk calls with FileService methods (e.g., existsCurrent, readCurrent, putPrivate) to enforce domain-specific storage policies.</li>
<li>Added and updated unit tests to verify the new storage architecture, replacing direct Storage facade mocks with FileService mocks.</li>
<li>Updated documentation to reflect the migration of budget estimate storage to the new FileService-based architecture.</li>
</ul></div>