### PR TITLE
perf[backend]: ограничено чтение истории отчёта R12

### DIFF
--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureBuiltinPublishedReport.php
@@ -12,7 +12,7 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFa
 
 final readonly class ContractSettlementExposureBuiltinPublishedReport
 {
-    public const CONTRACT_VERSION = '2.0.0';
+    public const CONTRACT_VERSION = '3.0.0';
     public const RENDERER_VERSION = '1.0.0';
     public const MANIFEST_ORDINAL = 14;
 

--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureCandidateContract.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureCandidateContract.php
@@ -24,9 +24,9 @@ final readonly class ContractSettlementExposureCandidateContract
 {
     public const CODE = 'contract_settlement_exposure';
     public const FORMULA_VERSION = ContractSettlementCalculator::FORMULA_VERSION;
-    public const SOURCE_SCHEMA_VERSION = 'contract_settlement_owner_history_party_v2';
+    public const SOURCE_SCHEMA_VERSION = 'contract_settlement_owner_history_latest_v3';
     public const FORMULA_HASH = 'b0c715bcda2e44886ac32fd37e8dc3e30edc333adb01801e5f7f21481d65b9f2';
-    public const SOURCE_HASH = '10180b068e2b5697ab76c96bcbd597331b7d53e4147226250fa135f7d6c4d33c';
+    public const SOURCE_HASH = 'a9003f712e1a298d546cada5dda0232d476157a6e10ae8d418116608d680ba1c';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerSource.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementOwnerSource.php
@@ -599,14 +599,10 @@ final readonly class ContractSettlementOwnerSource
         if (! $checkpoint instanceof ContractSettlementOwnerHistoryCheckpoint) {
             throw new DomainException('contract_settlement_owner_history_checkpoint_missing');
         }
-        $versions = ContractSettlementOwnerVersion::query()
-            ->where('organization_id', $scope->organizationId)
-            ->where('occurred_at', '<=', $asOf)
-            ->orderBy('owner_type')
-            ->orderBy('owner_id')
-            ->orderByDesc('version')
-            ->get()
-            ->unique(static fn (ContractSettlementOwnerVersion $version): string => $version->owner_type.':'.$version->owner_id);
+        $versions = $this->latestOwnerVersions(
+            $scope->organizationId,
+            $asOf,
+        );
         if ($versions->isEmpty()) {
             throw new DomainException('contract_settlement_owner_history_missing');
         }
@@ -637,6 +633,23 @@ final readonly class ContractSettlementOwnerSource
         }
 
         return $owners;
+    }
+
+    private function latestOwnerVersions(int $organizationId, string $asOf): Collection
+    {
+        $latestIds = ContractSettlementOwnerVersion::query()
+            ->selectRaw('DISTINCT ON (owner_type, owner_id) id')
+            ->where('organization_id', $organizationId)
+            ->where('occurred_at', '<=', $asOf)
+            ->orderBy('owner_type')
+            ->orderBy('owner_id')
+            ->orderByDesc('version');
+
+        return ContractSettlementOwnerVersion::query()
+            ->whereIn('id', $latestIds)
+            ->orderBy('owner_type')
+            ->orderBy('owner_id')
+            ->get();
     }
 
     private static function minor(string $amount): int

--- a/app/BusinessModules/Features/ContractManagement/migrations/2026_08_06_000110_add_latest_owner_version_index.php
+++ b/app/BusinessModules/Features/ContractManagement/migrations/2026_08_06_000110_add_latest_owner_version_index.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const INDEX = 'contract_settlement_owner_latest_asof_idx';
+
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            $this->dropInvalidPostgresIndex();
+            DB::statement(
+                'CREATE INDEX CONCURRENTLY IF NOT EXISTS '.self::INDEX.' '
+                .'ON contract_settlement_owner_versions '
+                .'(organization_id, owner_type, owner_id, version DESC, occurred_at) INCLUDE (id)',
+            );
+
+            return;
+        }
+
+        Schema::table('contract_settlement_owner_versions', function (Blueprint $table): void {
+            $table->index(
+                ['organization_id', 'owner_type', 'owner_id', 'version', 'occurred_at'],
+                self::INDEX,
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        if (Schema::getConnection()->getDriverName() === 'pgsql') {
+            DB::statement('DROP INDEX CONCURRENTLY IF EXISTS '.self::INDEX);
+
+            return;
+        }
+
+        Schema::table('contract_settlement_owner_versions', function (Blueprint $table): void {
+            $table->dropIndex(self::INDEX);
+        });
+    }
+
+    private function dropInvalidPostgresIndex(): void
+    {
+        $invalid = DB::selectOne(
+            'SELECT 1 FROM pg_index AS index_state '
+            .'INNER JOIN pg_class AS index_class ON index_class.oid = index_state.indexrelid '
+            .'INNER JOIN pg_namespace AS index_namespace ON index_namespace.oid = index_class.relnamespace '
+            .'WHERE index_namespace.nspname = current_schema() '
+            .'AND index_class.relname = ? AND index_state.indisvalid = false',
+            [self::INDEX],
+        );
+        if ($invalid !== null) {
+            DB::statement('DROP INDEX CONCURRENTLY IF EXISTS '.self::INDEX);
+        }
+    }
+};

--- a/tests/Feature/Reporting/FinanceOwnerPostgresContractTest.php
+++ b/tests/Feature/Reporting/FinanceOwnerPostgresContractTest.php
@@ -6,6 +6,8 @@ namespace Tests\Feature\Reporting;
 
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerHistoryBackfillService;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementAllocationConserver;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerSource;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerTimestamp;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerVersionRecorder;
 use App\BusinessModules\Features\ContractManagement\Reporting\Models\ContractSettlementOwnerHistoryCheckpoint;
@@ -21,6 +23,7 @@ use App\Models\User;
 use DateTimeImmutable;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
 use Tests\Support\Reporting\PostgresProcessRaceHarness;
 use Tests\TestCase;
 
@@ -176,6 +179,70 @@ SQL));
         self::assertSame($versionCount, DB::table('contract_settlement_owner_versions')
             ->where('organization_id', $organization->id)
             ->count());
+    }
+
+    #[Test]
+    public function contract_settlement_owner_query_returns_only_latest_version_available_at_as_of(): void
+    {
+        $organization = Organization::factory()->create();
+        $otherOrganization = Organization::factory()->create();
+        $ownerId = (string) random_int(1_000_000, 2_000_000);
+        $deletedOwnerId = (string) random_int(2_000_001, 3_000_000);
+        $firstAt = new DateTimeImmutable('2026-08-06T00:00:00.100000+00:00');
+        $secondAt = new DateTimeImmutable('2026-08-06T00:00:00.200000+00:00');
+        $futureAt = new DateTimeImmutable('2026-08-06T00:00:00.300000+00:00');
+        $insertVersion = static function (
+            int $organizationId,
+            string $identity,
+            int $version,
+            DateTimeImmutable $occurredAt,
+            string $operation,
+            string $marker,
+        ): void {
+            DB::table('contract_settlement_owner_versions')->insert([
+                'organization_id' => $organizationId,
+                'owner_type' => 'contract',
+                'owner_id' => $identity,
+                'version' => $version,
+                'operation' => $operation,
+                'occurred_at' => ContractSettlementOwnerTimestamp::database($occurredAt),
+                'payload' => json_encode(['marker' => $marker], JSON_THROW_ON_ERROR),
+                'owner_hash' => hash('sha256', $marker),
+                'created_at' => $occurredAt,
+                'updated_at' => $occurredAt,
+            ]);
+        };
+        foreach ([
+            [1, $firstAt, 'v1'],
+            [2, $secondAt, 'v2'],
+            [3, $futureAt, 'v3'],
+        ] as [$version, $occurredAt, $marker]) {
+            $insertVersion((int) $organization->id, $ownerId, $version, $occurredAt, 'upsert', $marker);
+        }
+        $insertVersion((int) $otherOrganization->id, $ownerId, 9, $secondAt, 'upsert', 'other-tenant');
+        $insertVersion((int) $organization->id, $deletedOwnerId, 1, $firstAt, 'upsert', 'before-delete');
+        $insertVersion((int) $organization->id, $deletedOwnerId, 2, $secondAt, 'delete', 'deleted');
+        $insertVersion((int) $organization->id, $deletedOwnerId, 3, $futureAt, 'upsert', 'future-recreated');
+
+        $source = new ContractSettlementOwnerSource(new ContractSettlementAllocationConserver);
+        $method = new ReflectionMethod($source, 'latestOwnerVersions');
+        $versions = $method->invoke(
+            $source,
+            (int) $organization->id,
+            ContractSettlementOwnerTimestamp::database($secondAt),
+        );
+
+        self::assertCount(2, $versions);
+        self::assertTrue($versions->every(
+            static fn (ContractSettlementOwnerVersion $version): bool => (int) $version->organization_id
+                === (int) $organization->id,
+        ));
+        $selected = $versions->keyBy('owner_id');
+        self::assertSame(2, (int) $selected->get($ownerId)?->version);
+        self::assertSame('v2', $selected->get($ownerId)?->payload['marker'] ?? null);
+        self::assertSame(2, (int) $selected->get($deletedOwnerId)?->version);
+        self::assertSame('delete', (string) $selected->get($deletedOwnerId)?->operation);
+        self::assertSame('deleted', $selected->get($deletedOwnerId)?->payload['marker'] ?? null);
     }
 
     #[Test]

--- a/tests/Unit/Reporting/WaveOne/ContractSettlementExposurePublishedContractTest.php
+++ b/tests/Unit/Reporting/WaveOne/ContractSettlementExposurePublishedContractTest.php
@@ -43,7 +43,7 @@ final class ContractSettlementExposurePublishedContractTest extends TestCase
         self::assertSame([], $definition->permissionPolicy->sensitivePermissions);
         self::assertSame([], $definition->permissionPolicy->auditPermissions);
         self::assertSame(['csv', 'xlsx'], $definition->formats);
-        self::assertSame('2.0.0', $definition->contractVersion);
+        self::assertSame('3.0.0', $definition->contractVersion);
         self::assertContains('party', array_column($definition->columns, 'id'));
         self::assertNotContains('party_type', array_column($definition->columns, 'id'));
         self::assertNotContains('party_key', array_column($definition->columns, 'id'));

--- a/tests/Unit/Reporting/WaveOne/ContractSettlementOwnerLatestVersionQueryTest.php
+++ b/tests/Unit/Reporting/WaveOne/ContractSettlementOwnerLatestVersionQueryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\WaveOne;
+
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementOwnerSource;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ContractSettlementOwnerLatestVersionQueryTest extends TestCase
+{
+    public function test_owner_source_selects_only_latest_as_of_version_in_postgres(): void
+    {
+        $sourceFile = (new ReflectionClass(ContractSettlementOwnerSource::class))->getFileName();
+        self::assertIsString($sourceFile);
+        $source = file_get_contents($sourceFile);
+
+        self::assertIsString($source);
+        self::assertStringContainsString(
+            "selectRaw('DISTINCT ON (owner_type, owner_id) id')",
+            $source,
+        );
+        self::assertStringContainsString("->whereIn('id', \$latestIds)", $source);
+        self::assertStringContainsString("->orderByDesc('version')", $source);
+        self::assertStringNotContainsString(
+            '->unique(static fn (ContractSettlementOwnerVersion',
+            $source,
+        );
+
+        $migration = file_get_contents(dirname(__DIR__, 4)
+            .'/app/BusinessModules/Features/ContractManagement/migrations/'
+            .'2026_08_06_000110_add_latest_owner_version_index.php');
+        self::assertIsString($migration);
+        self::assertStringContainsString('public $withinTransaction = false', $migration);
+        self::assertStringContainsString('CREATE INDEX CONCURRENTLY IF NOT EXISTS', $migration);
+        self::assertStringContainsString('index_state.indisvalid = false', $migration);
+        self::assertStringContainsString('DROP INDEX CONCURRENTLY IF EXISTS', $migration);
+        self::assertStringContainsString(
+            '(organization_id, owner_type, owner_id, version DESC, occurred_at)',
+            $migration,
+        );
+        self::assertStringContainsString('INCLUDE (id)', $migration);
+    }
+}


### PR DESCRIPTION
Узкий performance-релиз backend runtime R12.\n\n- выбирает в PostgreSQL только последнюю доступную на as-of версию владельца\n- сохраняет tenant isolation, future exclusion и delete-wins\n- добавляет concurrent covering index без транзакции миграции\n- повышает контракт источника до 3.0.0 и обновляет fingerprint\n\nПроверки: php -l 7 файлов, git diff --check, точный source fingerprint, независимое review CLEAN. PHPUnit/PHPStan локально недоступны: vendor отсутствует; дальнейшее доказательство — основной deploy workflow и production evidence.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated contract version to 3.0.0 and source schema version to v3.</li>
<li>Optimized historical owner version retrieval by introducing a new database index and a more efficient query method.</li>
<li>Added a new database migration to create a PostgreSQL-specific index for latest owner versions.</li>
<li>Updated relevant feature and unit tests to reflect the changes in contract and query logic.</li>
</ul></div>