### PR TITLE
feat[backend]: добавлены параметры отчёта R12

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ContractSettlementExposureReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ContractSettlementExposureReportOptionsController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ContractSettlementExposureReportOptionsRequest;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureCandidateContract;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class ContractSettlementExposureReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private ContractSettlementExposureOptionsService $options,
+    ) {}
+
+    public function __invoke(ContractSettlementExposureReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, ContractSettlementExposureCandidateContract::CODE)['context'];
+
+        return AdminResponse::success($this->options->options($context->scope, $request->asOf()));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -95,6 +95,7 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.workforce-capacity.options',
             'admin.reports.portfolio-liquidity.options',
             'admin.reports.contract-settlement-exposure.runs.store',
+            'admin.reports.contract-settlement-exposure.options',
             'admin.reports.holding-performance.runs.store',
             'admin.reports.holding-performance.options',
             'admin.reports.intercompany-contract-flows.runs.store',

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ContractSettlementExposureReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ContractSettlementExposureReportOptionsRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use DateTimeImmutable;
+
+final class ContractSettlementExposureReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'as_of' => [
+                'required',
+                'string',
+                static function (string $attribute, mixed $value, callable $fail): void {
+                    if (ReportAsOfParser::parse($value) === null) {
+                        $fail(trans_message('reports.errors.report_request_invalid'));
+                    }
+                },
+            ],
+            ...$this->forbiddenClientFieldsRules(),
+            'current_organization_id' => ['prohibited'],
+            'holding_organization_ids' => ['prohibited'],
+            'organization_ids' => ['prohibited'],
+            'project_id' => ['prohibited'],
+            'current_project_id' => ['prohibited'],
+            'project_ids' => ['prohibited'],
+            'scope' => ['prohibited'],
+            'actor_id' => ['prohibited'],
+        ];
+    }
+
+    protected function acceptedQueryFields(): array
+    {
+        return ['as_of'];
+    }
+
+    public function asOf(): DateTimeImmutable
+    {
+        $asOf = ReportAsOfParser::parse($this->validated('as_of'));
+        if ($asOf === null) {
+            throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => ['as_of']],
+            );
+        }
+
+        return $asOf;
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMatrix;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ContractSettlementExposureReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\HoldingPerformanceReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\IntercompanyContractFlowReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
@@ -117,6 +118,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'contract_settlement_exposure')
             ->middleware(['report.organization-scope', $resourceAccess])
             ->name('contract-settlement-exposure.runs.store');
+        Route::get('/contract-settlement-exposure/options', ContractSettlementExposureReportOptionsController::class)
+            ->defaults('reportCode', 'contract_settlement_exposure')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('contract-settlement-exposure.options');
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');

--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureOptionsService.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureOptionsService.php
@@ -1,0 +1,493 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ContractManagement\Reporting;
+
+use App\BusinessModules\Core\Payments\Enums\PaymentDocumentStatus;
+use App\BusinessModules\Core\Payments\Enums\PaymentDocumentType;
+use App\BusinessModules\Core\Payments\Reporting\SettlementAgingBucket;
+use App\BusinessModules\Core\Payments\Services\Reports\SettlementAgingPolicy;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Features\ContractManagement\Reporting\DTO\ContractSettlementInput;
+use App\Enums\CurrencyCode;
+use DateTimeImmutable;
+use DomainException;
+use Illuminate\Database\ConnectionInterface;
+use InvalidArgumentException;
+use JsonException;
+
+final readonly class ContractSettlementExposureOptionsService
+{
+    public function __construct(
+        private ContractSettlementOwnerSource $source,
+        private ContractSettlementExposureBuiltinPublishedReport $published,
+        private ContractSettlementCalculator $calculator,
+        private SettlementAgingPolicy $agingPolicy,
+        private ConnectionInterface $connection,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function options(ReportScope $scope, DateTimeImmutable $asOf): array
+    {
+        if ($this->connection->transactionLevel() > 0) {
+            return $this->optionsWithinStableView($scope, $asOf);
+        }
+
+        return $this->connection->transaction(function () use ($scope, $asOf): array {
+            if ($this->connection->getDriverName() === 'pgsql') {
+                $this->connection->statement('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY');
+            }
+
+            return $this->optionsWithinStableView($scope, $asOf);
+        }, 3);
+    }
+
+    /** @return array<string, mixed> */
+    private function optionsWithinStableView(ReportScope $scope, DateTimeImmutable $asOf): array
+    {
+        $query = new ReportQuery(
+            $this->published->definition()->payload(),
+            $scope,
+            new ReportFilterSet([]),
+            [],
+            $asOf,
+            'ru-RU',
+        );
+
+        try {
+            $inputs = $this->source->read($scope, $query);
+            $options = $this->assemble($scope, $asOf, $inputs);
+        } catch (DomainException|InvalidArgumentException) {
+            return $this->unavailable($asOf, 'source_unavailable');
+        }
+
+        return [
+            'available' => true,
+            'reason' => null,
+            'as_of' => $this->exactDateTime($asOf),
+            ...$options,
+        ];
+    }
+
+    /**
+     * @param  list<ContractSettlementInput>  $inputs
+     * @return array<string, mixed>
+     */
+    private function assemble(ReportScope $scope, DateTimeImmutable $asOf, array $inputs): array
+    {
+        $contractIds = [];
+        $projectIds = [];
+        $partyKeys = [];
+        $directions = [];
+        $currencies = [];
+        $agingBuckets = [];
+        $paymentDocumentIds = [];
+        $minimumDueAt = null;
+        $maximumDueAt = null;
+        $inputByAllocation = [];
+
+        foreach ($inputs as $input) {
+            if (! $input instanceof ContractSettlementInput
+                || ($scope->projectIds !== [] && ! in_array($input->projectId, $scope->projectIds, true))) {
+                throw new DomainException('contract_settlement_options_scope_invalid');
+            }
+
+            $contractIds[$input->contractId] = true;
+            if ($input->projectId !== null) {
+                $projectIds[$input->projectId] = true;
+            }
+            $partyKey = $input->partyKey();
+            if ($partyKey !== null) {
+                $partyKeys[$partyKey] = true;
+            }
+            $directions[$input->direction] = true;
+            $currencies[$input->currency] = true;
+            $agingBuckets[$this->calculator->calculate($input, $this->agingPolicy)->agingBucket] = true;
+            $inputByAllocation[$input->allocationId] = $input;
+
+            if ($input->dueAt !== null) {
+                $minimumDueAt = $minimumDueAt === null || $input->dueAt < $minimumDueAt
+                    ? $input->dueAt
+                    : $minimumDueAt;
+                $maximumDueAt = $maximumDueAt === null || $input->dueAt > $maximumDueAt
+                    ? $input->dueAt
+                    : $maximumDueAt;
+            }
+            foreach ($input->sourceRefs as $reference) {
+                if (is_array($reference)
+                    && ($reference['type'] ?? null) === 'payment_document'
+                    && ctype_digit((string) ($reference['id'] ?? ''))) {
+                    $paymentDocumentIds[(int) $reference['id']] = true;
+                }
+            }
+        }
+
+        $contractPayloads = $this->ownerPayloads($scope, $asOf, 'contract', array_keys($contractIds));
+        $paymentPayloads = $this->ownerPayloads(
+            $scope,
+            $asOf,
+            'payment_document',
+            array_keys($paymentDocumentIds),
+        );
+        $projects = $this->projectOptions($scope, array_keys($projectIds));
+        $contracts = $this->contractOptions($contractPayloads, array_keys($contractIds), $inputByAllocation);
+        $parties = $this->partyOptions(array_values($inputByAllocation));
+
+        if (count($projects) !== count($projectIds)
+            || count($contracts) !== count($contractIds)
+            || count($parties) !== count($partyKeys)) {
+            throw new DomainException('contract_settlement_options_reference_missing');
+        }
+
+        return [
+            'period' => [
+                'default_from' => null,
+                'default_to' => $asOf->setTimezone($scope->timezone)->format('Y-m-d'),
+            ],
+            'due' => [
+                'minimum' => $minimumDueAt?->format('Y-m-d'),
+                'maximum' => $maximumDueAt?->format('Y-m-d'),
+            ],
+            'projects' => $projects,
+            'contracts' => $contracts,
+            'allocations' => $this->allocationOptions($inputByAllocation, $projects, $contracts),
+            'parties' => $parties,
+            'directions' => $this->translatedOptions('directions', array_keys($directions)),
+            'instruments' => $this->paymentOptions($paymentPayloads, 'document_type'),
+            'statuses' => $this->paymentOptions($paymentPayloads, 'status'),
+            'currencies' => $this->currencyOptions(array_keys($currencies)),
+            'aging_buckets' => $this->agingOptions(array_keys($agingBuckets)),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return array<int, array<string, mixed>>
+     */
+    private function ownerPayloads(
+        ReportScope $scope,
+        DateTimeImmutable $asOf,
+        string $ownerType,
+        array $ids,
+    ): array {
+        if ($ids === []) {
+            return [];
+        }
+
+        $latestIds = $this->connection->table('contract_settlement_owner_versions')
+            ->selectRaw('DISTINCT ON (owner_id) id')
+            ->where('organization_id', $scope->organizationId)
+            ->where('owner_type', $ownerType)
+            ->where('occurred_at', '<=', ContractSettlementOwnerTimestamp::database($asOf))
+            ->whereIn('owner_id', array_map('strval', $ids))
+            ->orderBy('owner_id')
+            ->orderByDesc('version');
+
+        $rows = $this->connection->table('contract_settlement_owner_versions')
+            ->whereIn('id', $latestIds)
+            ->orderBy('owner_id')
+            ->get(['owner_id', 'operation', 'payload']);
+
+        $payloads = [];
+        foreach ($rows as $row) {
+            $ownerId = (int) $row->owner_id;
+            if ((string) $row->operation === 'delete') {
+                $payloads[$ownerId] = null;
+
+                continue;
+            }
+            $payloads[$ownerId] = $this->payload($row->payload);
+        }
+
+        return array_filter($payloads, 'is_array');
+    }
+
+    /** @return array<string, mixed> */
+    private function payload(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+        if (! is_string($payload)) {
+            throw new DomainException('contract_settlement_options_payload_invalid');
+        }
+
+        try {
+            $decoded = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new DomainException('contract_settlement_options_payload_invalid', previous: $exception);
+        }
+        if (! is_array($decoded)) {
+            throw new DomainException('contract_settlement_options_payload_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<array{id:int,name:string}>
+     */
+    private function projectOptions(ReportScope $scope, array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        return $this->connection->table('projects')
+            ->whereIn('id', array_intersect($ids, $scope->projectIds))
+            ->whereNull('deleted_at')
+            ->get(['id', 'name'])
+            ->map(static fn (object $row): array => [
+                'id' => (int) $row->id,
+                'name' => trim((string) $row->name),
+            ])
+            ->filter(static fn (array $option): bool => $option['name'] !== '')
+            ->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $payloads
+     * @param  list<int>  $ids
+     * @param  array<int, ContractSettlementInput>  $inputs
+     * @return list<array{id:int,name:string,project_ids:list<int>,party_keys:list<string>,directions:list<string>,currencies:list<string>}>
+     */
+    private function contractOptions(array $payloads, array $ids, array $inputs): array
+    {
+        $options = [];
+        foreach ($ids as $id) {
+            $payload = $payloads[$id] ?? null;
+            if (! is_array($payload)) {
+                continue;
+            }
+            $number = trim((string) ($payload['number'] ?? ''));
+            $subject = trim((string) ($payload['subject'] ?? ''));
+            if ($number === '') {
+                continue;
+            }
+            $projectIds = [];
+            $partyKeys = [];
+            $directions = [];
+            $currencies = [];
+            foreach ($inputs as $input) {
+                if ($input->contractId !== $id) {
+                    continue;
+                }
+                if ($input->projectId !== null) {
+                    $projectIds[$input->projectId] = true;
+                }
+                $partyKey = $input->partyKey();
+                if ($partyKey !== null) {
+                    $partyKeys[$partyKey] = true;
+                }
+                $directions[$input->direction] = true;
+                $currencies[$input->currency] = true;
+            }
+            $options[] = [
+                'id' => $id,
+                'name' => $subject === '' ? $number : $number.' — '.$subject,
+                'project_ids' => array_keys($projectIds),
+                'party_keys' => array_keys($partyKeys),
+                'directions' => array_keys($directions),
+                'currencies' => array_keys($currencies),
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<ContractSettlementInput>  $inputs
+     * @return list<array{id:string,name:string,contract_ids:list<int>}>
+     */
+    private function partyOptions(array $inputs): array
+    {
+        $parties = [];
+        foreach ($inputs as $input) {
+            $partyKey = $input->partyKey();
+            if ($partyKey === null) {
+                continue;
+            }
+
+            if (! array_key_exists($partyKey, $parties)) {
+                $parties[$partyKey] = ['names' => [], 'contract_ids' => []];
+            }
+            $parties[$partyKey]['names'][trim($input->partyLabel)] = true;
+            $parties[$partyKey]['contract_ids'][$input->contractId] = true;
+        }
+
+        $options = [];
+        foreach ($parties as $partyKey => $party) {
+            $names = array_keys($party['names']);
+            sort($names, SORT_NATURAL | SORT_FLAG_CASE);
+            $contractIds = array_keys($party['contract_ids']);
+            sort($contractIds, SORT_NUMERIC);
+            $options[] = [
+                'id' => $partyKey,
+                'name' => implode(' / ', $names),
+                'contract_ids' => $contractIds,
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  array<int, ContractSettlementInput>  $inputs
+     * @param  list<array{id:int,name:string}>  $projects
+     * @param  list<array{id:int,name:string,project_ids:list<int>,party_keys:list<string>,directions:list<string>,currencies:list<string>}>  $contracts
+     * @return list<array{id:int,name:string,contract_id:int,project_id:int,party_key:string|null,direction:string,currency:string}>
+     */
+    private function allocationOptions(array $inputs, array $projects, array $contracts): array
+    {
+        $projectNames = array_column($projects, 'name', 'id');
+        $contractNames = array_column($contracts, 'name', 'id');
+        $options = [];
+        foreach ($inputs as $allocationId => $input) {
+            $contract = $contractNames[$input->contractId] ?? null;
+            $project = $input->projectId === null ? null : ($projectNames[$input->projectId] ?? null);
+            if (! is_string($contract) || ! is_string($project)) {
+                throw new DomainException('contract_settlement_options_reference_missing');
+            }
+            $options[] = [
+                'id' => $allocationId,
+                'name' => $contract.' — '.$project,
+                'contract_id' => $input->contractId,
+                'project_id' => $input->projectId,
+                'party_key' => $input->partyKey(),
+                'direction' => $input->direction,
+                'currency' => $input->currency,
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $payloads
+     * @return list<array{id:string,name:string,contract_ids:list<int>}>
+     */
+    private function paymentOptions(array $payloads, string $field): array
+    {
+        $values = [];
+        foreach ($payloads as $payload) {
+            $value = $payload[$field] ?? null;
+            if (is_string($value) && $value !== '') {
+                $contractId = $payload['invoiceable_id'] ?? null;
+                if (! is_int($contractId) && ! (is_string($contractId) && ctype_digit($contractId))) {
+                    throw new DomainException('contract_settlement_options_payment_contract_invalid');
+                }
+                $values[$value][(int) $contractId] = true;
+            }
+        }
+
+        $options = [];
+        foreach ($values as $value => $contractIds) {
+            $valid = $field === 'document_type'
+                ? PaymentDocumentType::tryFrom($value) !== null
+                : PaymentDocumentStatus::tryFrom($value) !== null;
+            if (! $valid) {
+                throw new DomainException('contract_settlement_options_payment_value_invalid');
+            }
+            $group = $field === 'document_type' ? 'instruments' : 'statuses';
+            $options[] = [
+                'id' => $value,
+                'name' => trans_message('reports.options.contract_settlement_exposure.'.$group.'.'.$value),
+                'contract_ids' => array_keys($contractIds),
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<array{id:string,name:string}>
+     */
+    private function translatedOptions(string $group, array $values): array
+    {
+        $options = array_map(static fn (string $value): array => [
+            'id' => $value,
+            'name' => trans_message('reports.options.contract_settlement_exposure.'.$group.'.'.$value),
+        ], $values);
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<string>  $codes
+     * @return list<array{id:string,name:string}>
+     */
+    private function currencyOptions(array $codes): array
+    {
+        $labels = CurrencyCode::options();
+        $options = [];
+        foreach ($codes as $code) {
+            if (! isset($labels[$code])) {
+                throw new DomainException('contract_settlement_options_currency_invalid');
+            }
+            $options[] = ['id' => $code, 'name' => $labels[$code]];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<string>  $buckets
+     * @return list<array{id:string,name:string}>
+     */
+    private function agingOptions(array $buckets): array
+    {
+        foreach ($buckets as $bucket) {
+            if ($bucket !== 'due_date_missing' && SettlementAgingBucket::tryFrom($bucket) === null) {
+                throw new DomainException('contract_settlement_options_aging_invalid');
+            }
+        }
+
+        return $this->translatedOptions('aging_buckets', $buckets);
+    }
+
+    /** @param list<array{id:int|string,name:string}> $options */
+    private function sorted(array $options): array
+    {
+        usort($options, static fn (array $left, array $right): int => strnatcasecmp(
+            (string) $left['name'],
+            (string) $right['name'],
+        ));
+
+        return $options;
+    }
+
+    /** @return array<string, mixed> */
+    private function unavailable(DateTimeImmutable $asOf, string $reason): array
+    {
+        return [
+            'available' => false,
+            'reason' => $reason,
+            'as_of' => $this->exactDateTime($asOf),
+            'period' => ['default_from' => null, 'default_to' => null],
+            'due' => ['minimum' => null, 'maximum' => null],
+            'projects' => [],
+            'contracts' => [],
+            'allocations' => [],
+            'parties' => [],
+            'directions' => [],
+            'instruments' => [],
+            'statuses' => [],
+            'currencies' => [],
+            'aging_buckets' => [],
+        ];
+    }
+
+    private function exactDateTime(DateTimeImmutable $value): string
+    {
+        return $value->format('u') === '000000'
+            ? $value->format(DATE_ATOM)
+            : $value->format('Y-m-d\TH:i:s.uP');
+    }
+}

--- a/lang/ru/reports.php
+++ b/lang/ru/reports.php
@@ -93,6 +93,41 @@ return [
         'date_to_after_or_equal' => 'Дата окончания должна быть не раньше даты начала.',
         'format_invalid' => 'Выбран некорректный формат отчета.',
     ],
+    'options' => [
+        'contract_settlement_exposure' => [
+            'directions' => [
+                'receivable' => 'Дебиторская задолженность',
+                'payable' => 'Кредиторская задолженность',
+            ],
+            'instruments' => [
+                'payment_request' => 'Платёжное требование',
+                'invoice' => 'Счёт на оплату',
+                'payment_order' => 'Платёжное поручение',
+                'incoming_payment' => 'Входящий платёж',
+                'expense' => 'Расходный ордер',
+                'offset_act' => 'Акт взаимозачёта',
+            ],
+            'statuses' => [
+                'draft' => 'Черновик',
+                'submitted' => 'Отправлен',
+                'pending_approval' => 'На согласовании',
+                'approved' => 'Утверждён',
+                'scheduled' => 'Запланирован',
+                'paid' => 'Оплачен',
+                'partially_paid' => 'Частично оплачен',
+                'rejected' => 'Отклонён',
+                'cancelled' => 'Отменён',
+            ],
+            'aging_buckets' => [
+                'not_due' => 'Срок оплаты не наступил',
+                'days_1_30' => 'Просрочка 1–30 дней',
+                'days_31_60' => 'Просрочка 31–60 дней',
+                'days_61_90' => 'Просрочка 61–90 дней',
+                'over_90' => 'Просрочка более 90 дней',
+                'due_date_missing' => 'Дата оплаты не указана',
+            ],
+        ],
+    ],
     'errors' => [
         'report_not_found' => 'Отчёт не найден.',
         'report_scope_forbidden' => 'Отчёт недоступен в текущей организации.',

--- a/tests/Feature/Reporting/ContractSettlementExposureOptionsRequestTest.php
+++ b/tests/Feature/Reporting/ContractSettlementExposureOptionsRequestTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Reporting;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ContractSettlementExposureReportOptionsRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ContractSettlementExposureOptionsRequestTest extends TestCase
+{
+    #[Test]
+    public function exact_as_of_is_the_only_client_owned_option(): void
+    {
+        $request = $this->request(['as_of' => '2026-08-06T14:15:16.123456+03:00']);
+
+        $request->validateResolved();
+
+        self::assertSame(
+            '2026-08-06T14:15:16.123456+03:00',
+            $request->asOf()->format('Y-m-d\TH:i:s.uP'),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('clientContextFields')]
+    public function client_cannot_replace_server_owned_context(string $field, mixed $value): void
+    {
+        $request = $this->request([
+            'as_of' => '2026-08-06T14:15:16+03:00',
+            $field => $value,
+        ]);
+
+        try {
+            $request->validateResolved();
+            self::fail('Client-owned reporting context must be rejected.');
+        } catch (ReportContractException $exception) {
+            self::assertSame(ReportErrorCode::REPORT_REQUEST_INVALID, $exception->errorCode);
+            self::assertSame(['fields' => [$field]], $exception->safeFields);
+        }
+    }
+
+    public static function clientContextFields(): iterable
+    {
+        yield 'organization' => ['organization_id', 999];
+        yield 'current organization' => ['current_organization_id', 999];
+        yield 'holding organizations' => ['holding_organization_ids', [999]];
+        yield 'organizations' => ['organization_ids', [999]];
+        yield 'project' => ['project_id', 999];
+        yield 'current project' => ['current_project_id', 999];
+        yield 'projects' => ['project_ids', [999]];
+        yield 'user' => ['user_id', 999];
+        yield 'actor' => ['actor_id', 999];
+        yield 'scope' => ['scope', ['organization_id' => 999]];
+        yield 'permissions' => ['permissions', ['reports.view']];
+    }
+
+    /** @param array<string, mixed> $query */
+    private function request(array $query): ContractSettlementExposureReportOptionsRequest
+    {
+        $request = ContractSettlementExposureReportOptionsRequest::create(
+            '/api/v1/admin/reports/contract-settlement-exposure/options',
+            'GET',
+            $query,
+        );
+        $request->setContainer($this->app);
+        $request->setRedirector($this->app->make('redirect'));
+
+        return $request;
+    }
+}

--- a/tests/Integration/Reporting/WaveOne/ContractSettlementExposureOptionsPostgresTest.php
+++ b/tests/Integration/Reporting/WaveOne/ContractSettlementExposureOptionsPostgresTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Reporting\WaveOne;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureOptionsService;
+use App\Models\Organization;
+use App\Models\Project;
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use Tests\TestCase;
+
+#[Group('postgres')]
+final class ContractSettlementExposureOptionsPostgresTest extends TestCase
+{
+    protected function connectionsToTransact(): array
+    {
+        return [];
+    }
+
+    #[Test]
+    public function outermost_options_read_uses_a_valid_read_only_repeatable_read_transaction(): void
+    {
+        $this->requirePostgres();
+
+        self::assertSame(0, DB::transactionLevel());
+        $scope = new ReportScope(
+            799999981,
+            [799999981],
+            [799999982],
+            [],
+            new DateTimeZone('Europe/Moscow'),
+        );
+
+        $options = $this->app->make(ContractSettlementExposureOptionsService::class)->options(
+            $scope,
+            new DateTimeImmutable('2026-08-06T14:15:16.123456+03:00'),
+        );
+
+        self::assertFalse($options['available']);
+        self::assertSame(0, DB::transactionLevel());
+    }
+
+    #[Test]
+    public function latest_owner_payload_excludes_future_delete_and_other_tenant_versions(): void
+    {
+        $this->requirePostgres();
+        DB::beginTransaction();
+
+        try {
+            $organizationId = random_int(700000000, 709999999);
+            $otherOrganizationId = $organizationId + 1;
+            $activeOwnerId = random_int(710000000, 719999999);
+            $deletedOwnerId = $activeOwnerId + 1;
+            $firstAt = new DateTimeImmutable('2026-08-06T10:00:00.100000+00:00');
+            $asOf = new DateTimeImmutable('2026-08-06T11:00:00.200000+00:00');
+            $futureAt = new DateTimeImmutable('2026-08-06T12:00:00.300000+00:00');
+
+            $this->insertOwnerVersion(
+                $organizationId,
+                $activeOwnerId,
+                1,
+                'upsert',
+                $firstAt,
+                ['marker' => 'target-v1'],
+            );
+            $this->insertOwnerVersion(
+                $organizationId,
+                $activeOwnerId,
+                2,
+                'upsert',
+                $asOf,
+                ['marker' => 'target-v2'],
+            );
+            $this->insertOwnerVersion(
+                $organizationId,
+                $activeOwnerId,
+                3,
+                'upsert',
+                $futureAt,
+                ['marker' => 'target-future'],
+            );
+            $this->insertOwnerVersion(
+                $otherOrganizationId,
+                $activeOwnerId,
+                99,
+                'upsert',
+                $asOf,
+                ['marker' => 'other-tenant'],
+            );
+            $this->insertOwnerVersion(
+                $organizationId,
+                $deletedOwnerId,
+                1,
+                'upsert',
+                $firstAt,
+                ['marker' => 'before-delete'],
+            );
+            $this->insertOwnerVersion(
+                $organizationId,
+                $deletedOwnerId,
+                2,
+                'delete',
+                $asOf,
+                [],
+            );
+            $this->insertOwnerVersion(
+                $organizationId,
+                $deletedOwnerId,
+                3,
+                'upsert',
+                $futureAt,
+                ['marker' => 'future-restore'],
+            );
+
+            $payloads = $this->ownerPayloads(
+                new ReportScope(
+                    $organizationId,
+                    [$organizationId],
+                    [],
+                    [],
+                    new DateTimeZone('UTC'),
+                ),
+                $asOf,
+                [$activeOwnerId, $deletedOwnerId],
+            );
+
+            self::assertSame([$activeOwnerId], array_keys($payloads));
+            self::assertSame('target-v2', $payloads[$activeOwnerId]['marker']);
+        } finally {
+            DB::rollBack();
+        }
+    }
+
+    #[Test]
+    public function project_options_include_authorized_shared_project_and_reject_ids_outside_scope(): void
+    {
+        $this->requirePostgres();
+        DB::beginTransaction();
+
+        try {
+            $scopeOrganization = Organization::withoutEvents(
+                static fn (): Organization => Organization::factory()->create(),
+            );
+            $projectOwner = Organization::withoutEvents(
+                static fn (): Organization => Organization::factory()->create(),
+            );
+            $authorized = Project::withoutEvents(
+                static fn (): Project => Project::factory()
+                    ->for($projectOwner)
+                    ->create(['name' => 'Общий проект']),
+            );
+            $outsideScope = Project::withoutEvents(
+                static fn (): Project => Project::factory()
+                    ->for($projectOwner)
+                    ->create(['name' => 'Чужой проект']),
+            );
+            $scope = new ReportScope(
+                (int) $scopeOrganization->id,
+                [(int) $scopeOrganization->id],
+                [(int) $authorized->id],
+                [],
+                new DateTimeZone('UTC'),
+            );
+
+            $method = new ReflectionMethod(ContractSettlementExposureOptionsService::class, 'projectOptions');
+            $options = $method->invoke(
+                $this->app->make(ContractSettlementExposureOptionsService::class),
+                $scope,
+                [(int) $authorized->id, (int) $outsideScope->id],
+            );
+
+            self::assertSame([
+                ['id' => (int) $authorized->id, 'name' => 'Общий проект'],
+            ], $options);
+        } finally {
+            DB::rollBack();
+        }
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function insertOwnerVersion(
+        int $organizationId,
+        int $ownerId,
+        int $version,
+        string $operation,
+        DateTimeImmutable $occurredAt,
+        array $payload,
+    ): void {
+        $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
+        $now = new DateTimeImmutable('2026-08-06T13:00:00+00:00');
+
+        DB::table('contract_settlement_owner_versions')->insert([
+            'organization_id' => $organizationId,
+            'owner_type' => 'contract',
+            'owner_id' => (string) $ownerId,
+            'version' => $version,
+            'operation' => $operation,
+            'occurred_at' => $occurredAt,
+            'payload' => $encoded,
+            'owner_hash' => hash('sha256', implode('|', [
+                $organizationId,
+                $ownerId,
+                $version,
+                $operation,
+                $encoded,
+            ])),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * @param list<int> $ownerIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function ownerPayloads(ReportScope $scope, DateTimeImmutable $asOf, array $ownerIds): array
+    {
+        $method = new ReflectionMethod(ContractSettlementExposureOptionsService::class, 'ownerPayloads');
+
+        return $method->invoke(
+            $this->app->make(ContractSettlementExposureOptionsService::class),
+            $scope,
+            $asOf,
+            'contract',
+            $ownerIds,
+        );
+    }
+
+    private function requirePostgres(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            self::markTestSkipped('PostgreSQL integration only.');
+        }
+    }
+
+}

--- a/tests/Unit/Reporting/Access/AuthorizeReportDefinitionAccessTest.php
+++ b/tests/Unit/Reporting/Access/AuthorizeReportDefinitionAccessTest.php
@@ -53,6 +53,32 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
         self::assertSame(['server_report'], $resolver->createRunCodes);
     }
 
+    public function test_contract_settlement_options_route_uses_server_owned_definition_module(): void
+    {
+        $definition = $this->sourceDefinition('2');
+        $resolver = new DefinitionAccessTargetResolver([$definition]);
+        $modules = new DefinitionAccessModuleEntitlement(['act-reporting']);
+        $middleware = new AuthorizeReportDefinitionAccess(
+            $resolver,
+            new ReportDefinitionModuleAuthorizer($modules),
+        );
+        $request = $this->request('admin.reports.contract-settlement-exposure.options', [
+            'reportCode' => 'contract_settlement_exposure',
+        ]);
+        $called = false;
+
+        $response = $middleware->handle($request, static function () use (&$called): Response {
+            $called = true;
+
+            return new Response('', 204);
+        });
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertTrue($called);
+        self::assertSame(['act-reporting'], $modules->checkedModules);
+        self::assertSame(['contract_settlement_exposure'], $resolver->createRunCodes);
+    }
+
     public function test_catalog_records_only_module_accessible_definition_hashes(): void
     {
         $generic = (new ReportDefinitionBuilder)
@@ -135,6 +161,32 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
                 },
             );
             self::fail('Revoked source module must be denied.');
+        } catch (ReportContractException $exception) {
+            self::assertSame('REPORT_SCOPE_FORBIDDEN', $exception->getMessage());
+            self::assertFalse($called);
+        }
+    }
+
+    public function test_contract_settlement_options_route_denies_revoked_source_module(): void
+    {
+        $middleware = new AuthorizeReportDefinitionAccess(
+            new DefinitionAccessTargetResolver([$this->sourceDefinition('3')]),
+            new ReportDefinitionModuleAuthorizer(new DefinitionAccessModuleEntitlement(['reports'])),
+        );
+        $called = false;
+
+        try {
+            $middleware->handle(
+                $this->request('admin.reports.contract-settlement-exposure.options', [
+                    'reportCode' => 'contract_settlement_exposure',
+                ]),
+                static function () use (&$called): Response {
+                    $called = true;
+
+                    return new Response('', 204);
+                },
+            );
+            self::fail('Revoked contract settlement source module must be denied.');
         } catch (ReportContractException $exception) {
             self::assertSame('REPORT_SCOPE_FORBIDDEN', $exception->getMessage());
             self::assertFalse($called);

--- a/tests/Unit/Reporting/ContractSettlementExposureOptionsContractTest.php
+++ b/tests/Unit/Reporting/ContractSettlementExposureOptionsContractTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting;
+
+use App\BusinessModules\Core\Payments\Enums\PaymentDocumentStatus;
+use App\BusinessModules\Core\Payments\Enums\PaymentDocumentType;
+use App\BusinessModules\Core\Payments\Reporting\SettlementAgingBucket;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ContractSettlementExposureReportOptionsRequest;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureOptionsService;
+use App\BusinessModules\Features\ContractManagement\Reporting\DTO\ContractSettlementInput;
+use App\BusinessModules\Features\ContractManagement\Reporting\Enums\ContractSettlementPartyType;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+final class ContractSettlementExposureOptionsContractTest extends TestCase
+{
+    public function test_options_route_uses_server_owned_organization_scope(): void
+    {
+        $routes = file_get_contents(base_path('app/BusinessModules/Core/Reporting/routes.php'));
+        $middleware = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php',
+        ));
+        $controller = file_get_contents(base_path(
+            'app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ContractSettlementExposureReportOptionsController.php',
+        ));
+
+        self::assertIsString($routes);
+        self::assertStringContainsString("Route::get('/contract-settlement-exposure/options'", $routes);
+        self::assertStringContainsString("->defaults('reportCode', 'contract_settlement_exposure')", $routes);
+        self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
+        self::assertIsString($middleware);
+        self::assertStringContainsString("'admin.reports.contract-settlement-exposure.options'", $middleware);
+        self::assertIsString($controller);
+        self::assertStringContainsString('ContractSettlementExposureCandidateContract::CODE', $controller);
+        self::assertStringContainsString('$context->scope', $controller);
+        self::assertStringNotContainsString("input('organization_id')", $controller);
+        self::assertStringNotContainsString("input('project_id')", $controller);
+    }
+
+    public function test_options_reject_client_context_and_require_exact_as_of(): void
+    {
+        $rules = (new ContractSettlementExposureReportOptionsRequest)->rules();
+
+        foreach ([
+            'organization_id',
+            'current_organization_id',
+            'holding_organization_ids',
+            'organization_ids',
+            'project_id',
+            'current_project_id',
+            'project_ids',
+            'user_id',
+            'actor_id',
+            'scope',
+            'permissions',
+        ] as $field) {
+            self::assertContains('prohibited', $rules[$field]);
+        }
+        self::assertSame(['required', 'string'], array_slice($rules['as_of'], 0, 2));
+        self::assertNotNull(ReportAsOfParser::parse('2026-08-06T14:15:16.123456+03:00'));
+        self::assertNull(ReportAsOfParser::parse('2026-08-06'));
+    }
+
+    public function test_options_are_assembled_from_the_same_point_in_time_owner_source(): void
+    {
+        $source = file_get_contents((new ReflectionClass(
+            ContractSettlementExposureOptionsService::class,
+        ))->getFileName());
+
+        self::assertIsString($source);
+        self::assertStringContainsString('$this->source->read($scope, $query)', $source);
+        self::assertStringContainsString("'contract_settlement_owner_versions'", $source);
+        self::assertStringContainsString("->where('organization_id', \$scope->organizationId)", $source);
+        self::assertStringContainsString('ContractSettlementOwnerTimestamp::database($asOf)', $source);
+        self::assertStringContainsString('CurrencyCode::options()', $source);
+        self::assertStringContainsString('$this->calculator->calculate(', $source);
+        self::assertStringNotContainsString("input('organization_id')", $source);
+    }
+
+    public function test_options_read_uses_a_read_only_repeatable_read_snapshot(): void
+    {
+        $source = $this->methodSource('options');
+
+        self::assertStringContainsString('$this->connection->transactionLevel()', $source);
+        self::assertStringContainsString('$this->connection->transaction(', $source);
+        self::assertStringContainsString(
+            "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY",
+            $source,
+        );
+        self::assertStringContainsString('$this->optionsWithinStableView(', $source);
+    }
+
+    public function test_owner_payloads_select_only_latest_as_of_version(): void
+    {
+        $source = $this->methodSource('ownerPayloads');
+
+        self::assertStringContainsString("selectRaw('DISTINCT ON (owner_id) id')", $source);
+        self::assertStringContainsString("->whereIn('id', \$latestIds)", $source);
+        self::assertStringNotContainsString('array_key_exists($ownerId, $payloads)', $source);
+    }
+
+    public function test_project_options_use_authorized_scope_for_shared_projects(): void
+    {
+        $source = $this->methodSource('projectOptions');
+
+        self::assertStringContainsString('array_intersect($ids, $scope->projectIds)', $source);
+        self::assertStringNotContainsString("->where('organization_id', \$scope->organizationId)", $source);
+    }
+
+    public function test_party_options_keep_namespaces_and_point_in_time_labels(): void
+    {
+        $service = (new ReflectionClass(ContractSettlementExposureOptionsService::class))
+            ->newInstanceWithoutConstructor();
+        $method = new ReflectionMethod($service, 'partyOptions');
+        $options = $method->invoke($service, [
+            $this->input(101, 1001, ContractSettlementPartyType::CONTRACTOR, 'Подрядчик по договору №1'),
+            $this->input(102, 1002, ContractSettlementPartyType::CONTRACTOR, 'Подрядчик по договору №2'),
+            $this->input(103, 1003, ContractSettlementPartyType::SUPPLIER, 'Поставщик по договору №3'),
+        ]);
+
+        self::assertIsArray($options);
+        self::assertCount(2, $options);
+        $byId = array_column($options, null, 'id');
+        self::assertSame(
+            'Подрядчик по договору №1 / Подрядчик по договору №2',
+            $byId['contractor:40']['name'],
+        );
+        self::assertSame([101, 102], $byId['contractor:40']['contract_ids']);
+        self::assertSame('Поставщик по договору №3', $byId['supplier:40']['name']);
+        self::assertSame([103], $byId['supplier:40']['contract_ids']);
+    }
+
+    public function test_options_never_read_live_party_directories_or_expose_numeric_party_filters(): void
+    {
+        $source = file_get_contents((new ReflectionClass(
+            ContractSettlementExposureOptionsService::class,
+        ))->getFileName());
+
+        self::assertIsString($source);
+        self::assertStringContainsString('$input->partyKey()', $source);
+        self::assertStringContainsString('$input->partyLabel', $source);
+        self::assertStringContainsString("'party_key' => \$input->partyKey()", $source);
+        self::assertStringContainsString("'party_keys' => array_keys(\$partyKeys)", $source);
+        self::assertStringNotContainsString("'contractors' => 'contractor_id'", $source);
+        self::assertStringNotContainsString("'suppliers' => 'supplier_id'", $source);
+        self::assertStringNotContainsString("'party_id' =>", $source);
+        self::assertStringNotContainsString("'party_ids' =>", $source);
+    }
+
+    public function test_every_runtime_option_has_a_business_facing_russian_label(): void
+    {
+        $translations = require base_path('lang/ru/reports.php');
+        $options = $translations['options']['contract_settlement_exposure'];
+
+        foreach (PaymentDocumentType::cases() as $type) {
+            self::assertNotSame('', trim((string) ($options['instruments'][$type->value] ?? '')));
+        }
+        foreach (PaymentDocumentStatus::cases() as $status) {
+            self::assertNotSame('', trim((string) ($options['statuses'][$status->value] ?? '')));
+        }
+        foreach (SettlementAgingBucket::cases() as $bucket) {
+            self::assertNotSame('', trim((string) ($options['aging_buckets'][$bucket->value] ?? '')));
+        }
+        foreach (['receivable', 'payable'] as $direction) {
+            self::assertNotSame('', trim((string) ($options['directions'][$direction] ?? '')));
+        }
+        self::assertNotSame('', trim((string) ($options['aging_buckets']['due_date_missing'] ?? '')));
+    }
+
+    private function methodSource(string $method): string
+    {
+        $reflection = new ReflectionMethod(ContractSettlementExposureOptionsService::class, $method);
+        $file = $reflection->getFileName();
+        self::assertIsString($file);
+        $lines = file($file);
+        self::assertIsArray($lines);
+
+        return implode('', array_slice(
+            $lines,
+            $reflection->getStartLine() - 1,
+            $reflection->getEndLine() - $reflection->getStartLine() + 1,
+        ));
+    }
+
+    private function input(
+        int $contractId,
+        int $allocationId,
+        ContractSettlementPartyType $partyType,
+        string $partyLabel,
+    ): ContractSettlementInput {
+        return new ContractSettlementInput(
+            contractId: $contractId,
+            allocationId: $allocationId,
+            projectId: 501,
+            partyId: 40,
+            partyType: $partyType,
+            partyLabel: $partyLabel,
+            direction: 'payable',
+            currency: 'RUB',
+            effectiveMinor: 100,
+            acceptedMinor: 50,
+            cashMinor: 25,
+            dueAt: null,
+            asOf: new DateTimeImmutable('2026-08-06T00:00:00+00:00'),
+            sourceRefs: [],
+        );
+    }
+}


### PR DESCRIPTION
Отдельный options-релиз R12: server-owned scope, реальные point-in-time справочники, REPEATABLE READ READ ONLY, типизированные стороны договора и единый CurrencyCode. Добавлены Feature/Unit/PostgreSQL-контракты контекста, модульных прав, tenant isolation, delete/future semantics и shared project scope. Локально: php -l 10 файлов и git diff --check; PHPUnit/PHPStan недоступны без vendor. Независимое review: CLEAN.