### PR TITLE
refactor[backend]: бенчмарки переведены на единый S3 шлюз

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Benchmark/FileServiceAcceptanceBenchmarkObjectStore.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Benchmark/FileServiceAcceptanceBenchmarkObjectStore.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Addons\EstimateGeneration\Benchmark;
 
 use App\Services\Storage\FileService;
+use Throwable;
 
 final readonly class FileServiceAcceptanceBenchmarkObjectStore implements BenchmarkPrivateObjectStore
 {
@@ -16,7 +17,11 @@ final readonly class FileServiceAcceptanceBenchmarkObjectStore implements Benchm
             || str_contains($path, '..') || $maxBytes < 1 || $maxBytes > 64_000_000) {
             throw new BenchmarkContractException('private_object_path_invalid');
         }
-        $stream = $this->files->disk()->readStream($path);
+        try {
+            $stream = $this->files->readCurrent($path);
+        } catch (Throwable) {
+            throw new BenchmarkContractException('private_object_unavailable');
+        }
         if (! is_resource($stream)) {
             throw new BenchmarkContractException('private_object_unavailable');
         }

--- a/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
+++ b/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
@@ -378,6 +378,15 @@ AI-отчёты сохраняются бессрочно по ключу `org-{
 - [x] убрать прямой вызов `FileService->disk()`;
 - [x] сохранять XLSX через `putPrivate` с SHA-256 и UUID-ключом;
 - [x] изолировать ключ и download URL по `org-{id}` и `user-{id}`;
+- [x] commit, PR, merge и deploy.
+
+Реализовано в PR #249 (`8ea158d3358d4ea6f5af7864d381618327ac779e`), штатный deploy `31063720907` завершён успешно. Production SHA совпал, профильных ошибок в последних 500 строках журнала нет.
+
+**Подблок 3B.2c.4 — чтение acceptance-бенчмарков (`refactor/timeweb-s3-benchmark-store`):**
+
+- [x] убрать последний прикладной вызов `FileService->disk()`;
+- [x] читать приватный org-объект через `readCurrent()` с прежним лимитом размера;
+- [x] проверить закрытие stream и отказ для пути вне benchmark namespace;
 - [ ] commit, PR, merge и deploy.
 
 - [ ] **Step 1: Написать failing архитектурные и доменные тесты**

--- a/tests/Unit/Storage/AcceptanceBenchmarkObjectStoreTest.php
+++ b/tests/Unit/Storage/AcceptanceBenchmarkObjectStoreTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Storage;
+
+use App\BusinessModules\Addons\EstimateGeneration\Benchmark\BenchmarkContractException;
+use App\BusinessModules\Addons\EstimateGeneration\Benchmark\BenchmarkPrivateObjectStore;
+use App\BusinessModules\Addons\EstimateGeneration\Benchmark\FileServiceAcceptanceBenchmarkObjectStore;
+use App\Services\Storage\FileService;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class AcceptanceBenchmarkObjectStoreTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_reads_private_org_object_through_current_object_gateway_and_closes_stream(): void
+    {
+        $path = 'org-12/estimate-generation/benchmarks/acceptance/corpus/case.json';
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+        fwrite($stream, '{"case":"ok"}');
+        rewind($stream);
+
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('readCurrent')->once()->with($path)->andReturn($stream);
+        $store = new FileServiceAcceptanceBenchmarkObjectStore($files);
+
+        self::assertInstanceOf(BenchmarkPrivateObjectStore::class, $store);
+        self::assertSame('{"case":"ok"}', $store->read($path, 1024));
+        self::assertFalse(is_resource($stream));
+    }
+
+    public function test_rejects_object_larger_than_contract_limit_and_closes_stream(): void
+    {
+        $path = 'org-12/estimate-generation/benchmarks/acceptance/corpus/case.json';
+        $stream = fopen('php://temp', 'w+b');
+        self::assertIsResource($stream);
+        fwrite($stream, 'oversized');
+        rewind($stream);
+
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('readCurrent')->once()->with($path)->andReturn($stream);
+        $store = new FileServiceAcceptanceBenchmarkObjectStore($files);
+
+        try {
+            $store->read($path, 4);
+            self::fail('Oversized object must be rejected.');
+        } catch (BenchmarkContractException $exception) {
+            self::assertSame('private_object_too_large', $exception->getMessage());
+        }
+
+        self::assertFalse(is_resource($stream));
+    }
+
+    public function test_rejects_path_outside_acceptance_namespace_before_storage_read(): void
+    {
+        $files = Mockery::mock(FileService::class);
+        $files->shouldNotReceive('readCurrent');
+        $store = new FileServiceAcceptanceBenchmarkObjectStore($files);
+
+        $this->expectException(BenchmarkContractException::class);
+        $this->expectExceptionMessage('private_object_path_invalid');
+
+        $store->read('org-12/estimate-generation/benchmarks/../secret.json', 1024);
+    }
+
+    public function test_maps_gateway_read_failure_to_stable_benchmark_error(): void
+    {
+        $path = 'org-12/estimate-generation/benchmarks/acceptance/corpus/missing.json';
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('readCurrent')
+            ->once()
+            ->with($path)
+            ->andThrow(new RuntimeException('storage_object_read_failed'));
+        $store = new FileServiceAcceptanceBenchmarkObjectStore($files);
+
+        $this->expectException(BenchmarkContractException::class);
+        $this->expectExceptionMessage('private_object_unavailable');
+
+        $store->read($path, 1024);
+    }
+}

--- a/tests/Unit/Storage/AcceptanceBenchmarkStorageArchitectureTest.php
+++ b/tests/Unit/Storage/AcceptanceBenchmarkStorageArchitectureTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Storage;
+
+use PHPUnit\Framework\TestCase;
+
+final class AcceptanceBenchmarkStorageArchitectureTest extends TestCase
+{
+    public function test_benchmark_reader_does_not_select_storage_disk(): void
+    {
+        $source = file_get_contents(
+            __DIR__.'/../../../app/BusinessModules/Addons/EstimateGeneration/Benchmark/FileServiceAcceptanceBenchmarkObjectStore.php',
+        );
+        self::assertIsString($source);
+
+        self::assertStringContainsString('readCurrent(', $source);
+        self::assertStringNotContainsString('->disk()', $source);
+        self::assertStringNotContainsString('readStream(', $source);
+    }
+}


### PR DESCRIPTION
## Что изменено
- acceptance benchmark reader больше не выбирает S3-диск напрямую
- приватный org-объект читается через FileService::readCurrent
- сохранены namespace, лимит 64 MB, потоковое чтение и стабильные доменные ошибки

## Проверки
- PHPUnit: 5 tests, 15 assertions
- PHPStan: no errors
- Pint: pass
- независимое review: Critical/Important отсутствуют

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored FileServiceAcceptanceBenchmarkObjectStore to use readCurrent() instead of direct disk() access for improved storage abstraction.</li>
<li>Added error handling to map storage read exceptions to BenchmarkContractException.</li>
<li>Implemented comprehensive unit tests for the benchmark object store, covering successful reads, path validation, and error handling.</li>
<li>Added an architectural test to ensure no direct disk() or readStream() calls remain in the benchmark reader.</li>
</ul></div>