### PR TITLE
refactor: multipart-модели через единый Timeweb S3

### DIFF
--- a/app/BusinessModules/Features/DesignManagement/DesignManagementServiceProvider.php
+++ b/app/BusinessModules/Features/DesignManagement/DesignManagementServiceProvider.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\DesignManagement;
 
-use Aws\S3\S3Client;
-use Aws\S3\S3ClientInterface;
 use Illuminate\Support\ServiceProvider;
 
 final class DesignManagementServiceProvider extends ServiceProvider
@@ -23,6 +21,10 @@ final class DesignManagementServiceProvider extends ServiceProvider
         $this->app->singleton(Services\DesignWorkflowService::class);
         $this->app->singleton(Services\DesignPackageIssueRegisterService::class);
         $this->app->singleton(Services\DesignManagementService::class);
+        $this->app->bind(
+            Services\Contracts\DesignModelRegistrationService::class,
+            Services\DesignManagementService::class,
+        );
         $this->app->singleton(Services\DesignModelMultipartUploadService::class);
         $this->app->bind(
             Services\Contracts\DesignIfcToFragmentsConverterContract::class,
@@ -35,30 +37,16 @@ final class DesignManagementServiceProvider extends ServiceProvider
             )
         );
         $this->app->singleton(Services\DesignPulseFactSource::class);
-        $this->app->singleton(S3ClientInterface::class, static function (): S3Client {
-            $config = config('filesystems.disks.s3');
-
-            return new S3Client([
-                'region' => $config['region'] ?? 'ru-central1',
-                'version' => 'latest',
-                'credentials' => [
-                    'key' => $config['key'] ?? '',
-                    'secret' => $config['secret'] ?? '',
-                ],
-                'endpoint' => $config['endpoint'] ?? null,
-                'use_path_style_endpoint' => $config['use_path_style_endpoint'] ?? false,
-            ]);
-        });
     }
 
     public function boot(): void
     {
-        $migrationsPath = __DIR__ . '/migrations';
+        $migrationsPath = __DIR__.'/migrations';
         if (is_dir($migrationsPath)) {
             $this->loadMigrationsFrom($migrationsPath);
         }
 
-        $routesPath = __DIR__ . '/routes.php';
+        $routesPath = __DIR__.'/routes.php';
         if (is_file($routesPath)) {
             require $routesPath;
         }

--- a/app/BusinessModules/Features/DesignManagement/Services/Contracts/DesignModelRegistrationService.php
+++ b/app/BusinessModules/Features/DesignManagement/Services/Contracts/DesignModelRegistrationService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\DesignManagement\Services\Contracts;
+
+use App\BusinessModules\Features\DesignManagement\Models\DesignArtifactVersion;
+use App\BusinessModules\Features\DesignManagement\Models\DesignPackage;
+
+interface DesignModelRegistrationService
+{
+    public function ensurePackageAcceptsModelChanges(DesignPackage $package): void;
+
+    public function findPackage(int $organizationId, int $packageId): ?DesignPackage;
+
+    public function registerStoredIfcModel(
+        DesignPackage $package,
+        int $userId,
+        string $sourcePath,
+        array $fileInfo,
+        array $payload,
+    ): DesignArtifactVersion;
+}

--- a/app/BusinessModules/Features/DesignManagement/Services/DesignManagementService.php
+++ b/app/BusinessModules/Features/DesignManagement/Services/DesignManagementService.php
@@ -26,7 +26,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use BackedEnum;
 
-final class DesignManagementService
+final class DesignManagementService implements Contracts\DesignModelRegistrationService
 {
     private const PACKAGE_RELATIONS = [
         'project:id,name,organization_id',

--- a/app/BusinessModules/Features/DesignManagement/Services/DesignModelMultipartUploadService.php
+++ b/app/BusinessModules/Features/DesignManagement/Services/DesignModelMultipartUploadService.php
@@ -7,25 +7,36 @@ namespace App\BusinessModules\Features\DesignManagement\Services;
 use App\BusinessModules\Features\DesignManagement\Models\DesignArtifactVersion;
 use App\BusinessModules\Features\DesignManagement\Models\DesignPackage;
 use App\BusinessModules\Features\DesignManagement\Services\Contracts\DesignModelMultipartUploader;
-use Aws\S3\S3ClientInterface;
+use App\BusinessModules\Features\DesignManagement\Services\Contracts\DesignModelRegistrationService;
+use App\Services\Storage\DTO\CurrentMultipartCompletion;
+use App\Services\Storage\DTO\MultipartPart;
+use App\Services\Storage\DTO\MultipartUpload;
+use App\Services\Storage\FileService;
 use DomainException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Throwable;
 
 final class DesignModelMultipartUploadService implements DesignModelMultipartUploader
 {
     private const PART_SIZE_BYTES = 5_242_880;
+
     private const MAX_PARTS = 10_000;
+
     private const CACHE_PREFIX = 'design_management:model_upload:';
 
+    private const CACHE_LOCK_SECONDS = 10;
+
+    private const CACHE_LOCK_WAIT_SECONDS = 5;
+
     public function __construct(
-        private readonly S3ClientInterface $s3Client,
+        private readonly FileService $files,
         private readonly DesignStoragePathService $pathService,
-        private readonly DesignManagementService $designManagementService,
-    ) {
-    }
+        private readonly DesignModelRegistrationService $designManagementService,
+    ) {}
 
     public function start(DesignPackage $package, int $userId, array $payload): array
     {
@@ -38,31 +49,32 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
             throw new DomainException(trans_message('design_management.errors.multipart_upload_too_large'));
         }
 
-        $bucket = $this->bucket();
         $uploadId = (string) Str::uuid();
         $sourcePath = $this->pathService->multipartSourcePath(
             (int) $package->organization_id,
             (int) $package->project_id,
             (int) $package->id,
+            $userId,
             $uploadId,
             (string) $payload['original_name']
         );
-        $result = $this->s3Client->createMultipartUpload(array_filter([
-            'Bucket' => $bucket,
-            'Key' => $sourcePath,
-            'ACL' => 'private',
-            'ContentType' => $payload['content_type'] ?? 'application/octet-stream',
-            'Metadata' => [
-                'organization_id' => (string) $package->organization_id,
-                'project_id' => (string) $package->project_id,
-                'package_id' => (string) $package->id,
-                'upload_id' => $uploadId,
-            ],
-        ], static fn (mixed $value): bool => $value !== null));
-        $s3UploadId = (string) ($result->get('UploadId') ?? '');
+        $mime = (string) ($payload['content_type'] ?? 'application/octet-stream');
 
-        if ($s3UploadId === '') {
-            throw new DomainException(trans_message('design_management.errors.multipart_upload_failed'));
+        try {
+            $storageUpload = $this->files->startMultipart(
+                $sourcePath,
+                $mime,
+                self::PART_SIZE_BYTES,
+                [
+                    'organization_id' => (string) $package->organization_id,
+                    'project_id' => (string) $package->project_id,
+                    'package_id' => (string) $package->id,
+                    'user_id' => (string) $userId,
+                    'upload_id' => $uploadId,
+                ],
+            );
+        } catch (Throwable $exception) {
+            throw $this->storageFailure($exception);
         }
 
         $expiresAt = Carbon::now()->addHours(2);
@@ -75,10 +87,9 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
             ];
         }
 
-        Cache::put($this->cacheKey($uploadId), [
+        $session = [
             'upload_id' => $uploadId,
-            's3_upload_id' => $s3UploadId,
-            'bucket' => $bucket,
+            's3_upload_id' => $storageUpload->uploadId,
             'source_path' => $sourcePath,
             'organization_id' => (int) $package->organization_id,
             'project_id' => (int) $package->project_id,
@@ -88,12 +99,26 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
             'parts_count' => $partsCount,
             'file' => [
                 'original_name' => (string) $payload['original_name'],
-                'mime_type' => (string) ($payload['content_type'] ?? 'application/octet-stream'),
+                'mime_type' => $mime,
                 'size_bytes' => $fileSizeBytes,
             ],
             'uploaded_parts' => [],
+            'completion' => null,
+            'expires_at' => $expiresAt->toISOString(),
             'payload' => $this->modelPayload($payload),
-        ], Carbon::now()->addDay());
+        ];
+        try {
+            $sessionStored = Cache::put($this->cacheKey($uploadId), $session, $expiresAt);
+        } catch (Throwable $exception) {
+            $this->abortUntrackedUpload($storageUpload);
+
+            throw $this->storageFailure($exception);
+        }
+        if (! $sessionStored) {
+            $this->abortUntrackedUpload($storageUpload);
+
+            throw $this->storageFailure(new \RuntimeException('multipart_session_store_failed'));
+        }
 
         return [
             'upload_id' => $uploadId,
@@ -118,89 +143,89 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
         }
 
         $realPath = $chunk->getRealPath();
-        if (!$realPath || !is_file($realPath)) {
+        if (! $realPath || ! is_file($realPath)) {
             throw new DomainException(trans_message('design_management.errors.file_upload_failed'));
         }
 
-        $stream = fopen($realPath, 'rb');
-        if ($stream === false) {
+        $bytes = file_get_contents($realPath);
+        if (! is_string($bytes) || $bytes === '') {
             throw new DomainException(trans_message('design_management.errors.file_upload_failed'));
         }
 
         try {
-            $result = $this->s3Client->uploadPart([
-                'Bucket' => (string) $session['bucket'],
-                'Key' => (string) $session['source_path'],
-                'UploadId' => (string) $session['s3_upload_id'],
-                'PartNumber' => $partNumber,
-                'Body' => $stream,
-                'ContentLength' => (int) $chunk->getSize(),
-            ]);
-        } finally {
-            fclose($stream);
+            $part = $this->files->uploadPart(
+                $this->multipartUpload($session),
+                $partNumber,
+                $bytes,
+                hash('sha256', $bytes),
+            );
+        } catch (Throwable $exception) {
+            throw $this->storageFailure($exception);
         }
 
-        $etag = (string) ($result->get('ETag') ?? '');
-        if ($etag === '') {
-            throw new DomainException(trans_message('design_management.errors.multipart_upload_failed'));
-        }
-
-        $session['uploaded_parts'][$partNumber] = [
-            'PartNumber' => $partNumber,
-            'ETag' => $etag,
-            'Size' => (int) $chunk->getSize(),
-        ];
-        Cache::put($this->cacheKey($uploadId), $session, Carbon::now()->addDay());
+        $this->storeUploadedPart($organizationId, $userId, $uploadId, $part);
 
         return [
             'upload_id' => $uploadId,
-            'part_number' => $partNumber,
-            'etag' => $etag,
-            'size_bytes' => (int) $chunk->getSize(),
+            'part_number' => $part->number,
+            'etag' => $part->etag,
+            'size_bytes' => $part->sizeBytes,
         ];
     }
 
     public function complete(int $organizationId, int $userId, string $uploadId): DesignArtifactVersion
     {
         $session = $this->session($organizationId, $userId, $uploadId);
-        $parts = $this->listUploadedParts($session);
-
-        if (count($parts) !== (int) $session['parts_count']) {
-            throw new DomainException(trans_message('design_management.errors.multipart_upload_incomplete'));
-        }
-
-        $uploadedBytes = array_sum(array_map(static fn (array $part): int => (int) ($part['Size'] ?? 0), $parts));
-        if ($uploadedBytes !== (int) $session['file']['size_bytes']) {
-            throw new DomainException(trans_message('design_management.errors.multipart_upload_incomplete'));
-        }
-
-        $this->s3Client->completeMultipartUpload([
-            'Bucket' => (string) $session['bucket'],
-            'Key' => (string) $session['source_path'],
-            'UploadId' => (string) $session['s3_upload_id'],
-            'MultipartUpload' => [
-                'Parts' => array_map(static fn (array $part): array => [
-                    'PartNumber' => (int) $part['PartNumber'],
-                    'ETag' => (string) $part['ETag'],
-                ], $parts),
-            ],
-        ]);
+        $upload = $this->multipartUpload($session);
+        $parts = $this->multipartParts($session, $upload);
 
         $package = $this->designManagementService->findPackage($organizationId, (int) $session['package_id']);
 
-        if (!$package instanceof DesignPackage) {
+        if (! $package instanceof DesignPackage) {
             throw new DomainException(trans_message('design_management.errors.package_not_found'));
         }
 
         $this->designManagementService->ensurePackageAcceptsModelChanges($package);
 
-        $version = $this->designManagementService->registerStoredIfcModel(
-            $package,
-            $userId,
-            (string) $session['source_path'],
-            $session['file'],
-            $session['payload']
-        );
+        $completion = $this->multipartCompletion($session);
+        if (! $completion instanceof CurrentMultipartCompletion) {
+            try {
+                $completion = $this->files->completeCurrentMultipart(
+                    $upload,
+                    $parts,
+                    (int) $session['file']['size_bytes'],
+                );
+            } catch (Throwable $exception) {
+                throw $this->storageFailure($exception);
+            }
+
+            $this->storeCompletion($organizationId, $userId, $uploadId, $completion);
+        }
+
+        try {
+            $stored = $this->files->verifyCurrentMultipart($completion);
+        } catch (Throwable $exception) {
+            throw $this->storageFailure($exception);
+        }
+
+        $fileInfo = $session['file'];
+        $fileInfo['size_bytes'] = $stored->sizeBytes;
+        $fileInfo['sha256'] = $stored->sha256;
+
+        try {
+            $version = $this->designManagementService->registerStoredIfcModel(
+                $package,
+                $userId,
+                $stored->key,
+                $fileInfo,
+                $session['payload']
+            );
+        } catch (Throwable $exception) {
+            $this->deleteUnregisteredObject($stored->key);
+            Cache::forget($this->cacheKey($uploadId));
+
+            throw $exception;
+        }
 
         Cache::forget($this->cacheKey($uploadId));
 
@@ -211,7 +236,7 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
     {
         $session = Cache::get($this->cacheKey($uploadId));
 
-        if (!is_array($session)) {
+        if (! is_array($session)) {
             return;
         }
 
@@ -219,11 +244,18 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
             throw new DomainException(trans_message('design_management.errors.multipart_upload_not_found'));
         }
 
-        $this->s3Client->abortMultipartUpload([
-            'Bucket' => (string) $session['bucket'],
-            'Key' => (string) $session['source_path'],
-            'UploadId' => (string) $session['s3_upload_id'],
-        ]);
+        try {
+            $completion = $this->multipartCompletion($session);
+            if ($completion instanceof CurrentMultipartCompletion) {
+                $this->deleteCurrentIfExists($completion->key);
+            } else {
+                $upload = $this->multipartUpload($session);
+                $this->files->abortMultipart($upload);
+                $this->deleteCurrentIfExists($upload->organizationPath);
+            }
+        } catch (Throwable $exception) {
+            throw $this->storageFailure($exception);
+        }
 
         Cache::forget($this->cacheKey($uploadId));
     }
@@ -232,7 +264,7 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
     {
         $session = Cache::get($this->cacheKey($uploadId));
 
-        if (!is_array($session)
+        if (! is_array($session)
             || (int) $session['organization_id'] !== $organizationId
             || (int) $session['user_id'] !== $userId
         ) {
@@ -242,24 +274,85 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
         return $session;
     }
 
-    private function listUploadedParts(array $session): array
+    private function multipartUpload(array $session): MultipartUpload
+    {
+        try {
+            return new MultipartUpload(
+                (string) $session['source_path'],
+                (string) $session['s3_upload_id'],
+                (string) $session['file']['mime_type'],
+                (int) $session['part_size_bytes'],
+                [
+                    'organization_id' => (string) $session['organization_id'],
+                    'project_id' => (string) $session['project_id'],
+                    'package_id' => (string) $session['package_id'],
+                    'user_id' => (string) $session['user_id'],
+                    'upload_id' => (string) $session['upload_id'],
+                ],
+            );
+        } catch (Throwable $exception) {
+            throw new DomainException(
+                trans_message('design_management.errors.multipart_upload_not_found'),
+                0,
+                $exception,
+            );
+        }
+    }
+
+    private function multipartCompletion(array $session): ?CurrentMultipartCompletion
+    {
+        $completion = $session['completion'] ?? null;
+        if ($completion === null) {
+            return null;
+        }
+
+        try {
+            if (! is_array($completion)) {
+                throw new \InvalidArgumentException('multipart_completion_invalid');
+            }
+
+            return new CurrentMultipartCompletion(
+                (string) ($completion['key'] ?? ''),
+                (string) ($completion['etag'] ?? ''),
+                (int) ($completion['size_bytes'] ?? 0),
+                (string) ($completion['mime'] ?? ''),
+            );
+        } catch (Throwable $exception) {
+            throw new DomainException(
+                trans_message('design_management.errors.multipart_upload_not_found'),
+                0,
+                $exception,
+            );
+        }
+    }
+
+    /** @return list<MultipartPart> */
+    private function multipartParts(array $session, MultipartUpload $upload): array
     {
         $parts = [];
-        $marker = null;
+        for ($partNumber = 1; $partNumber <= (int) $session['parts_count']; $partNumber++) {
+            $cached = $session['uploaded_parts'][$partNumber] ?? null;
+            if (! is_array($cached)) {
+                throw new DomainException(trans_message('design_management.errors.multipart_upload_incomplete'));
+            }
 
-        do {
-            $result = $this->s3Client->listParts(array_filter([
-                'Bucket' => (string) $session['bucket'],
-                'Key' => (string) $session['source_path'],
-                'UploadId' => (string) $session['s3_upload_id'],
-                'PartNumberMarker' => $marker,
-            ], static fn (mixed $value): bool => $value !== null));
-
-            $parts = array_merge($parts, $result->get('Parts') ?? []);
-            $marker = $result->get('NextPartNumberMarker');
-        } while ((bool) ($result->get('IsTruncated') ?? false));
-
-        usort($parts, static fn (array $left, array $right): int => (int) $left['PartNumber'] <=> (int) $right['PartNumber']);
+            try {
+                $parts[] = new MultipartPart(
+                    $upload->organizationPath,
+                    $upload->uploadId,
+                    (int) ($cached['PartNumber'] ?? 0),
+                    (string) ($cached['ETag'] ?? ''),
+                    (int) ($cached['Size'] ?? 0),
+                    (string) ($cached['ChecksumSHA256'] ?? ''),
+                );
+            } catch (Throwable $exception) {
+                throw new DomainException(
+                    trans_message('design_management.errors.multipart_upload_incomplete'),
+                    0,
+                    $exception,
+                );
+            }
+        }
 
         return $parts;
     }
@@ -279,13 +372,171 @@ final class DesignModelMultipartUploadService implements DesignModelMultipartUpl
         ]));
     }
 
-    private function bucket(): string
+    private function storageFailure(Throwable $exception): DomainException
     {
-        return (string) config('filesystems.disks.s3.bucket', 'prohelper-storage');
+        return new DomainException(
+            trans_message('design_management.errors.multipart_upload_failed'),
+            0,
+            $exception,
+        );
+    }
+
+    private function storeUploadedPart(
+        int $organizationId,
+        int $userId,
+        string $uploadId,
+        MultipartPart $part,
+    ): void {
+        try {
+            $stored = Cache::lock(
+                $this->cacheKey($uploadId).':lock',
+                self::CACHE_LOCK_SECONDS,
+            )->block(self::CACHE_LOCK_WAIT_SECONDS, function () use (
+                $organizationId,
+                $userId,
+                $uploadId,
+                $part,
+            ): bool {
+                $session = $this->session($organizationId, $userId, $uploadId);
+                $session['uploaded_parts'][$part->number] = [
+                    'PartNumber' => $part->number,
+                    'ETag' => $part->etag,
+                    'Size' => $part->sizeBytes,
+                    'ChecksumSHA256' => $part->checksumSha256,
+                ];
+
+                return Cache::put(
+                    $this->cacheKey($uploadId),
+                    $session,
+                    $this->sessionExpiry($session),
+                );
+            });
+        } catch (Throwable $exception) {
+            throw $this->storageFailure($exception);
+        }
+
+        if ($stored !== true) {
+            throw $this->storageFailure(new \RuntimeException('multipart_part_state_store_failed'));
+        }
+    }
+
+    private function storeCompletion(
+        int $organizationId,
+        int $userId,
+        string $uploadId,
+        CurrentMultipartCompletion $completion,
+    ): void {
+        try {
+            $stored = Cache::lock(
+                $this->cacheKey($uploadId).':lock',
+                self::CACHE_LOCK_SECONDS,
+            )->block(self::CACHE_LOCK_WAIT_SECONDS, function () use (
+                $organizationId,
+                $userId,
+                $uploadId,
+                $completion,
+            ): bool {
+                $session = $this->session($organizationId, $userId, $uploadId);
+                $session['completion'] = [
+                    'key' => $completion->key,
+                    'etag' => $completion->etag,
+                    'size_bytes' => $completion->sizeBytes,
+                    'mime' => $completion->mime,
+                ];
+
+                return Cache::put(
+                    $this->cacheKey($uploadId),
+                    $session,
+                    $this->sessionExpiry($session),
+                );
+            });
+        } catch (Throwable $exception) {
+            try {
+                $this->discardUntrackedCompletion($uploadId, $completion);
+            } catch (Throwable $cleanupException) {
+                throw $this->storageFailure($cleanupException);
+            }
+
+            throw $this->storageFailure($exception);
+        }
+
+        if ($stored !== true) {
+            try {
+                $this->discardUntrackedCompletion($uploadId, $completion);
+            } catch (Throwable $cleanupException) {
+                throw $this->storageFailure($cleanupException);
+            }
+
+            throw $this->storageFailure(new \RuntimeException('multipart_completion_state_store_failed'));
+        }
+    }
+
+    private function sessionExpiry(array $session): Carbon
+    {
+        $expiresAt = $session['expires_at'] ?? null;
+        if (is_string($expiresAt)) {
+            try {
+                return Carbon::parse($expiresAt);
+            } catch (Throwable) {
+            }
+        }
+
+        return Carbon::now()->addHours(2);
+    }
+
+    private function abortUntrackedUpload(MultipartUpload $upload): void
+    {
+        try {
+            $this->files->abortMultipart($upload);
+        } catch (Throwable $exception) {
+            Log::error('Failed to abort untracked design model upload', [
+                'key' => $upload->organizationPath,
+                'exception' => $exception::class,
+            ]);
+        }
+    }
+
+    private function discardUntrackedCompletion(
+        string $uploadId,
+        CurrentMultipartCompletion $completion,
+    ): void {
+        try {
+            $this->deleteCurrentIfExists($completion->key);
+        } catch (Throwable $exception) {
+            Log::error('Failed to remove untracked completed design model upload', [
+                'key' => $completion->key,
+                'exception' => $exception::class,
+            ]);
+
+            throw new \RuntimeException('multipart_completion_cleanup_failed', 0, $exception);
+        }
+
+        if (! Cache::forget($this->cacheKey($uploadId))) {
+            throw new \RuntimeException('multipart_completion_session_cleanup_failed');
+        }
+    }
+
+    private function deleteCurrentIfExists(string $key): void
+    {
+        if ($this->files->existsCurrent($key)) {
+            $this->files->deleteCurrent($key);
+        }
+    }
+
+    private function deleteUnregisteredObject(string $key): void
+    {
+        try {
+            $this->files->deleteCurrent($key);
+        } catch (Throwable $exception) {
+            Log::error('Failed to remove unregistered design model object', [
+                'key' => $key,
+                'exception' => $exception::class,
+            ]);
+        }
     }
 
     private function cacheKey(string $uploadId): string
     {
-        return self::CACHE_PREFIX . $uploadId;
+        return self::CACHE_PREFIX.$uploadId;
     }
 }

--- a/app/BusinessModules/Features/DesignManagement/Services/DesignStoragePathService.php
+++ b/app/BusinessModules/Features/DesignManagement/Services/DesignStoragePathService.php
@@ -16,8 +16,8 @@ final class DesignStoragePathService
         string $originalName
     ): string {
         return $this->basePath($organizationId, $projectId, $packageId, $versionId)
-            . '/source/'
-            . $this->safeFileName($originalName, 'model.ifc');
+            .'/source/'
+            .$this->safeFileName($originalName, 'model.ifc');
     }
 
     public function derivativePath(
@@ -31,8 +31,8 @@ final class DesignStoragePathService
         $safeExtension = preg_replace('/[^a-z0-9]+/', '', $safeExtension) ?: 'frag';
 
         return $this->basePath($organizationId, $projectId, $packageId, $versionId)
-            . '/viewer/model.'
-            . $safeExtension;
+            .'/viewer/model.'
+            .$safeExtension;
     }
 
     public function documentSourcePath(
@@ -56,14 +56,16 @@ final class DesignStoragePathService
         int $organizationId,
         int $projectId,
         int $packageId,
+        int $userId,
         string $uploadId,
         string $originalName
     ): string {
         return sprintf(
-            'org-%d/pir/projects/%d/packages/%d/model-uploads/%s/source/%s',
+            'org-%d/pir/projects/%d/packages/%d/model-uploads/user-%d/%s/source/%s',
             $organizationId,
             $projectId,
             $packageId,
+            $userId,
             $this->safeUploadId($uploadId),
             $this->safeFileName($originalName, 'model.ifc')
         );
@@ -92,11 +94,11 @@ final class DesignStoragePathService
         }
 
         $safeExtension = preg_replace('/[^a-z0-9]+/', '', $extension);
-        if (!$safeExtension) {
+        if (! $safeExtension) {
             $safeExtension = (string) pathinfo($defaultName, PATHINFO_EXTENSION);
         }
 
-        return $safeStem . '.' . $safeExtension;
+        return $safeStem.'.'.$safeExtension;
     }
 
     private function safeUploadId(string $uploadId): string

--- a/app/Services/Storage/DTO/CurrentMultipartCompletion.php
+++ b/app/Services/Storage/DTO/CurrentMultipartCompletion.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage\DTO;
+
+use InvalidArgumentException;
+
+final readonly class CurrentMultipartCompletion
+{
+    public function __construct(
+        public string $key,
+        public string $etag,
+        public int $sizeBytes,
+        public string $mime,
+    ) {
+        if (
+            preg_match('#^org-[1-9][0-9]*/[^\\\\\x00-\x1F\x7F]+$#D', $key) !== 1
+            || strlen($key) > 1024
+            || str_contains($key, '://')
+            || preg_match('#(?:^|/)\.\.(?:/|$)#', $key) === 1
+            || $etag === ''
+            || strlen($etag) > 255
+            || preg_match('/[\x00-\x1F\x7F]/', $etag) === 1
+            || $sizeBytes < 1
+            || $mime === ''
+            || strlen($mime) > 255
+            || preg_match('/[\x00-\x1F\x7F]/', $mime) === 1
+        ) {
+            throw new InvalidArgumentException('multipart_completion_invalid');
+        }
+    }
+}

--- a/app/Services/Storage/FileService.php
+++ b/app/Services/Storage/FileService.php
@@ -5,6 +5,7 @@ namespace App\Services\Storage;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\Models\Organization;
 use App\Services\Logging\LoggingService;
+use App\Services\Storage\DTO\CurrentMultipartCompletion;
 use App\Services\Storage\DTO\CurrentStoredFile;
 use App\Services\Storage\DTO\MultipartPart;
 use App\Services\Storage\DTO\MultipartUpload;
@@ -300,6 +301,84 @@ class FileService
             $sizeBytes,
             new Sha256Hash($checksumSha256),
             $upload->mime,
+        );
+    }
+
+    public function completeCurrentMultipart(
+        MultipartUpload $upload,
+        array $orderedParts,
+        int $expectedSizeBytes,
+    ): CurrentMultipartCompletion {
+        $sizeBytes = $this->assertMultipartParts($upload, $orderedParts);
+        if ($expectedSizeBytes < 1 || $sizeBytes !== $expectedSizeBytes) {
+            throw new \InvalidArgumentException('multipart_parts_size_mismatch');
+        }
+        $completedParts = array_map(
+            static fn (MultipartPart $part): array => [
+                'PartNumber' => $part->number,
+                'ETag' => $part->etag,
+            ],
+            $orderedParts,
+        );
+
+        try {
+            $result = $this->reportS3Client()->completeMultipartUpload([
+                'Bucket' => $this->reportBucket(),
+                'Key' => $upload->organizationPath,
+                'UploadId' => $upload->uploadId,
+                'MultipartUpload' => ['Parts' => $completedParts],
+                'IfNoneMatch' => '*',
+                '@http' => $this->s3HttpOptions(),
+            ]);
+        } catch (AwsException $exception) {
+            throw $this->versionedAwsException($exception);
+        } catch (\InvalidArgumentException $exception) {
+            throw new VersionedObjectTransportException('s3_multipart_unavailable', 0, $exception);
+        }
+
+        $etag = is_string($result['ETag'] ?? null)
+            ? trim($result['ETag'], " \t\n\r\0\x0B\"")
+            : '';
+        if (
+            $etag === ''
+            || (isset($result['Key'])
+                && (! is_string($result['Key'])
+                    || ! hash_equals($upload->organizationPath, $result['Key'])))
+            || (isset($result['Bucket'])
+                && (! is_string($result['Bucket'])
+                    || ! hash_equals($this->reportBucket(), $result['Bucket'])))
+        ) {
+            throw new VersionedObjectIntegrityException('s3_multipart_completion_identity_invalid');
+        }
+
+        return new CurrentMultipartCompletion(
+            $upload->organizationPath,
+            $etag,
+            $expectedSizeBytes,
+            $upload->mime,
+        );
+    }
+
+    public function verifyCurrentMultipart(CurrentMultipartCompletion $completion): CurrentStoredFile
+    {
+        $stream = $this->readCurrent($completion->key);
+        try {
+            [$streamedSizeBytes, $checksumSha256] = $this->hashReadStream($stream);
+        } finally {
+            fclose($stream);
+        }
+        if ($streamedSizeBytes !== $completion->sizeBytes) {
+            $this->deleteInvalidCurrentObject($completion->key);
+
+            throw new VersionedObjectIntegrityException('s3_multipart_current_object_size_mismatch');
+        }
+
+        return new CurrentStoredFile(
+            $completion->key,
+            $completion->etag,
+            $streamedSizeBytes,
+            $checksumSha256,
+            $completion->mime,
         );
     }
 
@@ -741,6 +820,39 @@ class FileService
         }
 
         return [$sizeBytes, hash_final($hash)];
+    }
+
+    /** @param resource $stream @return array{0: int, 1: string} */
+    private function hashReadStream($stream): array
+    {
+        $hash = hash_init('sha256');
+        $sizeBytes = 0;
+        while (! feof($stream)) {
+            $chunk = fread($stream, 1024 * 1024);
+            if ($chunk === false) {
+                throw new VersionedObjectIntegrityException('s3_multipart_current_object_read_failed');
+            }
+            $sizeBytes += strlen($chunk);
+            hash_update($hash, $chunk);
+        }
+
+        if ($sizeBytes < 1) {
+            throw new VersionedObjectIntegrityException('s3_multipart_current_object_read_failed');
+        }
+
+        return [$sizeBytes, hash_final($hash)];
+    }
+
+    private function deleteInvalidCurrentObject(string $key): void
+    {
+        try {
+            $this->deleteCurrent($key);
+        } catch (\Throwable $exception) {
+            Log::error('Failed to remove invalid completed multipart object', [
+                'key' => $key,
+                'exception' => $exception::class,
+            ]);
+        }
     }
 
     private function assertSafeStorageString(string $value, int $maxLength, string $error): void

--- a/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
+++ b/docs/superpowers/plans/2026-08-06-timeweb-s3-migration.md
@@ -4,7 +4,7 @@
 
 **Goal:** Полностью перевести файловое хранилище МОСТ на один приватный бакет Timeweb Cloud S3 без переноса старых объектов, fallback на Яндекс и сохранения устаревших S3-контрактов.
 
-**Architecture:** `App\Services\Storage\FileService` — единственный прикладной шлюз к одному Laravel-диску `s3`; `OrganizationStoragePath` создаёт неизменяемые ключи `org-{organization_id}/...`, а крупные файлы загружаются напрямую multipart-частями по presigned URL. Домены сохраняют ключ, MIME, размер и SHA-256, но не зависят от S3 `VersionId`; старые файловые записи удаляются миграцией, потому что перенос объектов не выполняется.
+**Architecture:** `App\Services\Storage\FileService` — единственный прикладной шлюз к одному Laravel-диску `s3`; прикладные сервисы создают неизменяемые ключи `org-{organization_id}/.../user-{user_id}/...`. Существующая multipart-загрузка дизайн-моделей продолжает передавать части через Laravel API, но все S3-операции выполняет `FileService`; после завершения объект потоково перечитывается для проверки размера и вычисления SHA-256. Домены сохраняют ключ, MIME, размер и SHA-256, но не зависят от S3 `VersionId`; старые файловые записи удаляются миграцией, потому что перенос объектов не выполняется.
 
 **Tech Stack:** PHP 8.2+, Laravel 11, Flysystem AWS S3 v3, AWS SDK for PHP, PostgreSQL, PHPUnit/Pest, Larastan, GitHub CLI, существующий GitHub deploy workflow.
 
@@ -28,20 +28,13 @@
 ### Новые файлы
 
 - `app/Services/Storage/StorageRuntimeConfiguration.php` — валидация обязательной production-конфигурации Timeweb.
-- `app/Services/Storage/DTO/PresignedMultipartPart.php` — контракт URL одной multipart-части.
-- `app/Models/StorageMultipartUpload.php` — устойчивая multipart-сессия.
-- `app/Jobs/Storage/VerifyMultipartUpload.php` — потоковая проверка SHA-256 после завершения.
 - `app/Services/Storage/PersonalFileService.php` — бизнес-операции персональных файлов с organization/user scope.
-- `app/BusinessModules/Features/DesignManagement/Http/Requests/PresignDesignModelPartRequest.php` — HTTP-валидация presign-запроса.
 - `database/migrations/2026_08_06_000050_scope_personal_files_to_organizations.php` — очистка старых personal records и обязательный `organization_id`.
-- `database/migrations/2026_08_06_000100_create_storage_multipart_uploads.php` — таблица multipart-сессий.
 - `database/migrations/2026_08_06_000200_reset_legacy_file_storage_records.php` — удаление старых файловых записей и S3 `VersionId` полей.
 - `tests/Unit/Config/TimewebS3ConfigurationTest.php` — точный контракт одного диска.
 - `tests/Unit/Storage/StorageRuntimeConfigurationTest.php` — обязательность production-параметров.
 - `tests/Unit/Storage/StorageArchitectureTest.php` — запрет обхода `FileService`.
 - `tests/Unit/Storage/FileServiceCurrentObjectTest.php` — запись/чтение/удаление без VersionId.
-- `tests/Unit/Storage/FileServicePresignedMultipartTest.php` — presigned multipart-контракт.
-- `tests/Feature/Storage/StorageMultipartUploadWorkflowTest.php` — состояния и авторизация multipart.
 - `docs/runbooks/timeweb-s3.md` — безопасный production runbook без секретов.
 
 ### Удаляемые файлы
@@ -387,7 +380,9 @@ AI-отчёты сохраняются бессрочно по ключу `org-{
 - [x] убрать последний прикладной вызов `FileService->disk()`;
 - [x] читать приватный org-объект через `readCurrent()` с прежним лимитом размера;
 - [x] проверить закрытие stream и отказ для пути вне benchmark namespace;
-- [ ] commit, PR, merge и deploy.
+- [x] commit, PR, merge и deploy.
+
+Реализовано в PR #250 (`2a1cbe775d91abf0c3b2bb4f275fdf4f347fc4b6`), штатный deploy `31064219649` завершён успешно. Production SHA совпал, профильных ошибок в последних 500 строках журнала нет.
 
 - [ ] **Step 1: Написать failing архитектурные и доменные тесты**
 - [ ] **Step 2: Проверить RED**
@@ -397,104 +392,41 @@ AI-отчёты сохраняются бессрочно по ключу `org-{
 
 ---
 
-### Task 4: Прямой presigned multipart для крупных файлов
+### Task 4: Multipart дизайн-моделей через единый FileService
 
-**PR:** `feat/timeweb-s3-presigned-multipart`
-
-**Frontend PR:** `feat/timeweb-s3-direct-multipart` в репозитории `kamilgaraev/prohelper_admin`
+**PR:** `refactor/timeweb-s3-design-multipart`
 
 **Files:**
-- Create: `app/Services/Storage/DTO/PresignedMultipartPart.php`
-- Create: `app/Models/StorageMultipartUpload.php`
-- Create: `app/Jobs/Storage/VerifyMultipartUpload.php`
-- Create: `database/migrations/2026_08_06_000100_create_storage_multipart_uploads.php`
+- Create: `app/Services/Storage/DTO/CurrentMultipartCompletion.php`
+- Create: `app/BusinessModules/Features/DesignManagement/Services/Contracts/DesignModelRegistrationService.php`
 - Modify: `app/Services/Storage/FileService.php`
+- Modify: `app/BusinessModules/Features/DesignManagement/Services/DesignManagementService.php`
 - Modify: `app/BusinessModules/Features/DesignManagement/Services/DesignModelMultipartUploadService.php`
 - Modify: `app/BusinessModules/Features/DesignManagement/DesignManagementServiceProvider.php`
-- Create: `app/BusinessModules/Features/DesignManagement/Http/Requests/PresignDesignModelPartRequest.php`
-- Modify: `app/BusinessModules/Features/DesignManagement/routes.php`
-- Create: `tests/Unit/Storage/FileServicePresignedMultipartTest.php`
-- Create: `tests/Feature/Storage/StorageMultipartUploadWorkflowTest.php`
 - Modify: `tests/Unit/DesignManagement/DesignModelMultipartUploadServiceTest.php`
-- Modify (`prohelper_admin`): `src/services/apiConstants.ts`
-- Modify (`prohelper_admin`): `src/types/designManagement.ts`
-- Modify (`prohelper_admin`): `src/services/designManagementService.ts`
-- Modify (`prohelper_admin`): `src/services/designManagementService.test.ts`
-- Modify (`prohelper_admin`): `src/pages/DesignManagement/components/DesignModelUploadDialog.tsx`
-- Modify (`prohelper_admin`): `src/pages/DesignManagement/components/DesignModelUploadDialog.test.tsx`
+- Modify: `tests/Unit/Storage/FileServiceCurrentObjectTest.php`
+- Modify: `tests/Unit/DesignManagement/DesignStoragePathServiceTest.php`
 
 **Interfaces:**
-- Consumes: один S3 client и `OrganizationStoragePath`.
-- Produces: `FileService::startPresignedMultipart(...)`, `presignMultipartPart(...)`, `completePresignedMultipart(...)`, `abortPresignedMultipart(...)`; устойчивые сессии и очередь SHA-256 verify; админка отправляет байты части напрямую на Timeweb URL и возвращает backend только `part_number` и `ETag`.
+- Consumes: существующий HTTP-контракт multipart-загрузки и единый `FileService`.
+- Produces: org/user-scoped ключи, `FileService::startMultipart(...)`, `uploadPart(...)`, `completeCurrentMultipart(...)`, `verifyCurrentMultipart(...)`, `abortMultipart(...)`; повторяемую потоковую проверку готового объекта и SHA-256 без `VersionId`. Receipt завершения хранится в существующей cache-сессии, receipts частей объединяются под cache-lock, а явный abort удаляет уже завершённый объект. При невозможности подтвердить компенсационное удаление сессия сохраняется для повторной очистки.
 
-- [ ] **Step 1: Написать failing unit-тест presign**
-
-Проверить, что SDK получает точные `Bucket`, `Key`, `UploadId`, `PartNumber`, TTL 900 секунд и не получает ACL/public headers; результат содержит URL, номер части и expiry.
-
-- [ ] **Step 2: Проверить RED и реализовать SDK-методы**
-
-Run: `php artisan test tests/Unit/Storage/FileServicePresignedMultipartTest.php --stop-on-failure`
-
-Expected сначала FAIL, затем PASS.
-
-- [ ] **Step 3: Написать failing feature-тест состояний**
-
-Проверить переходы initiated/uploading/verifying/completed, идемпотентный complete, запрет чужой организации/пользователя, истечение сессии и dispatch `VerifyMultipartUpload`.
-
-- [ ] **Step 4: Реализовать модель, миграцию, job и design workflow**
-
-Миграция создаёт UUID/ULID primary key, organization/user foreign keys, purpose, storage_key unique, upload_id encrypted cast, expected/actual metadata, status, expires_at и timestamps. Job читает поток частями, вычисляет SHA-256, сверяет размер/MIME и только после этого регистрирует IFC-версию.
-
-- [ ] **Step 5: Проверить GREEN**
+- [x] **Step 1: Написать failing тесты шлюза и design upload**
+- [x] **Step 2: Проверить RED**
+- [x] **Step 3: Удалить прямой S3Client из DesignManagement**
+- [x] **Step 4: Добавить org/user namespace, SHA-256 и компенсационное удаление**
+- [x] **Step 5: Проверить GREEN и Larastan**
 
 Run:
 
 ```bash
-php artisan test tests/Unit/Storage/FileServicePresignedMultipartTest.php tests/Feature/Storage/StorageMultipartUploadWorkflowTest.php tests/Unit/DesignManagement/DesignModelMultipartUploadServiceTest.php --stop-on-failure
-vendor/bin/phpstan analyse app/Services/Storage app/Models/StorageMultipartUpload.php app/Jobs/Storage app/BusinessModules/Features/DesignManagement --memory-limit=1G
-php -l database/migrations/2026_08_06_000100_create_storage_multipart_uploads.php
+php vendor/bin/phpunit tests/Unit/Storage/FileServiceCurrentObjectTest.php
+php vendor/bin/phpunit tests/Unit/DesignManagement/DesignModelMultipartUploadServiceTest.php
+php vendor/bin/phpunit tests/Unit/DesignManagement/DesignStoragePathServiceTest.php
+vendor/bin/phpstan analyse app/Services/Storage/FileService.php app/BusinessModules/Features/DesignManagement --memory-limit=1G
 ```
 
-- [ ] **Step 6: Написать failing frontend-тест прямой загрузки**
-
-В чистом worktree `prohelper_admin` проверить, что `uploadModelMultipart`:
-
-1. получает presigned URL части от backend;
-2. выполняет `PUT` Blob напрямую на этот URL без JWT/cookie;
-3. читает `ETag` response header;
-4. сообщает ETag backend;
-5. отменяет multipart-сессию при необратимой ошибке;
-6. сохраняет текущий progress callback.
-
-Run: `npx vitest run src/services/designManagementService.test.ts src/pages/DesignManagement/components/DesignModelUploadDialog.test.tsx`
-
-Expected: FAIL, текущая реализация отправляет Blob части в Laravel API.
-
-- [ ] **Step 7: Реализовать frontend direct multipart и проверить GREEN**
-
-Обновить типы start/presign/complete, API constants и сервис. Не передавать application auth headers на Timeweb URL. Разрешить только HTTPS URL с host `s3.twcstorage.ru` или его bucket subdomain; пустой/неразрешённый ETag считать ошибкой и выполнять abort.
-
-Run:
-
-```bash
-npx vitest run src/services/designManagementService.test.ts src/pages/DesignManagement/components/DesignModelUploadDialog.test.tsx
-npx tsc --noEmit
-npx eslint src/services/apiConstants.ts src/types/designManagement.ts src/services/designManagementService.ts src/services/designManagementService.test.ts src/pages/DesignManagement/components/DesignModelUploadDialog.tsx src/pages/DesignManagement/components/DesignModelUploadDialog.test.tsx
-```
-
-Expected: PASS. `npm run build` не запускать согласно правилам workspace.
-
-- [ ] **Step 8: Commit backend, PR, merge и deploy**
-
-Commit: `feat[backend]: добавлена прямая multipart-загрузка в Timeweb S3`.
-
-После deploy backend проверить создание сессии, presign одной части и abort.
-
-- [ ] **Step 9: Commit frontend, PR, merge и deploy**
-
-Commit в `prohelper_admin`: `feat[admin]: крупные файлы загружаются напрямую в Timeweb S3`.
-
-После штатного deploy админки проверить полный multipart upload и отсутствие тела части в Laravel access log.
+- [ ] **Step 6: Независимое review, commit, PR, merge и deploy**
 
 ---
 
@@ -652,7 +584,7 @@ Run:
 ```bash
 php artisan test tests/Unit/Config/TimewebS3ConfigurationTest.php tests/Unit/Storage tests/Unit/Services/Storage tests/Unit/DesignManagement/DesignModelMultipartUploadServiceTest.php --stop-on-failure
 vendor/bin/phpstan analyse app/Services/Storage app/BusinessModules/Core/Reporting app/BusinessModules/Features/DesignManagement --memory-limit=1G
-vendor/bin/pint --test app/Services/Storage app/BusinessModules/Core/Reporting app/BusinessModules/Features/DesignManagement config/filesystems.php database/migrations/2026_08_06_000100_create_storage_multipart_uploads.php database/migrations/2026_08_06_000200_reset_legacy_file_storage_records.php
+vendor/bin/pint --test app/Services/Storage app/BusinessModules/Core/Reporting app/BusinessModules/Features/DesignManagement config/filesystems.php database/migrations/2026_08_06_000200_reset_legacy_file_storage_records.php
 rg -n "storage\.yandexcloud\.net|REPORTS_BUCKET|AWS_PERSONALS_BUCKET|OrgBucketService|reports:cleanup|personals:cleanup" app config routes .env.example
 ```
 

--- a/tests/Unit/DesignManagement/DesignModelMultipartUploadServiceTest.php
+++ b/tests/Unit/DesignManagement/DesignModelMultipartUploadServiceTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Unit\DesignManagement;
 
-use App\BusinessModules\Features\DesignManagement\Services\DesignManagementService;
+use App\BusinessModules\Features\DesignManagement\Models\DesignArtifactVersion;
+use App\BusinessModules\Features\DesignManagement\Models\DesignPackage;
+use App\BusinessModules\Features\DesignManagement\Services\Contracts\DesignModelRegistrationService;
 use App\BusinessModules\Features\DesignManagement\Services\DesignModelMultipartUploadService;
 use App\BusinessModules\Features\DesignManagement\Services\DesignStoragePathService;
-use Aws\Result;
-use Aws\S3\S3ClientInterface;
+use App\Services\Storage\DTO\CurrentMultipartCompletion;
+use App\Services\Storage\DTO\CurrentStoredFile;
+use App\Services\Storage\DTO\MultipartPart;
+use App\Services\Storage\DTO\MultipartUpload;
+use App\Services\Storage\FileService;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
@@ -16,20 +21,17 @@ use Tests\TestCase;
 
 final class DesignModelMultipartUploadServiceTest extends TestCase
 {
-    public function refreshDatabase(): void
-    {
-    }
+    public function refreshDatabase(): void {}
 
-    public function testUploadsApiChunkToS3MultipartUpload(): void
+    public function test_uploads_api_chunk_to_s3_multipart_upload(): void
     {
         Cache::flush();
 
         $uploadId = 'upload-123';
-        Cache::put('design_management:model_upload:' . $uploadId, [
+        Cache::put('design_management:model_upload:'.$uploadId, [
             'upload_id' => $uploadId,
             's3_upload_id' => 's3-upload-123',
-            'bucket' => 'prohelper-storage',
-            'source_path' => 'org-7/pir/model-uploads/upload-123/building.ifc',
+            'source_path' => 'org-7/pir/model-uploads/user-15/upload-123/building.ifc',
             'organization_id' => 7,
             'project_id' => 11,
             'package_id' => 21,
@@ -48,20 +50,43 @@ final class DesignModelMultipartUploadServiceTest extends TestCase
             ],
         ], now()->addDay());
 
-        $s3Client = Mockery::mock(S3ClientInterface::class);
-        $s3Client->shouldReceive('uploadPart')
+        $contents = str_repeat('A', 1024);
+        $checksum = hash('sha256', $contents);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('uploadPart')
             ->once()
-            ->with(Mockery::on(static fn (array $payload): bool => $payload['Bucket'] === 'prohelper-storage'
-                && $payload['Key'] === 'org-7/pir/model-uploads/upload-123/building.ifc'
-                && $payload['UploadId'] === 's3-upload-123'
-                && $payload['PartNumber'] === 1
-                && $payload['ContentLength'] === 1024
-                && is_resource($payload['Body'])))
-            ->andReturn(new Result(['ETag' => '"etag-1"']));
+            ->with(
+                Mockery::on(static fn (MultipartUpload $upload): bool => $upload->organizationPath
+                    === 'org-7/pir/model-uploads/user-15/upload-123/building.ifc'
+                    && $upload->uploadId === 's3-upload-123'
+                    && $upload->partSizeBytes === 5_242_880),
+                1,
+                $contents,
+                $checksum,
+            )
+            ->andReturnUsing(static function () use ($uploadId, $checksum): MultipartPart {
+                $session = Cache::get('design_management:model_upload:'.$uploadId);
+                $session['uploaded_parts'][2] = [
+                    'PartNumber' => 2,
+                    'ETag' => '"etag-2"',
+                    'Size' => 1024,
+                    'ChecksumSHA256' => str_repeat('b', 64),
+                ];
+                Cache::put('design_management:model_upload:'.$uploadId, $session, now()->addDay());
+
+                return new MultipartPart(
+                    'org-7/pir/model-uploads/user-15/upload-123/building.ifc',
+                    's3-upload-123',
+                    1,
+                    '"etag-1"',
+                    1024,
+                    $checksum,
+                );
+            });
 
         $tmpPath = tempnam(sys_get_temp_dir(), 'ifc-part-test-');
         $this->assertIsString($tmpPath);
-        file_put_contents($tmpPath, str_repeat('A', 1024));
+        file_put_contents($tmpPath, $contents);
 
         $chunk = new UploadedFile(
             $tmpPath,
@@ -70,10 +95,11 @@ final class DesignModelMultipartUploadServiceTest extends TestCase
             null,
             true
         );
+        $registrar = Mockery::mock(DesignModelRegistrationService::class);
         $service = new DesignModelMultipartUploadService(
-            $s3Client,
-            new DesignStoragePathService(),
-            $this->app->make(DesignManagementService::class)
+            $files,
+            new DesignStoragePathService,
+            $registrar,
         );
 
         $result = $service->uploadPart(7, 15, $uploadId, 1, $chunk);
@@ -82,6 +108,448 @@ final class DesignModelMultipartUploadServiceTest extends TestCase
         $this->assertSame(1, $result['part_number']);
         $this->assertSame('"etag-1"', $result['etag']);
         $this->assertSame(1024, $result['size_bytes']);
-        $this->assertSame('"etag-1"', Cache::get('design_management:model_upload:' . $uploadId)['uploaded_parts'][1]['ETag']);
+        $this->assertSame('"etag-1"', Cache::get('design_management:model_upload:'.$uploadId)['uploaded_parts'][1]['ETag']);
+        $this->assertSame($checksum, Cache::get('design_management:model_upload:'.$uploadId)['uploaded_parts'][1]['ChecksumSHA256']);
+        $this->assertSame('"etag-2"', Cache::get('design_management:model_upload:'.$uploadId)['uploaded_parts'][2]['ETag']);
+    }
+
+    public function test_start_uses_org_user_path_and_unified_storage_session(): void
+    {
+        Cache::flush();
+        $package = new DesignPackage;
+        $package->forceFill(['id' => 21, 'organization_id' => 7, 'project_id' => 11]);
+        $registrar = Mockery::mock(DesignModelRegistrationService::class);
+        $registrar->shouldReceive('ensurePackageAcceptsModelChanges')->once()->with($package);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('startMultipart')
+            ->once()
+            ->withArgs(static fn (string $path, string $mime, int $partSize, array $metadata): bool => str_starts_with(
+                $path,
+                'org-7/pir/projects/11/packages/21/model-uploads/user-15/',
+            )
+                && str_ends_with($path, '/source/building.ifc')
+                && $mime === 'application/x-step'
+                && $partSize === 5_242_880
+                && ($metadata['user_id'] ?? null) === '15')
+            ->andReturnUsing(static fn (
+                string $path,
+                string $mime,
+                int $partSize,
+                array $metadata,
+            ): MultipartUpload => new MultipartUpload($path, 'provider-upload', $mime, $partSize, $metadata));
+
+        $result = (new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            $registrar,
+        ))->start($package, 15, [
+            'file_size_bytes' => 1024,
+            'original_name' => 'building.ifc',
+            'content_type' => 'application/x-step',
+            'title' => 'IFC',
+            'version_number' => '1',
+        ]);
+
+        $session = Cache::get('design_management:model_upload:'.$result['upload_id']);
+        $this->assertIsArray($session);
+        $this->assertStringContainsString('/user-15/', $session['source_path']);
+        $this->assertArrayNotHasKey('bucket', $session);
+        $this->assertSame('provider-upload', $session['s3_upload_id']);
+    }
+
+    public function test_start_aborts_provider_upload_when_cache_rejects_session(): void
+    {
+        $package = new DesignPackage;
+        $package->forceFill(['id' => 21, 'organization_id' => 7, 'project_id' => 11]);
+        $registrar = Mockery::mock(DesignModelRegistrationService::class);
+        $registrar->shouldReceive('ensurePackageAcceptsModelChanges')->once()->with($package);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('startMultipart')
+            ->once()
+            ->andReturnUsing(static fn (
+                string $path,
+                string $mime,
+                int $partSize,
+                array $metadata,
+            ): MultipartUpload => new MultipartUpload($path, 'provider-upload', $mime, $partSize, $metadata));
+        $files->shouldReceive('abortMultipart')
+            ->once()
+            ->with(Mockery::on(static fn (MultipartUpload $upload): bool => $upload->uploadId === 'provider-upload'));
+        Cache::shouldReceive('put')->once()->andReturn(false);
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            $registrar,
+        );
+
+        $this->expectException(\DomainException::class);
+        $service->start($package, 15, [
+            'file_size_bytes' => 1024,
+            'original_name' => 'building.ifc',
+            'content_type' => 'application/x-step',
+            'title' => 'IFC',
+            'version_number' => '1',
+        ]);
+    }
+
+    public function test_start_aborts_provider_upload_when_cache_throws(): void
+    {
+        $package = new DesignPackage;
+        $package->forceFill(['id' => 21, 'organization_id' => 7, 'project_id' => 11]);
+        $registrar = Mockery::mock(DesignModelRegistrationService::class);
+        $registrar->shouldReceive('ensurePackageAcceptsModelChanges')->once()->with($package);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('startMultipart')
+            ->once()
+            ->andReturnUsing(static fn (
+                string $path,
+                string $mime,
+                int $partSize,
+                array $metadata,
+            ): MultipartUpload => new MultipartUpload($path, 'provider-upload', $mime, $partSize, $metadata));
+        $files->shouldReceive('abortMultipart')->once();
+        Cache::shouldReceive('put')->once()->andThrow(new \RuntimeException('cache_unavailable'));
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            $registrar,
+        );
+
+        $this->expectException(\DomainException::class);
+        $service->start($package, 15, [
+            'file_size_bytes' => 1024,
+            'original_name' => 'building.ifc',
+            'content_type' => 'application/x-step',
+            'title' => 'IFC',
+            'version_number' => '1',
+        ]);
+    }
+
+    public function test_upload_part_fails_when_atomic_receipt_cannot_be_persisted(): void
+    {
+        $uploadId = 'upload-cache-failure';
+        $path = 'org-7/pir/model-uploads/user-15/upload-cache-failure/building.ifc';
+        $session = $this->multipartSession($uploadId, $path);
+        $contents = str_repeat('A', 1024);
+        $checksum = hash('sha256', $contents);
+        $part = new MultipartPart($path, 'provider-'.$uploadId, 1, 'part-etag', 1024, $checksum);
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('uploadPart')->once()->andReturn($part);
+        Cache::shouldReceive('get')->twice()->with('design_management:model_upload:'.$uploadId)->andReturn($session);
+        Cache::shouldReceive('lock')->once()->andReturn(new class
+        {
+            public function block(int $seconds, callable $callback): mixed
+            {
+                return $callback();
+            }
+        });
+        Cache::shouldReceive('put')->once()->andReturn(false);
+        $tmpPath = tempnam(sys_get_temp_dir(), 'ifc-part-cache-test-');
+        $this->assertIsString($tmpPath);
+        file_put_contents($tmpPath, $contents);
+        $chunk = new UploadedFile(
+            $tmpPath,
+            'building.ifc.part-1',
+            'application/octet-stream',
+            null,
+            true,
+        );
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            Mockery::mock(DesignModelRegistrationService::class),
+        );
+
+        $this->expectException(\DomainException::class);
+        $service->uploadPart(7, 15, $uploadId, 1, $chunk);
+    }
+
+    public function test_complete_retries_only_verification_after_transient_read_failure(): void
+    {
+        Cache::flush();
+        $uploadId = 'upload-retry';
+        $path = 'org-7/pir/model-uploads/user-15/upload-retry/building.ifc';
+        Cache::put('design_management:model_upload:'.$uploadId, [
+            'upload_id' => $uploadId,
+            's3_upload_id' => 'provider-upload-retry',
+            'source_path' => $path,
+            'organization_id' => 7,
+            'project_id' => 11,
+            'package_id' => 21,
+            'user_id' => 15,
+            'part_size_bytes' => 5_242_880,
+            'parts_count' => 1,
+            'file' => [
+                'original_name' => 'building.ifc',
+                'mime_type' => 'application/x-step',
+                'size_bytes' => 1024,
+            ],
+            'uploaded_parts' => [
+                1 => [
+                    'PartNumber' => 1,
+                    'ETag' => 'part-etag',
+                    'Size' => 1024,
+                    'ChecksumSHA256' => str_repeat('a', 64),
+                ],
+            ],
+            'completion' => null,
+            'expires_at' => now()->addHours(2)->toISOString(),
+            'payload' => ['title' => 'IFC', 'version_number' => '1'],
+        ], now()->addHours(2));
+        $package = new DesignPackage;
+        $package->forceFill(['id' => 21, 'organization_id' => 7, 'project_id' => 11]);
+        $version = new DesignArtifactVersion;
+        $version->forceFill(['id' => 31]);
+        $completion = new CurrentMultipartCompletion($path, 'object-etag', 1024, 'application/x-step');
+        $stored = new CurrentStoredFile(
+            $path,
+            'object-etag',
+            1024,
+            hash('sha256', 'body'),
+            'application/x-step',
+        );
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('completeCurrentMultipart')->once()->andReturn($completion);
+        $verificationAttempt = 0;
+        $files->shouldReceive('verifyCurrentMultipart')
+            ->twice()
+            ->andReturnUsing(static function () use (&$verificationAttempt, $stored): CurrentStoredFile {
+                $verificationAttempt++;
+                if ($verificationAttempt === 1) {
+                    throw new \RuntimeException('storage_object_read_failed');
+                }
+
+                return $stored;
+            });
+        $registrar = Mockery::mock(DesignModelRegistrationService::class);
+        $registrar->shouldReceive('findPackage')->twice()->with(7, 21)->andReturn($package);
+        $registrar->shouldReceive('ensurePackageAcceptsModelChanges')->twice()->with($package);
+        $registrar->shouldReceive('registerStoredIfcModel')
+            ->once()
+            ->withArgs(static fn (
+                DesignPackage $actualPackage,
+                int $userId,
+                string $sourcePath,
+                array $fileInfo,
+                array $payload,
+            ): bool => $actualPackage === $package
+                && $userId === 15
+                && $sourcePath === $path
+                && ($fileInfo['sha256'] ?? null) === $stored->sha256)
+            ->andReturn($version);
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            $registrar,
+        );
+
+        try {
+            $service->complete(7, 15, $uploadId);
+            $this->fail('Transient verification failure was accepted.');
+        } catch (\DomainException) {
+        }
+
+        $cached = Cache::get('design_management:model_upload:'.$uploadId);
+        $this->assertSame('object-etag', $cached['completion']['etag']);
+        $this->assertSame($version, $service->complete(7, 15, $uploadId));
+        $this->assertNull(Cache::get('design_management:model_upload:'.$uploadId));
+    }
+
+    public function test_abort_uses_file_service_and_removes_owned_session(): void
+    {
+        Cache::flush();
+        $uploadId = 'upload-abort';
+        $path = 'org-7/pir/model-uploads/user-15/upload-abort/building.ifc';
+        Cache::put(
+            'design_management:model_upload:'.$uploadId,
+            $this->multipartSession($uploadId, $path),
+            now()->addHours(2),
+        );
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('abortMultipart')
+            ->once()
+            ->with(Mockery::on(static fn (MultipartUpload $upload): bool => $upload->organizationPath === $path
+                && $upload->uploadId === 'provider-'.$uploadId));
+        $files->shouldReceive('existsCurrent')->once()->with($path)->andReturn(false);
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            Mockery::mock(DesignModelRegistrationService::class),
+        );
+
+        $service->abort(7, 15, $uploadId);
+
+        $this->assertNull(Cache::get('design_management:model_upload:'.$uploadId));
+    }
+
+    public function test_abort_deletes_completed_object_after_frontend_handles_complete_error(): void
+    {
+        Cache::flush();
+        $uploadId = 'upload-completed-abort';
+        $path = 'org-7/pir/model-uploads/user-15/upload-completed-abort/building.ifc';
+        $session = $this->multipartSession($uploadId, $path);
+        $session['completion'] = [
+            'key' => $path,
+            'etag' => 'object-etag',
+            'size_bytes' => 1024,
+            'mime' => 'application/x-step',
+        ];
+        Cache::put('design_management:model_upload:'.$uploadId, $session, now()->addHours(2));
+        $files = Mockery::mock(FileService::class);
+        $files->shouldNotReceive('abortMultipart');
+        $files->shouldReceive('existsCurrent')->once()->with($path)->andReturn(true);
+        $files->shouldReceive('deleteCurrent')->once()->with($path);
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            Mockery::mock(DesignModelRegistrationService::class),
+        );
+
+        $service->abort(7, 15, $uploadId);
+
+        $this->assertNull(Cache::get('design_management:model_upload:'.$uploadId));
+    }
+
+    public function test_abort_rejects_foreign_organization_or_user_without_storage_access(): void
+    {
+        Cache::flush();
+        $uploadId = 'upload-foreign-abort';
+        $path = 'org-7/pir/model-uploads/user-15/upload-foreign-abort/building.ifc';
+        Cache::put(
+            'design_management:model_upload:'.$uploadId,
+            $this->multipartSession($uploadId, $path),
+            now()->addHours(2),
+        );
+        $files = Mockery::mock(FileService::class);
+        $files->shouldNotReceive('abortMultipart');
+        $files->shouldNotReceive('existsCurrent');
+        $files->shouldNotReceive('deleteCurrent');
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            Mockery::mock(DesignModelRegistrationService::class),
+        );
+
+        $this->expectException(\DomainException::class);
+        $service->abort(8, 15, $uploadId);
+    }
+
+    public function test_complete_deletes_object_when_database_registration_fails(): void
+    {
+        Cache::flush();
+        $uploadId = 'upload-registration-failure';
+        $path = 'org-7/pir/model-uploads/user-15/upload-registration-failure/building.ifc';
+        Cache::put(
+            'design_management:model_upload:'.$uploadId,
+            $this->multipartSession($uploadId, $path),
+            now()->addHours(2),
+        );
+        $package = new DesignPackage;
+        $package->forceFill(['id' => 21, 'organization_id' => 7, 'project_id' => 11]);
+        $completion = new CurrentMultipartCompletion($path, 'object-etag', 1024, 'application/x-step');
+        $stored = new CurrentStoredFile(
+            $path,
+            'object-etag',
+            1024,
+            hash('sha256', 'body'),
+            'application/x-step',
+        );
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('completeCurrentMultipart')->once()->andReturn($completion);
+        $files->shouldReceive('verifyCurrentMultipart')->once()->andReturn($stored);
+        $files->shouldReceive('deleteCurrent')->once()->with($path);
+        $registrar = Mockery::mock(DesignModelRegistrationService::class);
+        $registrar->shouldReceive('findPackage')->once()->with(7, 21)->andReturn($package);
+        $registrar->shouldReceive('ensurePackageAcceptsModelChanges')->once()->with($package);
+        $registrar->shouldReceive('registerStoredIfcModel')
+            ->once()
+            ->andThrow(new \DomainException('registration_failed'));
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            $registrar,
+        );
+
+        try {
+            $service->complete(7, 15, $uploadId);
+            $this->fail('Registration failure was accepted.');
+        } catch (\DomainException $exception) {
+            $this->assertSame('registration_failed', $exception->getMessage());
+        }
+
+        $this->assertNull(Cache::get('design_management:model_upload:'.$uploadId));
+    }
+
+    public function test_completion_cleanup_failure_keeps_cache_session_for_retry(): void
+    {
+        $uploadId = 'upload-cleanup-retry';
+        $path = 'org-7/pir/model-uploads/user-15/upload-cleanup-retry/building.ifc';
+        $session = $this->multipartSession($uploadId, $path);
+        $package = new DesignPackage;
+        $package->forceFill(['id' => 21, 'organization_id' => 7, 'project_id' => 11]);
+        $completion = new CurrentMultipartCompletion($path, 'object-etag', 1024, 'application/x-step');
+        $files = Mockery::mock(FileService::class);
+        $files->shouldReceive('completeCurrentMultipart')->once()->andReturn($completion);
+        $files->shouldNotReceive('verifyCurrentMultipart');
+        $files->shouldReceive('existsCurrent')->once()->with($path)->andReturn(true);
+        $files->shouldReceive('deleteCurrent')
+            ->once()
+            ->with($path)
+            ->andThrow(new \RuntimeException('storage_unavailable'));
+        $registrar = Mockery::mock(DesignModelRegistrationService::class);
+        $registrar->shouldReceive('findPackage')->once()->with(7, 21)->andReturn($package);
+        $registrar->shouldReceive('ensurePackageAcceptsModelChanges')->once()->with($package);
+        Cache::shouldReceive('get')
+            ->twice()
+            ->with('design_management:model_upload:'.$uploadId)
+            ->andReturn($session);
+        Cache::shouldReceive('lock')->once()->andReturn(new class
+        {
+            public function block(int $seconds, callable $callback): mixed
+            {
+                return $callback();
+            }
+        });
+        Cache::shouldReceive('put')->once()->andReturn(false);
+        Cache::shouldNotReceive('forget');
+        $service = new DesignModelMultipartUploadService(
+            $files,
+            new DesignStoragePathService,
+            $registrar,
+        );
+
+        $this->expectException(\DomainException::class);
+        $service->complete(7, 15, $uploadId);
+    }
+
+    private function multipartSession(string $uploadId, string $path): array
+    {
+        return [
+            'upload_id' => $uploadId,
+            's3_upload_id' => 'provider-'.$uploadId,
+            'source_path' => $path,
+            'organization_id' => 7,
+            'project_id' => 11,
+            'package_id' => 21,
+            'user_id' => 15,
+            'part_size_bytes' => 5_242_880,
+            'parts_count' => 1,
+            'file' => [
+                'original_name' => 'building.ifc',
+                'mime_type' => 'application/x-step',
+                'size_bytes' => 1024,
+            ],
+            'uploaded_parts' => [
+                1 => [
+                    'PartNumber' => 1,
+                    'ETag' => 'part-etag',
+                    'Size' => 1024,
+                    'ChecksumSHA256' => str_repeat('a', 64),
+                ],
+            ],
+            'completion' => null,
+            'expires_at' => now()->addHours(2)->toISOString(),
+            'payload' => ['title' => 'IFC', 'version_number' => '1'],
+        ];
     }
 }

--- a/tests/Unit/DesignManagement/DesignStoragePathServiceTest.php
+++ b/tests/Unit/DesignManagement/DesignStoragePathServiceTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Tests\Unit\DesignManagement;
 
 use App\BusinessModules\Features\DesignManagement\Services\DesignStoragePathService;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 final class DesignStoragePathServiceTest extends TestCase
 {
     public function test_source_path_uses_organization_project_package_and_version_scope(): void
     {
-        $service = new DesignStoragePathService();
+        $service = new DesignStoragePathService;
 
         $path = $service->sourcePath(7, 15, 22, 101, 'model.ifc');
 
@@ -20,7 +20,7 @@ final class DesignStoragePathServiceTest extends TestCase
 
     public function test_derivative_path_uses_viewer_folder_and_normalized_extension(): void
     {
-        $service = new DesignStoragePathService();
+        $service = new DesignStoragePathService;
 
         $path = $service->derivativePath(7, 15, 22, 101, '.FRAG');
 
@@ -29,7 +29,7 @@ final class DesignStoragePathServiceTest extends TestCase
 
     public function test_document_source_path_uses_document_folder_and_safe_name(): void
     {
-        $service = new DesignStoragePathService();
+        $service = new DesignStoragePathService;
 
         $path = $service->documentSourcePath(7, 15, 22, 101, '..\\АР том 1.pdf');
 
@@ -38,10 +38,22 @@ final class DesignStoragePathServiceTest extends TestCase
 
     public function test_source_path_drops_user_provided_directories(): void
     {
-        $service = new DesignStoragePathService();
+        $service = new DesignStoragePathService;
 
         $path = $service->sourcePath(7, 15, 22, 101, '..\\unsafe/model.ifc');
 
         self::assertSame('org-7/pir/projects/15/packages/22/models/101/source/model.ifc', $path);
+    }
+
+    public function test_multipart_source_path_is_scoped_to_organization_and_user(): void
+    {
+        $service = new DesignStoragePathService;
+
+        $path = $service->multipartSourcePath(7, 15, 22, 91, 'upload-123', '..\\unsafe/model.ifc');
+
+        self::assertSame(
+            'org-7/pir/projects/15/packages/22/model-uploads/user-91/upload-123/source/model.ifc',
+            $path,
+        );
     }
 }

--- a/tests/Unit/Storage/FileServiceCurrentObjectTest.php
+++ b/tests/Unit/Storage/FileServiceCurrentObjectTest.php
@@ -6,7 +6,11 @@ namespace Tests\Unit\Storage;
 
 use App\Models\Organization;
 use App\Services\Logging\LoggingService;
+use App\Services\Storage\DTO\CurrentMultipartCompletion;
 use App\Services\Storage\DTO\CurrentStoredFile;
+use App\Services\Storage\DTO\MultipartPart;
+use App\Services\Storage\DTO\MultipartUpload;
+use App\Services\Storage\Exceptions\VersionedObjectIntegrityException;
 use App\Services\Storage\FileService;
 use Aws\Result;
 use Aws\S3\S3ClientInterface;
@@ -18,6 +22,8 @@ use PHPUnit\Framework\TestCase;
 
 final class FileServiceCurrentObjectTest extends TestCase
 {
+    private const PART_SIZE = 5 * 1024 * 1024;
+
     protected function tearDown(): void
     {
         Mockery::close();
@@ -94,6 +100,137 @@ final class FileServiceCurrentObjectTest extends TestCase
         fclose($stream);
     }
 
+    public function test_it_completes_a_current_multipart_object_and_streams_its_sha256(): void
+    {
+        $contents = str_repeat('m', self::PART_SIZE);
+        $path = 'org-42/pir/projects/11/packages/21/model-uploads/user-15/upload-1/model.ifc';
+        $upload = new MultipartUpload(
+            $path,
+            'provider-upload-1',
+            'application/x-step',
+            self::PART_SIZE,
+            ['organization_id' => '42', 'user_id' => '15'],
+        );
+        $part = new MultipartPart(
+            $path,
+            $upload->uploadId,
+            1,
+            'part-etag',
+            strlen($contents),
+            hash('sha256', $contents),
+        );
+        $client = Mockery::mock(S3ClientInterface::class);
+        $client->shouldReceive('completeMultipartUpload')
+            ->once()
+            ->with(Mockery::on(static fn (array $arguments): bool => ($arguments['Bucket'] ?? null) === 'prohelper-storage'
+                && ($arguments['Key'] ?? null) === $path
+                && ($arguments['UploadId'] ?? null) === 'provider-upload-1'
+                && ($arguments['IfNoneMatch'] ?? null) === '*'
+                && ($arguments['MultipartUpload']['Parts'] ?? null) === [[
+                    'PartNumber' => 1,
+                    'ETag' => 'part-etag',
+                ]]))
+            ->andReturn(new Result([
+                'Bucket' => 'prohelper-storage',
+                'Key' => $path,
+                'ETag' => 'object-etag',
+                'VersionId' => 'internal-only',
+            ]));
+        $disk = $this->recordingDisk($contents);
+
+        $files = $this->service($client, $disk);
+        $completion = $files->completeCurrentMultipart(
+            $upload,
+            [$part],
+            strlen($contents),
+        );
+        $stored = $files->verifyCurrentMultipart($completion);
+
+        self::assertInstanceOf(CurrentMultipartCompletion::class, $completion);
+        self::assertSame($path, $stored->key);
+        self::assertSame('object-etag', $stored->etag);
+        self::assertSame(strlen($contents), $stored->sizeBytes);
+        self::assertSame(hash('sha256', $contents), $stored->sha256);
+        self::assertSame('application/x-step', $stored->mime);
+        self::assertSame([], $disk->deletedKeys);
+    }
+
+    public function test_it_deletes_a_completed_current_object_when_streamed_size_does_not_match(): void
+    {
+        $path = 'org-42/pir/model-uploads/user-15/upload-2/model.ifc';
+        $upload = new MultipartUpload(
+            $path,
+            'provider-upload-2',
+            'application/x-step',
+            self::PART_SIZE,
+            ['organization_id' => '42', 'user_id' => '15'],
+        );
+        $part = new MultipartPart(
+            $path,
+            $upload->uploadId,
+            1,
+            'part-etag',
+            self::PART_SIZE,
+            str_repeat('a', 64),
+        );
+        $client = Mockery::mock(S3ClientInterface::class);
+        $client->shouldReceive('completeMultipartUpload')
+            ->once()
+            ->andReturn(new Result(['ETag' => 'object-etag']));
+        $disk = $this->recordingDisk('short-body');
+        $files = $this->service($client, $disk);
+
+        $completion = $files->completeCurrentMultipart($upload, [$part], self::PART_SIZE);
+
+        try {
+            $files->verifyCurrentMultipart($completion);
+            self::fail('Multipart object with a mismatched size was accepted.');
+        } catch (VersionedObjectIntegrityException $exception) {
+            self::assertSame('s3_multipart_current_object_size_mismatch', $exception->getMessage());
+        }
+
+        self::assertSame([$path], $disk->deletedKeys);
+    }
+
+    public function test_it_keeps_a_completed_object_after_transient_read_failure_and_allows_retry(): void
+    {
+        $contents = str_repeat('r', self::PART_SIZE);
+        $path = 'org-42/pir/model-uploads/user-15/upload-3/model.ifc';
+        $upload = new MultipartUpload(
+            $path,
+            'provider-upload-3',
+            'application/x-step',
+            self::PART_SIZE,
+            ['organization_id' => '42', 'user_id' => '15'],
+        );
+        $part = new MultipartPart(
+            $path,
+            $upload->uploadId,
+            1,
+            'part-etag',
+            self::PART_SIZE,
+            hash('sha256', $contents),
+        );
+        $client = Mockery::mock(S3ClientInterface::class);
+        $client->shouldReceive('completeMultipartUpload')
+            ->once()
+            ->andReturn(new Result(['ETag' => 'object-etag']));
+        $disk = $this->recordingDisk($contents, 1);
+        $files = $this->service($client, $disk);
+        $completion = $files->completeCurrentMultipart($upload, [$part], self::PART_SIZE);
+
+        try {
+            $files->verifyCurrentMultipart($completion);
+            self::fail('Transient read failure was accepted.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('storage_object_read_failed', $exception->getMessage());
+        }
+
+        self::assertSame([], $disk->deletedKeys);
+        $stored = $files->verifyCurrentMultipart($completion);
+        self::assertSame(hash('sha256', $contents), $stored->sha256);
+    }
+
     #[DataProvider('invalidWriteProvider')]
     public function test_it_rejects_invalid_write_before_calling_s3(
         string $key,
@@ -167,14 +304,17 @@ final class FileServiceCurrentObjectTest extends TestCase
         };
     }
 
-    private function recordingDisk(): FilesystemAdapter
+    private function recordingDisk(string $contents = 'stored-body', int $readFailures = 0): FilesystemAdapter
     {
-        return new class extends FilesystemAdapter
+        return new class($contents, $readFailures) extends FilesystemAdapter
         {
             /** @var list<string> */
             public array $deletedKeys = [];
 
-            public function __construct() {}
+            public function __construct(
+                private readonly string $contents,
+                private int $readFailures,
+            ) {}
 
             public function getConfig(): array
             {
@@ -188,8 +328,14 @@ final class FileServiceCurrentObjectTest extends TestCase
 
             public function readStream($path)
             {
+                if ($this->readFailures > 0) {
+                    $this->readFailures--;
+
+                    return false;
+                }
+
                 $stream = fopen('php://temp', 'w+b');
-                fwrite($stream, 'stored-body');
+                fwrite($stream, $this->contents);
                 rewind($stream);
 
                 return $stream;


### PR DESCRIPTION
## Что изменено
- удалён прямой S3Client из DesignManagement
- multipart-части проходят через единый FileService и один приватный бакет
- ключи моделей содержат org-{id} и user-{id}
- complete и потоковая SHA-256-верификация разделены для безопасного повтора
- cache receipts защищены lock-ом; abort и компенсации не оставляют бесхозные объекты
- API-контракт админки сохранён без новой инфраструктуры

## Проверки
- PHPUnit: 25 tests, 111 assertions
- Larastan: без ошибок
- Pint: без замечаний
- независимое Superpowers-review: Critical/Important закрыты