### PR TITLE
fix[backend]: исправлено выполнение JSONB constraint

### DIFF
--- a/database/migrations/2026_08_06_000200_reset_legacy_file_storage_records.php
+++ b/database/migrations/2026_08_06_000200_reset_legacy_file_storage_records.php
@@ -203,7 +203,7 @@ SQL);
                 ]);
             }
             DB::table('estimate_generation_processing_units')->delete();
-            DB::statement(<<<'SQL'
+            DB::unprepared(<<<'SQL'
 ALTER TABLE estimate_generation_processing_units ADD CONSTRAINT eg_units_locator_provenance_ck CHECK (
     locator ?& ARRAY['source_kind', 'source_version', 'coordinate_space', 'artifact_path', 'artifact_sha256']
     AND jsonb_typeof(locator->'source_kind') = 'string'
@@ -410,7 +410,7 @@ SQL);
     {
         if (Schema::hasTable('estimate_generation_processing_units')) {
             DB::statement('ALTER TABLE estimate_generation_processing_units DROP CONSTRAINT IF EXISTS eg_units_locator_provenance_ck');
-            DB::statement(<<<'SQL'
+            DB::unprepared(<<<'SQL'
 ALTER TABLE estimate_generation_processing_units ADD CONSTRAINT eg_units_locator_provenance_ck CHECK (
     locator ?& ARRAY['source_kind', 'source_version', 'coordinate_space', 'artifact_path', 'artifact_sha256', 'artifact_version_id']
     AND locator->>'source_version' = source_version

--- a/tests/Unit/Storage/ResetLegacyFileStorageRecordsMigrationContractTest.php
+++ b/tests/Unit/Storage/ResetLegacyFileStorageRecordsMigrationContractTest.php
@@ -8,6 +8,18 @@ use PHPUnit\Framework\TestCase;
 
 final class ResetLegacyFileStorageRecordsMigrationContractTest extends TestCase
 {
+    public function test_jsonb_constraint_sql_bypasses_pdo_placeholder_parsing(): void
+    {
+        $source = $this->migrationSource();
+        $jsonbConstraint = "DB::unprepared(<<<'SQL'\nALTER TABLE estimate_generation_processing_units ADD CONSTRAINT eg_units_locator_provenance_ck CHECK (\n    locator ?& ARRAY";
+
+        self::assertSame(2, substr_count($source, $jsonbConstraint));
+        self::assertStringNotContainsString(
+            "DB::statement(<<<'SQL'\nALTER TABLE estimate_generation_processing_units ADD CONSTRAINT eg_units_locator_provenance_ck CHECK (\n    locator ?& ARRAY",
+            $source,
+        );
+    }
+
     public function test_down_restores_and_validates_the_original_report_and_quality_constraints(): void
     {
         $source = $this->migrationSource();


### PR DESCRIPTION
## Причина
Laravel/PDO интерпретировал PostgreSQL JSONB-оператор ?& как placeholder и отправлял $1, поэтому reset migration прерывалась до применения изменений.

## Исправление
- оба статических constraint-блока up/down выполняются через DB::unprepared
- добавлен регрессионный source-contract тест

## Проверки
- 5 тестов, 48 assertions
- php -l, Pint, PHPStan, git diff --check
- Superpowers review: Critical/Important нет, Ready to merge: Yes

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated database migration to use DB::unprepared instead of DB::statement for complex SQL constraints.</li>
<li>Ensured JSONB constraint definitions bypass PDO placeholder parsing to prevent syntax errors.</li>
<li>Added a unit test to verify that the migration source code correctly uses DB::unprepared for the specified constraints.</li>
</ul></div>