### PR TITLE
feat: зафиксирована граница истории принятой выработки

### DIFF
--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Models/ProductionAcceptanceHistoryCheckpoint.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Models/ProductionAcceptanceHistoryCheckpoint.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CompletedWork\Reporting\AcceptedProduction\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class ProductionAcceptanceHistoryCheckpoint extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'production_acceptance_history_checkpoints';
+
+    protected $guarded = [];
+
+    protected function casts(): array
+    {
+        return [
+            'completed_at' => 'immutable_datetime',
+            'backfill_ledger_watermark_id' => 'integer',
+            'event_count' => 'integer',
+            'event_watermark_id' => 'integer',
+            'excluded_legacy_act_count' => 'integer',
+            'owner_member_count' => 'integer',
+            'owner_member_watermark_id' => 'integer',
+            'owner_version_count' => 'integer',
+            'owner_version_watermark_id' => 'integer',
+            'performance_act_watermark_id' => 'integer',
+            'unprovable_legacy_count' => 'integer',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::updating(static function (): never {
+            throw new \LogicException('production_acceptance_history_checkpoint_immutable');
+        });
+        static::deleting(static function (): never {
+            throw new \LogicException('production_acceptance_history_checkpoint_immutable');
+        });
+    }
+}

--- a/database/migrations/2026_08_06_000150_create_production_acceptance_history_checkpoints.php
+++ b/database/migrations/2026_08_06_000150_create_production_acceptance_history_checkpoints.php
@@ -1,0 +1,450 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $evidence = DB::transaction(function (): array {
+            Schema::create('production_acceptance_history_checkpoints', function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('organization_id');
+                $table->dateTimeTz('completed_at', 6);
+                $table->unsignedBigInteger('excluded_legacy_act_count');
+                $table->unsignedBigInteger('performance_act_watermark_id');
+                $table->char('legacy_act_set_hash', 64);
+                $table->unsignedBigInteger('owner_version_count');
+                $table->unsignedBigInteger('owner_version_watermark_id');
+                $table->char('owner_version_set_hash', 64);
+                $table->unsignedBigInteger('owner_member_count');
+                $table->unsignedBigInteger('owner_member_watermark_id');
+                $table->char('owner_member_set_hash', 64);
+                $table->unsignedBigInteger('event_count');
+                $table->unsignedBigInteger('event_watermark_id');
+                $table->char('event_set_hash', 64);
+                $table->unsignedBigInteger('unprovable_legacy_count');
+                $table->unsignedBigInteger('backfill_ledger_watermark_id');
+                $table->char('backfill_ledger_set_hash', 64);
+                $table->char('source_hash', 64);
+                $table->dateTimeTz('created_at', 6);
+                $table->dateTimeTz('updated_at', 6);
+
+                $table->unique('organization_id', 'production_acceptance_history_checkpoint_org_unique');
+            });
+
+            DB::statement('LOCK TABLE organizations, contracts, contract_performance_acts, production_acceptance_owner_versions, production_acceptance_owner_members, production_acceptance_events, production_acceptance_backfill_ledger IN SHARE ROW EXCLUSIVE MODE');
+            $ownerMemberDriftCount = (int) DB::scalar(<<<'SQL'
+SELECT COUNT(*)
+FROM production_acceptance_owner_members AS member
+INNER JOIN production_acceptance_owner_versions AS owner
+    ON owner.id = member.owner_version_id
+WHERE member.organization_id IS DISTINCT FROM owner.organization_id
+   OR member.project_id IS DISTINCT FROM owner.project_id
+   OR member.performance_act_id IS DISTINCT FROM owner.performance_act_id
+SQL);
+            if ($ownerMemberDriftCount !== 0) {
+                throw new RuntimeException('Production acceptance owner member scope drift detected.');
+            }
+            DB::statement(<<<'SQL'
+WITH boundary AS MATERIALIZED (
+    SELECT clock_timestamp()::timestamptz(6) AS completed_at
+), legacy_sources AS MATERIALIZED (
+    SELECT
+        contracts.organization_id,
+        COUNT(*) FILTER (
+            WHERE (
+                contract_performance_acts.signed_at IS NOT NULL
+                AND contract_performance_acts.signed_at < boundary.completed_at
+            ) OR (
+                contract_performance_acts.approval_date IS NOT NULL
+                AND contract_performance_acts.approval_date
+                    <= (boundary.completed_at AT TIME ZONE 'UTC')::date
+            )
+        )::bigint AS excluded_legacy_act_count,
+        COALESCE(MAX(contract_performance_acts.id), 0)::bigint AS performance_act_watermark_id,
+        encode(sha256(convert_to(COALESCE(string_agg(
+            encode(sha256(convert_to(jsonb_build_object(
+                'id', contract_performance_acts.id,
+                'approval_date', COALESCE(contract_performance_acts.approval_date::text, ''),
+                'signed_at', CASE
+                    WHEN contract_performance_acts.signed_at IS NULL THEN ''
+                    ELSE to_char(
+                        contract_performance_acts.signed_at AT TIME ZONE 'UTC',
+                        'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+                    )
+                END
+            )::text, 'UTF8')), 'hex'),
+            '' ORDER BY contract_performance_acts.id
+        ) FILTER (
+            WHERE (
+                contract_performance_acts.signed_at IS NOT NULL
+                AND contract_performance_acts.signed_at < boundary.completed_at
+            ) OR (
+                contract_performance_acts.approval_date IS NOT NULL
+                AND contract_performance_acts.approval_date
+                    <= (boundary.completed_at AT TIME ZONE 'UTC')::date
+            )
+        ), ''), 'UTF8')), 'hex') AS legacy_act_set_hash
+    FROM contract_performance_acts
+    INNER JOIN contracts ON contracts.id = contract_performance_acts.contract_id
+    CROSS JOIN boundary
+    GROUP BY contracts.organization_id
+), owner_sources AS MATERIALIZED (
+    SELECT
+        organization_id,
+        COUNT(*)::bigint AS owner_version_count,
+        COALESCE(MAX(id), 0)::bigint AS owner_version_watermark_id,
+        encode(sha256(convert_to(COALESCE(string_agg(
+            encode(sha256(convert_to(
+                jsonb_build_array(id, source_hash)::text,
+                'UTF8'
+            )), 'hex'),
+            '' ORDER BY id
+        ), ''), 'UTF8')), 'hex') AS owner_version_set_hash
+    FROM production_acceptance_owner_versions
+    GROUP BY organization_id
+), owner_member_sources AS MATERIALIZED (
+    SELECT
+        owner.organization_id,
+        COUNT(*)::bigint AS owner_member_count,
+        COALESCE(MAX(member.id), 0)::bigint AS owner_member_watermark_id,
+        encode(sha256(convert_to(COALESCE(string_agg(
+            encode(sha256(convert_to(jsonb_build_object(
+                'id', member.id,
+                'owner_version_id', member.owner_version_id,
+                'owner_organization_id', owner.organization_id,
+                'owner_project_id', owner.project_id,
+                'owner_performance_act_id', owner.performance_act_id,
+                'member_organization_id', member.organization_id,
+                'member_project_id', member.project_id,
+                'member_performance_act_id', member.performance_act_id,
+                'source_line_type', member.source_line_type,
+                'source_line_id', member.source_line_id,
+                'work_id', member.work_id,
+                'contractor_id', member.contractor_id,
+                'unit_code', member.unit_code,
+                'zone', member.zone
+            )::text, 'UTF8')), 'hex'),
+            '' ORDER BY member.id
+        ), ''), 'UTF8')), 'hex') AS owner_member_set_hash
+    FROM production_acceptance_owner_members AS member
+    INNER JOIN production_acceptance_owner_versions AS owner
+        ON owner.id = member.owner_version_id
+    GROUP BY owner.organization_id
+), event_sources AS MATERIALIZED (
+    SELECT
+        organization_id,
+        COUNT(*)::bigint AS event_count,
+        COALESCE(MAX(id), 0)::bigint AS event_watermark_id,
+        encode(sha256(convert_to(COALESCE(string_agg(
+            encode(sha256(convert_to(
+                jsonb_build_array(id, source_hash)::text,
+                'UTF8'
+            )), 'hex'),
+            '' ORDER BY id
+        ), ''), 'UTF8')), 'hex') AS event_set_hash
+    FROM production_acceptance_events
+    GROUP BY organization_id
+), ledger_sources AS MATERIALIZED (
+    SELECT
+        organization_id,
+        COUNT(*) FILTER (WHERE status = 'unprovable')::bigint AS unprovable_legacy_count,
+        COALESCE(MAX(id), 0)::bigint AS backfill_ledger_watermark_id,
+        encode(sha256(convert_to(COALESCE(string_agg(
+            encode(sha256(convert_to(
+                jsonb_build_array(id, source_hash)::text,
+                'UTF8'
+            )), 'hex'),
+            '' ORDER BY id
+        ), ''), 'UTF8')), 'hex') AS backfill_ledger_set_hash
+    FROM production_acceptance_backfill_ledger
+    GROUP BY organization_id
+), checkpoint_counts AS (
+    SELECT
+        organizations.id AS organization_id,
+        boundary.completed_at,
+        COALESCE(legacy_sources.excluded_legacy_act_count, 0) AS excluded_legacy_act_count,
+        COALESCE(legacy_sources.performance_act_watermark_id, 0) AS performance_act_watermark_id,
+        COALESCE(
+            legacy_sources.legacy_act_set_hash,
+            encode(sha256(convert_to('', 'UTF8')), 'hex')
+        ) AS legacy_act_set_hash,
+        COALESCE(owner_sources.owner_version_count, 0) AS owner_version_count,
+        COALESCE(owner_sources.owner_version_watermark_id, 0) AS owner_version_watermark_id,
+        COALESCE(
+            owner_sources.owner_version_set_hash,
+            encode(sha256(convert_to('', 'UTF8')), 'hex')
+        ) AS owner_version_set_hash,
+        COALESCE(owner_member_sources.owner_member_count, 0) AS owner_member_count,
+        COALESCE(owner_member_sources.owner_member_watermark_id, 0) AS owner_member_watermark_id,
+        COALESCE(
+            owner_member_sources.owner_member_set_hash,
+            encode(sha256(convert_to('', 'UTF8')), 'hex')
+        ) AS owner_member_set_hash,
+        COALESCE(event_sources.event_count, 0) AS event_count,
+        COALESCE(event_sources.event_watermark_id, 0) AS event_watermark_id,
+        COALESCE(
+            event_sources.event_set_hash,
+            encode(sha256(convert_to('', 'UTF8')), 'hex')
+        ) AS event_set_hash,
+        COALESCE(ledger_sources.unprovable_legacy_count, 0) AS unprovable_legacy_count,
+        COALESCE(ledger_sources.backfill_ledger_watermark_id, 0) AS backfill_ledger_watermark_id,
+        COALESCE(
+            ledger_sources.backfill_ledger_set_hash,
+            encode(sha256(convert_to('', 'UTF8')), 'hex')
+        ) AS backfill_ledger_set_hash
+    FROM organizations
+    CROSS JOIN boundary
+    LEFT JOIN legacy_sources ON legacy_sources.organization_id = organizations.id
+    LEFT JOIN owner_sources ON owner_sources.organization_id = organizations.id
+    LEFT JOIN owner_member_sources ON owner_member_sources.organization_id = organizations.id
+    LEFT JOIN event_sources ON event_sources.organization_id = organizations.id
+    LEFT JOIN ledger_sources ON ledger_sources.organization_id = organizations.id
+)
+INSERT INTO production_acceptance_history_checkpoints (
+    organization_id,
+    completed_at,
+    excluded_legacy_act_count,
+    performance_act_watermark_id,
+    legacy_act_set_hash,
+    owner_version_count,
+    owner_version_watermark_id,
+    owner_version_set_hash,
+    owner_member_count,
+    owner_member_watermark_id,
+    owner_member_set_hash,
+    event_count,
+    event_watermark_id,
+    event_set_hash,
+    unprovable_legacy_count,
+    backfill_ledger_watermark_id,
+    backfill_ledger_set_hash,
+    source_hash,
+    created_at,
+    updated_at
+)
+SELECT
+    organization_id,
+    completed_at,
+    excluded_legacy_act_count,
+    performance_act_watermark_id,
+    legacy_act_set_hash,
+    owner_version_count,
+    owner_version_watermark_id,
+    owner_version_set_hash,
+    owner_member_count,
+    owner_member_watermark_id,
+    owner_member_set_hash,
+    event_count,
+    event_watermark_id,
+    event_set_hash,
+    unprovable_legacy_count,
+    backfill_ledger_watermark_id,
+    backfill_ledger_set_hash,
+    encode(sha256(convert_to(jsonb_build_object(
+        'organization_id', organization_id,
+        'completed_at', to_char(
+            completed_at AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+        ),
+        'excluded_legacy_act_count', excluded_legacy_act_count,
+        'performance_act_watermark_id', performance_act_watermark_id,
+        'legacy_act_set_hash', legacy_act_set_hash,
+        'owner_version_count', owner_version_count,
+        'owner_version_watermark_id', owner_version_watermark_id,
+        'owner_version_set_hash', owner_version_set_hash,
+        'owner_member_count', owner_member_count,
+        'owner_member_watermark_id', owner_member_watermark_id,
+        'owner_member_set_hash', owner_member_set_hash,
+        'event_count', event_count,
+        'event_watermark_id', event_watermark_id,
+        'event_set_hash', event_set_hash,
+        'unprovable_legacy_count', unprovable_legacy_count,
+        'backfill_ledger_watermark_id', backfill_ledger_watermark_id,
+        'backfill_ledger_set_hash', backfill_ledger_set_hash
+    )::text, 'UTF8')), 'hex'),
+    completed_at,
+    completed_at
+FROM checkpoint_counts
+SQL);
+
+            DB::unprepared(<<<'SQL'
+CREATE OR REPLACE FUNCTION production_acceptance_owner_member_scope_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    owner_organization_id bigint;
+    owner_project_id bigint;
+    owner_performance_act_id bigint;
+BEGIN
+    SELECT organization_id, project_id, performance_act_id
+    INTO owner_organization_id, owner_project_id, owner_performance_act_id
+    FROM production_acceptance_owner_versions
+    WHERE id = NEW.owner_version_id;
+
+    IF NOT FOUND
+        OR NEW.organization_id IS DISTINCT FROM owner_organization_id
+        OR NEW.project_id IS DISTINCT FROM owner_project_id
+        OR NEW.performance_act_id IS DISTINCT FROM owner_performance_act_id
+    THEN
+        RAISE EXCEPTION 'production_acceptance_owner_member_scope_mismatch'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS production_acceptance_owner_members_scope_guard
+ON production_acceptance_owner_members;
+CREATE TRIGGER production_acceptance_owner_members_scope_guard
+BEFORE INSERT ON production_acceptance_owner_members
+FOR EACH ROW EXECUTE FUNCTION production_acceptance_owner_member_scope_guard();
+
+CREATE OR REPLACE FUNCTION most_seed_production_acceptance_history_checkpoint_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    checkpoint_at timestamptz(6) := clock_timestamp()::timestamptz(6);
+    empty_set_hash char(64) := encode(sha256(convert_to('', 'UTF8')), 'hex');
+    checkpoint_hash char(64);
+BEGIN
+    checkpoint_hash := encode(sha256(convert_to(jsonb_build_object(
+        'organization_id', NEW.id,
+        'completed_at', to_char(
+            checkpoint_at AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+        ),
+        'excluded_legacy_act_count', 0,
+        'performance_act_watermark_id', 0,
+        'legacy_act_set_hash', empty_set_hash,
+        'owner_version_count', 0,
+        'owner_version_watermark_id', 0,
+        'owner_version_set_hash', empty_set_hash,
+        'owner_member_count', 0,
+        'owner_member_watermark_id', 0,
+        'owner_member_set_hash', empty_set_hash,
+        'event_count', 0,
+        'event_watermark_id', 0,
+        'event_set_hash', empty_set_hash,
+        'unprovable_legacy_count', 0,
+        'backfill_ledger_watermark_id', 0,
+        'backfill_ledger_set_hash', empty_set_hash
+    )::text, 'UTF8')), 'hex');
+
+    INSERT INTO production_acceptance_history_checkpoints (
+        organization_id,
+        completed_at,
+        excluded_legacy_act_count,
+        performance_act_watermark_id,
+        legacy_act_set_hash,
+        owner_version_count,
+        owner_version_watermark_id,
+        owner_version_set_hash,
+        owner_member_count,
+        owner_member_watermark_id,
+        owner_member_set_hash,
+        event_count,
+        event_watermark_id,
+        event_set_hash,
+        unprovable_legacy_count,
+        backfill_ledger_watermark_id,
+        backfill_ledger_set_hash,
+        source_hash,
+        created_at,
+        updated_at
+    ) VALUES (
+        NEW.id,
+        checkpoint_at,
+        0,
+        0,
+        empty_set_hash,
+        0,
+        0,
+        empty_set_hash,
+        0,
+        0,
+        empty_set_hash,
+        0,
+        0,
+        empty_set_hash,
+        0,
+        0,
+        empty_set_hash,
+        checkpoint_hash,
+        checkpoint_at,
+        checkpoint_at
+    )
+    ON CONFLICT (organization_id) DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS most_seed_production_acceptance_history_checkpoint_v1 ON organizations;
+CREATE TRIGGER most_seed_production_acceptance_history_checkpoint_v1
+AFTER INSERT ON organizations
+FOR EACH ROW EXECUTE FUNCTION most_seed_production_acceptance_history_checkpoint_v1();
+
+CREATE TRIGGER production_acceptance_history_checkpoints_append_only
+BEFORE UPDATE OR DELETE ON production_acceptance_history_checkpoints
+FOR EACH ROW EXECUTE FUNCTION production_acceptance_event_immutable_guard();
+SQL);
+
+            $organizationCount = DB::table('organizations')->count();
+            $checkpoints = DB::table('production_acceptance_history_checkpoints')
+                ->orderBy('organization_id')
+                ->get();
+            if ($checkpoints->count() !== $organizationCount) {
+                throw new RuntimeException('Production acceptance checkpoint organization coverage mismatch.');
+            }
+            $identities = [];
+            foreach ($checkpoints as $checkpoint) {
+                foreach ([
+                    'backfill_ledger_set_hash',
+                    'event_set_hash',
+                    'legacy_act_set_hash',
+                    'owner_member_set_hash',
+                    'owner_version_set_hash',
+                    'source_hash',
+                ] as $hashField) {
+                    if (! is_string($checkpoint->{$hashField})
+                        || preg_match('/^[a-f0-9]{64}$/D', $checkpoint->{$hashField}) !== 1) {
+                        throw new RuntimeException('Production acceptance checkpoint hash is invalid.');
+                    }
+                }
+                $identities[] = (int) $checkpoint->organization_id.':'.$checkpoint->source_hash;
+            }
+
+            return [
+                'checkpoint_count' => $checkpoints->count(),
+                'content_hash' => hash('sha256', implode('|', $identities)),
+                'event_count' => (int) $checkpoints->sum('event_count'),
+                'excluded_legacy_act_count' => (int) $checkpoints->sum('excluded_legacy_act_count'),
+                'owner_version_count' => (int) $checkpoints->sum('owner_version_count'),
+                'owner_member_count' => (int) $checkpoints->sum('owner_member_count'),
+                'unprovable_legacy_count' => (int) $checkpoints->sum('unprovable_legacy_count'),
+            ];
+        });
+
+        DB::afterCommit(static function () use ($evidence): void {
+            Log::info('report_accepted_production_history_boundary_completed', $evidence);
+        });
+    }
+
+    public function down(): void
+    {
+        throw new RuntimeException(
+            'Production acceptance history checkpoints are irreversible reporting evidence.',
+        );
+    }
+};

--- a/tests/Architecture/Reporting/AcceptedProductionHistoryBoundaryContractTest.php
+++ b/tests/Architecture/Reporting/AcceptedProductionHistoryBoundaryContractTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AcceptedProductionHistoryBoundaryContractTest extends TestCase
+{
+    #[Test]
+    public function migration_creates_a_truthful_boundary_without_reconstructing_legacy_events(): void
+    {
+        $migration = file_get_contents(
+            dirname(__DIR__, 3)
+            .'/database/migrations/2026_08_06_000150_create_production_acceptance_history_checkpoints.php',
+        );
+
+        self::assertIsString($migration);
+        self::assertStringContainsString(
+            "Schema::create('production_acceptance_history_checkpoints'",
+            $migration,
+        );
+        self::assertStringContainsString(
+            'LOCK TABLE organizations, contracts, contract_performance_acts, '
+            .'production_acceptance_owner_versions, production_acceptance_owner_members, '
+            .'production_acceptance_events, production_acceptance_backfill_ledger',
+            $migration,
+        );
+        self::assertStringContainsString('clock_timestamp()::timestamptz(6)', $migration);
+        self::assertStringContainsString('excluded_legacy_act_count', $migration);
+        self::assertStringContainsString('performance_act_watermark_id', $migration);
+        self::assertStringContainsString('owner_version_watermark_id', $migration);
+        self::assertStringContainsString('owner_member_watermark_id', $migration);
+        self::assertStringContainsString('event_watermark_id', $migration);
+        self::assertStringContainsString('backfill_ledger_watermark_id', $migration);
+        self::assertStringContainsString('legacy_act_set_hash', $migration);
+        self::assertStringContainsString('owner_version_set_hash', $migration);
+        self::assertStringContainsString('owner_member_set_hash', $migration);
+        self::assertStringContainsString('event_set_hash', $migration);
+        self::assertStringContainsString('backfill_ledger_set_hash', $migration);
+        self::assertStringContainsString('owner_version_count', $migration);
+        self::assertStringContainsString('owner_member_count', $migration);
+        self::assertStringContainsString('event_count', $migration);
+        self::assertStringContainsString(
+            'production_acceptance_history_checkpoints_append_only',
+            $migration,
+        );
+        self::assertStringContainsString(
+            'production_acceptance_owner_members_scope_guard',
+            $migration,
+        );
+        self::assertStringContainsString('owner member scope drift detected', $migration);
+        self::assertStringContainsString(
+            'most_seed_production_acceptance_history_checkpoint_v1',
+            $migration,
+        );
+        self::assertStringContainsString(
+            'report_accepted_production_history_boundary_completed',
+            $migration,
+        );
+        self::assertStringContainsString('$evidence = DB::transaction', $migration);
+        self::assertStringContainsString('DB::afterCommit', $migration);
+        self::assertGreaterThan(
+            strpos($migration, 'DB::afterCommit'),
+            strpos($migration, "Log::info('report_accepted_production_history_boundary_completed'"),
+        );
+        self::assertStringContainsString('checkpoint organization coverage mismatch', $migration);
+        self::assertStringNotContainsString('INSERT INTO production_acceptance_events', $migration);
+        self::assertStringNotContainsString('INSERT INTO production_acceptance_owner_versions', $migration);
+        self::assertStringNotContainsString('AcceptedProductionBackfill', $migration);
+        self::assertStringNotContainsString('ProductionAcceptanceEventRecorder', $migration);
+    }
+
+    #[Test]
+    public function checkpoint_model_is_append_only_by_convention(): void
+    {
+        $model = file_get_contents(
+            dirname(__DIR__, 3)
+            .'/app/Services/CompletedWork/Reporting/AcceptedProduction/Models/'
+            .'ProductionAcceptanceHistoryCheckpoint.php',
+        );
+
+        self::assertIsString($model);
+        self::assertStringContainsString(
+            "protected \$table = 'production_acceptance_history_checkpoints';",
+            $model,
+        );
+        self::assertStringContainsString('public $timestamps = false;', $model);
+        self::assertStringContainsString("'completed_at' => 'immutable_datetime'", $model);
+        self::assertStringContainsString(
+            'production_acceptance_history_checkpoint_immutable',
+            $model,
+        );
+    }
+}

--- a/tests/Feature/Reporting/Waves23/AcceptedProductionMaterializationPostgresTest.php
+++ b/tests/Feature/Reporting/Waves23/AcceptedProductionMaterializationPostgresTest.php
@@ -163,6 +163,229 @@ final class AcceptedProductionMaterializationPostgresTest extends TestCase
         );
     }
 
+    public function test_history_checkpoint_is_created_for_new_organization_and_is_append_only(): void
+    {
+        $organization = Organization::factory()->create();
+        $checkpoint = DB::table('production_acceptance_history_checkpoints')
+            ->where('organization_id', $organization->getKey())
+            ->first();
+
+        self::assertNotNull($checkpoint);
+        self::assertSame(0, (int) $checkpoint->excluded_legacy_act_count);
+        self::assertSame(0, (int) $checkpoint->performance_act_watermark_id);
+        self::assertSame(0, (int) $checkpoint->owner_version_count);
+        self::assertSame(0, (int) $checkpoint->owner_version_watermark_id);
+        self::assertSame(0, (int) $checkpoint->owner_member_count);
+        self::assertSame(0, (int) $checkpoint->owner_member_watermark_id);
+        self::assertSame(0, (int) $checkpoint->event_count);
+        self::assertSame(0, (int) $checkpoint->event_watermark_id);
+        self::assertSame(0, (int) $checkpoint->backfill_ledger_watermark_id);
+        $emptySetHash = hash('sha256', '');
+        self::assertSame($emptySetHash, (string) $checkpoint->legacy_act_set_hash);
+        self::assertSame($emptySetHash, (string) $checkpoint->owner_version_set_hash);
+        self::assertSame($emptySetHash, (string) $checkpoint->owner_member_set_hash);
+        self::assertSame($emptySetHash, (string) $checkpoint->event_set_hash);
+        self::assertSame($emptySetHash, (string) $checkpoint->backfill_ledger_set_hash);
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/D', (string) $checkpoint->source_hash);
+
+        $this->assertMutationRejected(
+            static fn (): int => DB::table('production_acceptance_history_checkpoints')
+                ->where('organization_id', $organization->getKey())
+                ->update(['excluded_legacy_act_count' => 1]),
+        );
+        $this->assertMutationRejected(
+            static fn (): int => DB::table('production_acceptance_history_checkpoints')
+                ->where('organization_id', $organization->getKey())
+                ->delete(),
+        );
+    }
+
+    public function test_history_checkpoint_captures_existing_source_sets_and_separates_late_backdated_rows(): void
+    {
+        [, $actId, $lineId, $projectId, $organizationId] = $this->insertLifecycleOwner(
+            approvalDate: '2026-07-20',
+            rejectedAt: null,
+            signedAt: '2099-08-02T12:00:00Z',
+        );
+        [$ownerId, $ownerMemberId] = $this->insertOwnerVersion(
+            $organizationId,
+            $projectId,
+            'accepted',
+            '2026-07-20T00:00:00Z',
+            1,
+            $actId,
+            $lineId,
+        );
+        $eventId = $this->insertEvent(
+            organizationId: $organizationId,
+            projectId: $projectId,
+            eventType: 'accepted',
+            quantity: '1.000',
+            recognizedAt: '2026-07-20T00:00:00Z',
+            performanceActId: $actId,
+            sourceLineId: $lineId,
+        );
+        $ledgerId = (int) DB::table('production_acceptance_backfill_ledger')->insertGetId([
+            'organization_id' => $organizationId,
+            'project_id' => $projectId,
+            'performance_act_id' => $actId,
+            'recognized_at' => '2026-07-20T00:00:00Z',
+            'status' => 'unprovable',
+            'reason' => 'historical_membership_unprovable',
+            'source_hash' => hash('sha256', 'checkpoint-ledger-'.$organizationId),
+            'recorded_at' => '2026-08-01T00:00:00Z',
+        ]);
+
+        $this->rerunHistoryCheckpointMigration();
+
+        $checkpoint = DB::table('production_acceptance_history_checkpoints')
+            ->where('organization_id', $organizationId)
+            ->first();
+
+        self::assertNotNull($checkpoint);
+        self::assertSame(1, (int) $checkpoint->excluded_legacy_act_count);
+        self::assertSame($actId, (int) $checkpoint->performance_act_watermark_id);
+        self::assertSame(1, (int) $checkpoint->owner_version_count);
+        self::assertSame($ownerId, (int) $checkpoint->owner_version_watermark_id);
+        self::assertSame(1, (int) $checkpoint->owner_member_count);
+        self::assertSame($ownerMemberId, (int) $checkpoint->owner_member_watermark_id);
+        self::assertSame(1, (int) $checkpoint->event_count);
+        self::assertSame($eventId, (int) $checkpoint->event_watermark_id);
+        self::assertSame(1, (int) $checkpoint->unprovable_legacy_count);
+        self::assertSame($ledgerId, (int) $checkpoint->backfill_ledger_watermark_id);
+        self::assertSame(
+            (string) $checkpoint->event_set_hash,
+            $this->acceptanceEventSetHash($organizationId),
+        );
+        self::assertSame(
+            (string) $checkpoint->owner_member_set_hash,
+            $this->acceptanceOwnerMemberSetHash($organizationId),
+        );
+        self::assertSame(
+            (string) $checkpoint->source_hash,
+            (string) DB::table('production_acceptance_history_checkpoints')
+                ->where('organization_id', $organizationId)
+                ->selectRaw(<<<'SQL'
+encode(sha256(convert_to(jsonb_build_object(
+    'organization_id', organization_id,
+    'completed_at', to_char(completed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+    'excluded_legacy_act_count', excluded_legacy_act_count,
+    'performance_act_watermark_id', performance_act_watermark_id,
+    'legacy_act_set_hash', legacy_act_set_hash,
+    'owner_version_count', owner_version_count,
+    'owner_version_watermark_id', owner_version_watermark_id,
+    'owner_version_set_hash', owner_version_set_hash,
+    'owner_member_count', owner_member_count,
+    'owner_member_watermark_id', owner_member_watermark_id,
+    'owner_member_set_hash', owner_member_set_hash,
+    'event_count', event_count,
+    'event_watermark_id', event_watermark_id,
+    'event_set_hash', event_set_hash,
+    'unprovable_legacy_count', unprovable_legacy_count,
+    'backfill_ledger_watermark_id', backfill_ledger_watermark_id,
+    'backfill_ledger_set_hash', backfill_ledger_set_hash
+)::text, 'UTF8')), 'hex') AS calculated_hash
+SQL)
+                ->value('calculated_hash'),
+        );
+
+        $lateEventId = $this->insertEvent(
+            organizationId: $organizationId,
+            projectId: $projectId,
+            eventType: 'accepted',
+            quantity: '2.000',
+            recognizedAt: '2026-07-01T00:00:00Z',
+            performanceActId: $actId,
+            sourceLineId: $lineId + 1,
+        );
+        self::assertGreaterThan((int) $checkpoint->event_watermark_id, $lateEventId);
+        self::assertLessThan(
+            new DateTimeImmutable((string) $checkpoint->completed_at),
+            new DateTimeImmutable('2026-07-01T00:00:00Z'),
+        );
+        self::assertNotSame(
+            (string) $checkpoint->event_set_hash,
+            $this->acceptanceEventSetHash($organizationId),
+        );
+        $lateOwnerMemberId = (int) DB::table('production_acceptance_owner_members')->insertGetId([
+            'owner_version_id' => $ownerId,
+            'organization_id' => $organizationId,
+            'project_id' => $projectId,
+            'performance_act_id' => $actId,
+            'source_line_type' => 'performance_act_line',
+            'source_line_id' => $lineId + 1,
+            'work_id' => 78,
+            'contractor_id' => 19,
+            'unit_code' => 'm3',
+            'zone' => 'B',
+        ]);
+        self::assertGreaterThan((int) $checkpoint->owner_member_watermark_id, $lateOwnerMemberId);
+        self::assertNotSame(
+            (string) $checkpoint->owner_member_set_hash,
+            $this->acceptanceOwnerMemberSetHash($organizationId),
+        );
+        $foreignOrganization = Organization::factory()->create();
+        $this->assertQueryRejected(
+            static fn (): int => DB::table('production_acceptance_owner_members')->insertGetId([
+                'owner_version_id' => $ownerId,
+                'organization_id' => $foreignOrganization->getKey(),
+                'project_id' => $projectId,
+                'performance_act_id' => $actId,
+                'source_line_type' => 'performance_act_line',
+                'source_line_id' => $lineId + 2,
+                'work_id' => 79,
+                'contractor_id' => 19,
+                'unit_code' => 'm3',
+                'zone' => 'C',
+            ]),
+            '23514',
+        );
+        $this->assertMutationRejected(
+            static fn (): int => DB::table('production_acceptance_history_checkpoints')
+                ->where('organization_id', $organizationId)
+                ->delete(),
+        );
+    }
+
+    public function test_history_checkpoint_rejects_preexisting_owner_member_scope_drift(): void
+    {
+        [, $actId, $lineId, $projectId, $organizationId] = $this->insertLifecycleOwner(
+            approvalDate: '2026-07-20',
+            rejectedAt: null,
+        );
+        [$ownerId] = $this->insertOwnerVersion(
+            $organizationId,
+            $projectId,
+            'accepted',
+            '2026-07-20T00:00:00Z',
+            1,
+            $actId,
+            $lineId,
+        );
+        $foreignOrganization = Organization::factory()->create();
+        DB::unprepared(
+            'DROP TRIGGER IF EXISTS production_acceptance_owner_members_scope_guard '
+            .'ON production_acceptance_owner_members',
+        );
+        DB::unprepared('DROP FUNCTION IF EXISTS production_acceptance_owner_member_scope_guard()');
+        DB::table('production_acceptance_owner_members')->insert([
+            'owner_version_id' => $ownerId,
+            'organization_id' => $foreignOrganization->getKey(),
+            'project_id' => $projectId,
+            'performance_act_id' => $actId,
+            'source_line_type' => 'performance_act_line',
+            'source_line_id' => $lineId + 1,
+            'work_id' => 78,
+            'contractor_id' => 19,
+            'unit_code' => 'm3',
+            'zone' => 'B',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('owner member scope drift detected');
+        $this->rerunHistoryCheckpointMigration();
+    }
+
     public function test_approval_after_as_of_is_not_part_of_candidate_universe(): void
     {
         [$scope] = $this->insertLifecycleOwner(
@@ -365,10 +588,12 @@ final class AcceptedProductionMaterializationPostgresTest extends TestCase
         string $eventType,
         string $effectiveAt,
         int $version,
+        int $performanceActId = 51,
+        int $sourceLineId = 91,
     ): array {
         $member = [
             'contractor_id' => 19,
-            'source_line_id' => 91,
+            'source_line_id' => $sourceLineId,
             'source_line_type' => 'performance_act_line',
             'unit_code' => 'm3',
             'work_id' => 77,
@@ -378,7 +603,7 @@ final class AcceptedProductionMaterializationPostgresTest extends TestCase
             'organization_id' => $organizationId,
             'project_id' => $projectId,
             'contract_id' => 21,
-            'performance_act_id' => 51,
+            'performance_act_id' => $performanceActId,
             'version' => $version,
             'event_type' => $eventType,
             'effective_at' => $effectiveAt,
@@ -401,7 +626,7 @@ final class AcceptedProductionMaterializationPostgresTest extends TestCase
             'owner_version_id' => $ownerId,
             'organization_id' => $organizationId,
             'project_id' => $projectId,
-            'performance_act_id' => 51,
+            'performance_act_id' => $performanceActId,
             'source_line_type' => $member['source_line_type'],
             'source_line_id' => $member['source_line_id'],
             'work_id' => $member['work_id'],
@@ -415,11 +640,81 @@ final class AcceptedProductionMaterializationPostgresTest extends TestCase
 
     private function assertMutationRejected(callable $mutation): void
     {
+        $this->assertQueryRejected($mutation, '55000');
+    }
+
+    private function assertQueryRejected(callable $mutation, string $expectedCode): void
+    {
         try {
             DB::transaction($mutation);
-            self::fail('Expected append-only owner history mutation to be rejected.');
+            self::fail('Expected production acceptance source mutation to be rejected.');
         } catch (QueryException $exception) {
-            self::assertSame('55000', $exception->getCode());
+            self::assertSame($expectedCode, $exception->getCode());
         }
+    }
+
+    private function rerunHistoryCheckpointMigration(): void
+    {
+        DB::unprepared(
+            'DROP TRIGGER IF EXISTS most_seed_production_acceptance_history_checkpoint_v1 ON organizations',
+        );
+        DB::unprepared('DROP FUNCTION IF EXISTS most_seed_production_acceptance_history_checkpoint_v1()');
+        DB::unprepared(
+            'DROP TRIGGER IF EXISTS production_acceptance_owner_members_scope_guard '
+            .'ON production_acceptance_owner_members',
+        );
+        DB::unprepared('DROP FUNCTION IF EXISTS production_acceptance_owner_member_scope_guard()');
+        DB::unprepared('DROP TABLE production_acceptance_history_checkpoints');
+
+        $migration = require dirname(__DIR__, 4)
+            .'/database/migrations/2026_08_06_000150_create_production_acceptance_history_checkpoints.php';
+        $migration->up();
+    }
+
+    private function acceptanceEventSetHash(int $organizationId): string
+    {
+        return (string) DB::table('production_acceptance_events')
+            ->where('organization_id', $organizationId)
+            ->selectRaw(<<<'SQL'
+encode(sha256(convert_to(COALESCE(string_agg(
+    encode(sha256(convert_to(jsonb_build_array(id, source_hash)::text, 'UTF8')), 'hex'),
+    '' ORDER BY id
+), ''), 'UTF8')), 'hex') AS set_hash
+SQL)
+            ->value('set_hash');
+    }
+
+    private function acceptanceOwnerMemberSetHash(int $organizationId): string
+    {
+        return (string) DB::table('production_acceptance_owner_members as member')
+            ->join(
+                'production_acceptance_owner_versions as owner',
+                'owner.id',
+                '=',
+                'member.owner_version_id',
+            )
+            ->where('owner.organization_id', $organizationId)
+            ->selectRaw(<<<'SQL'
+encode(sha256(convert_to(COALESCE(string_agg(
+    encode(sha256(convert_to(jsonb_build_object(
+        'id', member.id,
+        'owner_version_id', member.owner_version_id,
+        'owner_organization_id', owner.organization_id,
+        'owner_project_id', owner.project_id,
+        'owner_performance_act_id', owner.performance_act_id,
+        'member_organization_id', member.organization_id,
+        'member_project_id', member.project_id,
+        'member_performance_act_id', member.performance_act_id,
+        'source_line_type', member.source_line_type,
+        'source_line_id', member.source_line_id,
+        'work_id', member.work_id,
+        'contractor_id', member.contractor_id,
+        'unit_code', member.unit_code,
+        'zone', member.zone
+    )::text, 'UTF8')), 'hex'),
+    '' ORDER BY member.id
+), ''), 'UTF8')), 'hex') AS set_hash
+SQL)
+            ->value('set_hash');
     }
 }


### PR DESCRIPTION
## Что сделано
- добавлен необратимый append-only checkpoint границы истории R08 по каждой организации
- зафиксированы точные source-set hashes и ID watermarks актов, owner versions, owner members, acceptance events и backfill ledger
- раннее согласование учитывается независимо от более поздней подписи
- tenant/project/act drift owner members отклоняется до capture и запрещён для новых вставок
- completion marker регистрируется через afterCommit

## Проверки
- php -l: 4 изменённых PHP-файла
- git diff --check
- независимое review: CLEAN
- добавлены architecture contract tests и PostgreSQL regression scenarios для non-zero seed, late backdated rows, append-only и scope drift

Локально PHPUnit/Larastan не запускались: vendor отсутствует; миграции и DB-команды локально не выполнялись согласно ограничениям проекта. Исполняемые PostgreSQL-проверки должен выполнить CI.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a new Eloquent model 'ProductionAcceptanceHistoryCheckpoint' with immutable behavior enforced via booted events.</li>
<li>Created a database migration to add the 'production_acceptance_history_checkpoints' table with various watermark and count fields.</li>
<li>Added architecture and feature tests to verify the new reporting history contract and materialization logic.</li>
</ul></div>