### PR TITLE
fix: сохранена точность принятой выработки

### DIFF
--- a/database/migrations/2026_08_06_000250_widen_production_acceptance_quantity_precision.php
+++ b/database/migrations/2026_08_06_000250_widen_production_acceptance_quantity_precision.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+ALTER TABLE production_acceptance_events
+    ALTER COLUMN accepted_quantity_delta TYPE NUMERIC(20, 4),
+    ALTER COLUMN planned_quantity TYPE NUMERIC(20, 4),
+    ALTER COLUMN reported_quantity TYPE NUMERIC(20, 4)
+SQL);
+    }
+
+    public function down(): void
+    {
+        $hasFourDecimalValues = DB::table('production_acceptance_events')
+            ->whereRaw('accepted_quantity_delta <> ROUND(accepted_quantity_delta, 3)')
+            ->orWhereRaw('planned_quantity <> ROUND(planned_quantity, 3)')
+            ->orWhereRaw('reported_quantity <> ROUND(reported_quantity, 3)')
+            ->exists();
+
+        if ($hasFourDecimalValues) {
+            throw new LogicException('production_acceptance_quantity_precision_rollback_unsafe');
+        }
+
+        DB::statement(<<<'SQL'
+ALTER TABLE production_acceptance_events
+    ALTER COLUMN accepted_quantity_delta TYPE NUMERIC(20, 3),
+    ALTER COLUMN planned_quantity TYPE NUMERIC(20, 3),
+    ALTER COLUMN reported_quantity TYPE NUMERIC(20, 3)
+SQL);
+    }
+};

--- a/tests/Architecture/Reporting/AcceptedProductionQuantityPrecisionMigrationTest.php
+++ b/tests/Architecture/Reporting/AcceptedProductionQuantityPrecisionMigrationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AcceptedProductionQuantityPrecisionMigrationTest extends TestCase
+{
+    #[Test]
+    public function event_quantities_preserve_the_four_decimal_source_contract(): void
+    {
+        $migration = file_get_contents(
+            dirname(__DIR__, 3)
+            .'/database/migrations/2026_08_06_000250_widen_production_acceptance_quantity_precision.php',
+        );
+
+        self::assertIsString($migration);
+        self::assertSame(3, substr_count($migration, 'TYPE NUMERIC(20, 4)'));
+        self::assertStringContainsString('accepted_quantity_delta', $migration);
+        self::assertStringContainsString('planned_quantity', $migration);
+        self::assertStringContainsString('reported_quantity', $migration);
+        self::assertStringContainsString(
+            'production_acceptance_quantity_precision_rollback_unsafe',
+            $migration,
+        );
+    }
+}


### PR DESCRIPTION
## Что изменено
- quantity-поля immutable событий принятой выработки расширены с 3 до 4 знаков после запятой
- rollback запрещён при наличии значений, которые потеряли бы точность
- добавлен архитектурный контракт миграции

## Проверки
- php -l migration/test
- git diff --cached --check
- независимое review: CLEAN
- PHPUnit не запускался локально: vendor отсутствует; дальнейшее доказательство — CI/deploy

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Created a new database migration to increase the precision of quantity columns in the 'production_acceptance_events' table from NUMERIC(20, 3) to NUMERIC(20, 4).</li>
<li>Implemented a safety check in the migration's down() method to prevent rollback if data with four decimal places exists.</li>
<li>Added a new architecture test to verify the migration correctly updates the column types and includes the safety rollback check.</li>
</ul></div>