### PR TITLE
fix: защищена чувствительная отчётность

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Access/ReportDefinitionVisibilityResolver.php
+++ b/app/BusinessModules/Core/Reporting/Application/Access/ReportDefinitionVisibilityResolver.php
@@ -98,6 +98,18 @@ final readonly class ReportDefinitionVisibilityResolver
             $exportFormat,
             $permissionGranted,
         );
+        $canViewSensitive = $canView
+            && $definition->permissionPolicy->sensitivePermissions !== []
+            && $this->allGranted(
+                $definition->permissionPolicy->sensitivePermissions,
+                $permissionGranted,
+            );
+        $canViewAudit = $canView
+            && $definition->permissionPolicy->auditPermissions !== []
+            && $this->allGranted(
+                $definition->permissionPolicy->auditPermissions,
+                $permissionGranted,
+            );
 
         return new ReportVisibility(
             $canView,
@@ -105,8 +117,8 @@ final readonly class ReportDefinitionVisibilityResolver
             $canExport,
             $canExport,
             false,
-            false,
-            false,
+            $canViewSensitive,
+            $canViewAudit,
         );
     }
 
@@ -128,22 +140,49 @@ final readonly class ReportDefinitionVisibilityResolver
                 default => null,
             };
 
-            return $permission !== null
-                && in_array($permission, $definition->permissionPolicy->exportPermissions, true)
-                && $permissionGranted($permission);
+            if ($permission !== null
+                && in_array($permission, $definition->permissionPolicy->exportPermissions, true)) {
+                return $permissionGranted($permission);
+            }
+
+            return $definition->permissionPolicy->exportPermissions !== []
+                && $this->allGranted(
+                    $definition->permissionPolicy->exportPermissions,
+                    $permissionGranted,
+                );
         }
 
         if (in_array($operation, [ReportOperation::EXPORT, ReportOperation::DOWNLOAD], true)) {
             return false;
         }
 
-        foreach ($definition->permissionPolicy->exportPermissions as $permission) {
-            if ($permissionGranted($permission)) {
-                return true;
+        $exportPermissions = $definition->permissionPolicy->exportPermissions;
+        if ($exportPermissions === []) {
+            return false;
+        }
+
+        if ($this->usesFormatSpecificExportPermissions($exportPermissions)) {
+            foreach ($exportPermissions as $permission) {
+                if ($permissionGranted($permission)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $this->allGranted($exportPermissions, $permissionGranted);
+    }
+
+    private function usesFormatSpecificExportPermissions(array $permissions): bool
+    {
+        foreach ($permissions as $permission) {
+            if (! in_array($permission, ['act_reports.export.excel', 'act_reports.export.pdf'], true)) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /** @param Closure(string): bool $permissionGranted */

--- a/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/GetReportRowsHandler.php
+++ b/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/GetReportRowsHandler.php
@@ -49,7 +49,7 @@ final readonly class GetReportRowsHandler implements GetReportRowsAction
         $query = $this->runs->queryForRun($context, $runId);
         $this->assertIdentity($context, $runId, $run, $query, $snapshot);
         $binding = $this->binding($run, $query);
-        $current = $this->authorizeRows($context, $query, $snapshot);
+        $current = $this->authorizeRows($context, $query, $snapshot, $window);
         $providerContext = $this->contexts->fromCurrentAuthorization($current);
         $cursor = $window->cursor === null ? null : $this->cursors->decode(
             $window->cursor,
@@ -131,13 +131,16 @@ final readonly class GetReportRowsHandler implements GetReportRowsAction
         ReportExecutionContext $context,
         ReportQuery $query,
         ReportSnapshotRef $snapshot,
+        ReportRowsWindow $window,
     ): CurrentReportAuthorization {
         $authorization = $this->authorize($context, $query, $snapshot, ReportOperation::VIEW);
         $classification = $query->definition->outputClassification;
-        if ($classification->requiresSensitiveForRows()) {
+        if ($classification->requiresSensitiveForRows()
+            || $classification->requiresSensitiveForColumns([$window->sort->field])) {
             $authorization = $this->authorize($context, $query, $snapshot, ReportOperation::VIEW_SENSITIVE);
         }
-        if ($classification->requiresAuditForRows()) {
+        if ($classification->requiresAuditForRows()
+            || $classification->requiresAuditForColumns([$window->sort->field])) {
             $authorization = $this->authorize($context, $query, $snapshot, ReportOperation::VIEW_AUDIT);
         }
 

--- a/app/BusinessModules/Core/Reporting/Application/Execution/ReportRunCoordinator.php
+++ b/app/BusinessModules/Core/Reporting/Application/Execution/ReportRunCoordinator.php
@@ -24,6 +24,7 @@ final readonly class ReportRunCoordinator
         private ReportAccessService $access,
         private ReportRunStore $runs,
         private ReportExecutionClock $clock,
+        private ReportRunResponseRedactor $responseRedactor,
     ) {
     }
 
@@ -41,7 +42,12 @@ final readonly class ReportRunCoordinator
     {
         $run = $this->runs->get($context, $runId);
         $query = $this->runs->queryForRun($context, $runId);
-        $this->access->assertOperation($context, $query->definition, ReportOperation::VIEW, null);
+        $visibility = $this->access->assertOperation(
+            $context,
+            $query->definition,
+            ReportOperation::VIEW,
+            null,
+        );
         if ($query->definition->outputClassification->requiresSensitiveForSummary()) {
             $this->access->assertOperation($context, $query->definition, ReportOperation::VIEW_SENSITIVE, null);
         }
@@ -49,7 +55,11 @@ final readonly class ReportRunCoordinator
             $this->access->assertOperation($context, $query->definition, ReportOperation::VIEW_AUDIT, null);
         }
 
-        return $run;
+        return $this->responseRedactor->redact(
+            $run,
+            $query->definition->outputClassification,
+            $visibility,
+        );
     }
 
     public function retry(ReportExecutionContext $context, string $runId, IdempotencyKey $key): ReportRun

--- a/app/BusinessModules/Core/Reporting/Application/Execution/ReportRunResponseRedactor.php
+++ b/app/BusinessModules/Core/Reporting/Application/Execution/ReportRunResponseRedactor.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Application\Execution;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportOutputClassification;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportRun;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportVisibility;
+
+final readonly class ReportRunResponseRedactor
+{
+    public function redact(
+        ReportRun $run,
+        ReportOutputClassification $classification,
+        ReportVisibility $visibility,
+    ): ReportRun {
+        $protectedColumnIds = [
+            ...($visibility->canViewSensitive ? [] : $classification->sensitiveColumnIds),
+            ...($visibility->canViewAudit ? [] : $classification->auditColumnIds),
+        ];
+        if ($protectedColumnIds === []) {
+            return $run;
+        }
+
+        return $run->withTotals($this->redactArray($run->totals, $protectedColumnIds));
+    }
+
+    private function redactArray(array $value, array $protectedColumnIds): array
+    {
+        foreach ($value as $key => $item) {
+            if (is_string($key) && $this->isProtectedKey($key, $protectedColumnIds)) {
+                unset($value[$key]);
+                continue;
+            }
+
+            if (is_array($item)) {
+                $value[$key] = $this->redactArray($item, $protectedColumnIds);
+            }
+        }
+
+        return $value;
+    }
+
+    private function isProtectedKey(string $key, array $protectedColumnIds): bool
+    {
+        if (in_array($key, $protectedColumnIds, true)) {
+            return true;
+        }
+
+        return str_ends_with($key, '_minor')
+            && in_array(substr($key, 0, -6), $protectedColumnIds, true);
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportOutputClassification.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportOutputClassification.php
@@ -33,7 +33,7 @@ final readonly class ReportOutputClassification
 
     public function requiresAuditForRows(): bool
     {
-        return $this->auditColumnIds !== [] || $this->totalsAudit;
+        return $this->totalsAudit;
     }
 
     public function requiresSensitiveForColumns(array $columnIds): bool

--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportRun.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportRun.php
@@ -71,6 +71,36 @@ final readonly class ReportRun
         return [];
     }
 
+    public function withTotals(array $totals): self
+    {
+        return new self(
+            id: $this->id,
+            reportCode: $this->reportCode,
+            status: $this->status,
+            definitionHash: $this->definitionHash,
+            contractVersion: $this->contractVersion,
+            formulaVersion: $this->formulaVersion,
+            sourceSchemaVersion: $this->sourceSchemaVersion,
+            rendererVersion: $this->rendererVersion,
+            queryHash: $this->queryHash,
+            sourceHash: $this->sourceHash,
+            progress: $this->progress,
+            rowCount: $this->rowCount,
+            resultMetadata: $this->resultMetadata,
+            totals: $totals,
+            freshness: $this->freshness,
+            quality: $this->quality,
+            provenance: $this->provenance,
+            createdAt: $this->createdAt,
+            updatedAt: $this->updatedAt,
+            readyAt: $this->readyAt,
+            expiresAt: $this->expiresAt,
+            cancelRequestedAt: $this->cancelRequestedAt,
+            httpDisposition: $this->httpDisposition,
+            pollAfterMs: $this->pollAfterMs,
+        );
+    }
+
     private function assertReadyIdentity(): void
     {
         if ($this->sourceHash === null || $this->rowCount === null || $this->resultMetadata === null || $this->freshness === null || $this->quality === null || $this->provenance === null || $this->readyAt === null || $this->rowCount < 0 || $this->resultMetadata->rowCount !== $this->rowCount || $this->resultMetadata->snapshot->sourceHash->value !== $this->sourceHash->value || $this->provenance->sourceHash->value !== $this->sourceHash->value) {

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/ReportDefinitionFactory.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/ReportDefinitionFactory.php
@@ -32,6 +32,7 @@ final class ReportDefinitionFactory
         );
         $sourceModule = $this->optionalString($row, 'source_module')
             ?? ($coreAccessMode === ReportCoreAccessMode::REPORTING_WORKSPACE ? 'reports' : '');
+        $outputClassification = $this->outputClassification($row);
 
         return new ReportDefinition(
             code: $this->string($row, 'code'),
@@ -51,14 +52,7 @@ final class ReportDefinitionFactory
                 $this->list($permissions, 'audit'),
             ),
             snapshotClassification: ReportSnapshotClassification::OPERATIONAL,
-            outputClassification: new ReportOutputClassification(
-                ReportDataClassification::STANDARD,
-                [],
-                [],
-                false,
-                false,
-                false,
-            ),
+            outputClassification: $outputClassification,
             publicationReadiness: ReportPublicationReadiness::from($this->string($readiness, 'publication')),
             supportsSubscriptions: $this->boolean($capabilities, 'supports_subscriptions'),
             sourceModule: $sourceModule,
@@ -98,6 +92,44 @@ final class ReportDefinitionFactory
         }
 
         return $value;
+    }
+
+    private function outputClassification(array $row): ReportOutputClassification
+    {
+        if (! array_key_exists('output_classification', $row)) {
+            return new ReportOutputClassification(
+                ReportDataClassification::STANDARD,
+                [],
+                [],
+                false,
+                false,
+                false,
+            );
+        }
+
+        $classification = $this->map($row, 'output_classification');
+        $expectedKeys = [
+            'audit_column_ids',
+            'default_classification',
+            'provenance_audit',
+            'sensitive_column_ids',
+            'totals_audit',
+            'totals_sensitive',
+        ];
+        $actualKeys = array_keys($classification);
+        sort($actualKeys, SORT_STRING);
+        if ($actualKeys !== $expectedKeys) {
+            throw new InvalidArgumentException('report_manifest_definition_invalid');
+        }
+
+        return new ReportOutputClassification(
+            ReportDataClassification::from($this->string($classification, 'default_classification')),
+            $this->list($classification, 'sensitive_column_ids'),
+            $this->list($classification, 'audit_column_ids'),
+            $this->boolean($classification, 'totals_sensitive'),
+            $this->boolean($classification, 'totals_audit'),
+            $this->boolean($classification, 'provenance_audit'),
+        );
     }
 
     private function list(array $source, string $key): array

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/ProjectEvmControlBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/ProjectEvmControlBuiltinPublishedReport.php
@@ -76,6 +76,22 @@ final readonly class ProjectEvmControlBuiltinPublishedReport
                 'sensitive' => ['budgeting.wip_forecast.view_sensitive_costs'],
                 'audit' => [],
             ],
+            'output_classification' => [
+                'default_classification' => 'standard',
+                'sensitive_column_ids' => [
+                    'ac_minor',
+                    'approved_etc_minor',
+                    'cv_minor',
+                    'cpi',
+                    'eac_minor',
+                    'vac_minor',
+                    'tcpi',
+                ],
+                'audit_column_ids' => [],
+                'totals_sensitive' => false,
+                'totals_audit' => false,
+                'provenance_audit' => false,
+            ],
             'readiness' => [
                 'source' => 'ready',
                 'formula' => 'ready',

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/ProjectEvmControlCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/ProjectEvmControlCandidateContract.php
@@ -6,6 +6,7 @@ namespace App\BusinessModules\Features\Budgeting\Reporting\ProjectControl;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportDataClassification;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\DTO\ProjectControlAmounts;
@@ -98,7 +99,21 @@ final readonly class ProjectEvmControlCandidateContract
             || $definition->permissionPolicy->viewPermissions !== ['reports.project_control.view']
             || $definition->permissionPolicy->exportPermissions !== ['reports.project_control.export']
             || $definition->permissionPolicy->sensitivePermissions !== ['budgeting.wip_forecast.view_sensitive_costs']
-            || $definition->permissionPolicy->auditPermissions !== []) {
+            || $definition->permissionPolicy->auditPermissions !== []
+            || $definition->outputClassification->defaultClassification !== ReportDataClassification::STANDARD
+            || $definition->outputClassification->sensitiveColumnIds !== [
+                'ac_minor',
+                'approved_etc_minor',
+                'cpi',
+                'cv_minor',
+                'eac_minor',
+                'tcpi',
+                'vac_minor',
+            ]
+            || $definition->outputClassification->auditColumnIds !== []
+            || $definition->outputClassification->totalsSensitive
+            || $definition->outputClassification->totalsAudit
+            || $definition->outputClassification->provenanceAudit) {
             throw new InvalidArgumentException('project_evm_control_candidate_definition_invalid');
         }
     }

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/ProjectFinanceOutputRedactor.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/ProjectFinanceOutputRedactor.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance;
+
+final readonly class ProjectFinanceOutputRedactor
+{
+    private const SENSITIVE_TOTAL_FIELDS = [
+        'wip_completion_forecast' => [
+            'bac_minor',
+            'pv_minor',
+            'ev_minor',
+            'ac_minor',
+            'ctc_minor',
+            'eac_minor',
+            'forecast_variance_minor',
+        ],
+    ];
+
+    public function totals(string $reportCode, array $totals, bool $canViewSensitive): array
+    {
+        if ($canViewSensitive) {
+            return $totals;
+        }
+
+        $fields = self::SENSITIVE_TOTAL_FIELDS[$reportCode] ?? [];
+        if ($fields === []) {
+            return $totals;
+        }
+
+        return $this->redact($totals, $fields);
+    }
+
+    private function redact(array $value, array $fields): array
+    {
+        foreach ($value as $key => $item) {
+            if (is_string($key) && in_array($key, $fields, true)) {
+                unset($value[$key]);
+                continue;
+            }
+
+            if (is_array($item)) {
+                $value[$key] = $this->redact($item, $fields);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/ProjectFinanceQueryService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/ProjectFinanceQueryService.php
@@ -39,6 +39,7 @@ final readonly class ProjectFinanceQueryService implements ReportDrillDownProvid
     public function __construct(
         private FinanceSourceAccessPolicy $sourceAccess,
         private OwnerSnapshotIdentityGuard $identityGuard,
+        private ProjectFinanceOutputRedactor $outputRedactor,
     ) {}
 
     private const SORTS = [
@@ -140,7 +141,7 @@ final readonly class ProjectFinanceQueryService implements ReportDrillDownProvid
                 generatedAt: $snapshot->generatedAt,
                 staleAt: $snapshot->staleAt,
             ),
-            totals: is_array($record->totals) ? $record->totals : [],
+            totals: $this->visibleTotals($record, $context),
             freshness: $this->freshness($snapshot),
             quality: $quality,
             provenance: new ReportProvenance(
@@ -194,7 +195,7 @@ final readonly class ProjectFinanceQueryService implements ReportDrillDownProvid
 
         return new ReportPage(
             rows: $rows,
-            totals: is_array($record->totals) ? $record->totals : [],
+            totals: $this->visibleTotals($record, $context),
             freshness: $this->freshness($snapshot),
             quality: $this->quality($record),
             nextCursor: null,
@@ -338,6 +339,15 @@ final readonly class ProjectFinanceQueryService implements ReportDrillDownProvid
             ],
             default => throw new DomainException('report_code_invalid'),
         };
+    }
+
+    private function visibleTotals(ProjectFinanceSnapshot $snapshot, ReportExecutionContext $context): array
+    {
+        return $this->outputRedactor->totals(
+            (string) $snapshot->report_code,
+            is_array($snapshot->totals) ? $snapshot->totals : [],
+            $context->visibility->canViewSensitive,
+        );
     }
 
     private function quality(ProjectFinanceSnapshot $snapshot): ReportQuality

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastBuiltinPublishedReport.php
@@ -76,6 +76,23 @@ final readonly class WipCompletionForecastBuiltinPublishedReport
                 'sensitive' => ['budgeting.wip_forecast.view_sensitive_costs'],
                 'audit' => ['budgeting.wip_forecast.view_audit'],
             ],
+            'output_classification' => [
+                'default_classification' => 'standard',
+                'sensitive_column_ids' => [
+                    'bac',
+                    'pv',
+                    'ev',
+                    'ac',
+                    'ctc',
+                    'eac',
+                    'forecast_variance',
+                    'cpi',
+                ],
+                'audit_column_ids' => [],
+                'totals_sensitive' => false,
+                'totals_audit' => false,
+                'provenance_audit' => false,
+            ],
             'readiness' => [
                 'source' => 'ready',
                 'formula' => 'ready',

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastCandidateContract.php
@@ -7,6 +7,7 @@ namespace App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportDataClassification;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSortDirection;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use InvalidArgumentException;
@@ -77,7 +78,22 @@ final readonly class WipCompletionForecastCandidateContract
             || $definition->permissionPolicy->viewPermissions !== ['budgeting.wip_forecast.view']
             || $definition->permissionPolicy->exportPermissions !== ['budgeting.wip_forecast.export']
             || $definition->permissionPolicy->sensitivePermissions !== ['budgeting.wip_forecast.view_sensitive_costs']
-            || $definition->permissionPolicy->auditPermissions !== ['budgeting.wip_forecast.view_audit']) {
+            || $definition->permissionPolicy->auditPermissions !== ['budgeting.wip_forecast.view_audit']
+            || $definition->outputClassification->defaultClassification !== ReportDataClassification::STANDARD
+            || $definition->outputClassification->sensitiveColumnIds !== [
+                'ac',
+                'bac',
+                'cpi',
+                'ctc',
+                'eac',
+                'ev',
+                'forecast_variance',
+                'pv',
+            ]
+            || $definition->outputClassification->auditColumnIds !== []
+            || $definition->outputClassification->totalsSensitive
+            || $definition->outputClassification->totalsAudit
+            || $definition->outputClassification->provenanceAudit) {
             throw new InvalidArgumentException('wip_completion_forecast_candidate_definition_invalid');
         }
     }

--- a/tests/Unit/Reporting/Access/ReportAccessServiceTest.php
+++ b/tests/Unit/Reporting/Access/ReportAccessServiceTest.php
@@ -425,6 +425,43 @@ final class ReportAccessServiceTest extends TestCase
         self::assertFalse($visibility->canViewAudit);
     }
 
+    public function test_source_module_report_uses_exact_sensitive_and_audit_permissions_for_redaction_visibility(): void
+    {
+        $definition = $this->sourceModuleDefinition(
+            sensitivePermissions: ['act_reports.costs.view'],
+            auditPermissions: ['act_reports.audit.view'],
+        );
+        $service = $this->service([
+            'act_reports.view',
+            'act_reports.costs.view',
+            'act_reports.audit.view',
+        ]);
+
+        $visibility = $service->assertOperation(
+            $this->context([
+                'act_reports.view',
+                'act_reports.costs.view',
+                'act_reports.audit.view',
+            ]),
+            $definition,
+            ReportOperation::VIEW,
+            null,
+        );
+
+        self::assertTrue($visibility->canViewSensitive);
+        self::assertTrue($visibility->canViewAudit);
+
+        $redacted = $this->service(['act_reports.view'])->assertOperation(
+            $this->context(['act_reports.view']),
+            $definition,
+            ReportOperation::VIEW,
+            null,
+        );
+
+        self::assertFalse($redacted->canViewSensitive);
+        self::assertFalse($redacted->canViewAudit);
+    }
+
     public function test_source_module_report_authorizes_only_the_requested_export_format(): void
     {
         $permissions = ['act_reports.view', 'act_reports.export.excel'];
@@ -442,6 +479,66 @@ final class ReportAccessServiceTest extends TestCase
 
         $this->expectScopeForbidden();
         $service->assertOperation($context, $definition, ReportOperation::EXPORT, null, 'pdf');
+    }
+
+    public function test_canonical_source_module_export_uses_declared_permission_for_each_declared_format(): void
+    {
+        $definition = $this->sourceModuleDefinition(
+            ['csv', 'xlsx'],
+            exportPermissions: ['reports.project_control.export'],
+        );
+        $permissions = ['act_reports.view', 'reports.project_control.export'];
+        $service = $this->service($permissions);
+        $context = $this->context($permissions);
+
+        foreach (['csv', 'xlsx'] as $format) {
+            self::assertTrue($service->assertOperation(
+                $context,
+                $definition,
+                ReportOperation::EXPORT,
+                null,
+                $format,
+            )->canExport);
+        }
+
+        $this->expectScopeForbidden();
+        $this->service(['act_reports.view'])->assertOperation(
+            $this->context(['act_reports.view']),
+            $definition,
+            ReportOperation::EXPORT,
+            null,
+            'csv',
+        );
+    }
+
+    public function test_canonical_source_module_catalog_requires_every_declared_export_permission(): void
+    {
+        $definition = $this->sourceModuleDefinition(
+            ['csv', 'xlsx'],
+            exportPermissions: ['reports.project_control.export', 'reports.project_control.export_sensitive'],
+        );
+        $partialPermissions = ['act_reports.view', 'reports.project_control.export'];
+        $completePermissions = [
+            'act_reports.view',
+            'reports.project_control.export',
+            'reports.project_control.export_sensitive',
+        ];
+
+        $partial = $this->service($partialPermissions)->assertOperation(
+            $this->context($partialPermissions),
+            $definition,
+            ReportOperation::VIEW,
+            null,
+        );
+        $complete = $this->service($completePermissions)->assertOperation(
+            $this->context($completePermissions),
+            $definition,
+            ReportOperation::VIEW,
+            null,
+        );
+
+        self::assertFalse($partial->canExport);
+        self::assertTrue($complete->canExport);
     }
 
     public function test_generic_permissions_never_authorize_source_module_report(): void
@@ -551,9 +648,14 @@ final class ReportAccessServiceTest extends TestCase
             ->payload();
     }
 
-    private function sourceModuleDefinition(array $formats = ['xlsx']): ReportDefinition
+    private function sourceModuleDefinition(
+        array $formats = ['xlsx'],
+        array $sensitivePermissions = [],
+        array $auditPermissions = [],
+        ?array $exportPermissions = null,
+    ): ReportDefinition
     {
-        $exportPermissions = array_map(
+        $exportPermissions ??= array_map(
             static fn (string $format): string => match ($format) {
                 'xlsx' => 'act_reports.export.excel',
                 'pdf' => 'act_reports.export.pdf',
@@ -569,8 +671,8 @@ final class ReportAccessServiceTest extends TestCase
             ->permissionPolicy(new ReportPermissionPolicy(
                 ['act_reports.view'],
                 $exportPermissions,
-                [],
-                [],
+                $sensitivePermissions,
+                $auditPermissions,
             ))
             ->payload();
     }

--- a/tests/Unit/Reporting/Actions/ReportReadHandlersTest.php
+++ b/tests/Unit/Reporting/Actions/ReportReadHandlersTest.php
@@ -91,11 +91,7 @@ final class ReportReadHandlersTest extends TestCase
         );
 
         self::assertSame($fixture['page'], $result);
-        self::assertSame([
-            ReportOperation::VIEW,
-            ReportOperation::VIEW_SENSITIVE,
-            ReportOperation::VIEW_AUDIT,
-        ], $operations);
+        self::assertSame([ReportOperation::VIEW], $operations);
         self::assertCount(1, $fixture['rowQuery']->pageCalls());
         self::assertSame($fixture['run']->resultMetadata->snapshot, $fixture['rowQuery']->pageCalls()[0][1]);
         self::assertSame($this->sort, $fixture['rowQuery']->pageCalls()[0][2]);
@@ -133,6 +129,138 @@ final class ReportReadHandlersTest extends TestCase
         self::assertSame('Первая строка', $decoded->keyset->lastSortValue);
         self::assertSame('row-1', $decoded->keyset->lastStableRowKey);
         self::assertSame($this->sort, $decoded->sort);
+    }
+
+    public function test_sensitive_sort_is_authorized_before_provider_and_supports_cursor_pagination(): void
+    {
+        $sort = new ReportWindowSort('secret_amount', ReportSortDirection::DESC);
+        $classification = new ReportOutputClassification(
+            ReportDataClassification::STANDARD,
+            ['secret_amount'],
+            [],
+            false,
+            false,
+            false,
+        );
+        $fixture = $this->fixture(
+            $classification,
+            columns: [['id' => 'name'], ['id' => 'secret_amount']],
+            rows: [['row_key' => 'row-1', 'name' => 'Первая строка', 'secret_amount' => 500]],
+            hasMore: true,
+            limit: 1,
+            sort: $sort,
+        );
+        $operations = [];
+        $handler = $this->rowsHandler($fixture, $this->authorizer($operations));
+
+        $first = $handler->handle(
+            $this->context,
+            self::RUN_ID,
+            new ReportRowsWindow(null, 1, $sort),
+        );
+
+        self::assertSame([ReportOperation::VIEW, ReportOperation::VIEW_SENSITIVE], $operations);
+        self::assertNotNull($first->nextCursor);
+
+        $handler->handle(
+            $this->context,
+            self::RUN_ID,
+            new ReportRowsWindow($first->nextCursor, 1, $sort),
+        );
+
+        $decoded = $fixture['rowQuery']->pageCalls()[1][3];
+        self::assertNotNull($decoded);
+        self::assertSame(500, $decoded->keyset->lastSortValue);
+        self::assertSame('row-1', $decoded->keyset->lastStableRowKey);
+    }
+
+    public function test_sensitive_sort_denial_happens_before_provider_call(): void
+    {
+        $sort = new ReportWindowSort('secret_amount', ReportSortDirection::DESC);
+        $fixture = $this->fixture(
+            new ReportOutputClassification(
+                ReportDataClassification::STANDARD,
+                ['secret_amount'],
+                [],
+                false,
+                false,
+                false,
+            ),
+            columns: [['id' => 'name'], ['id' => 'secret_amount']],
+            sort: $sort,
+        );
+        $operations = [];
+
+        $this->expectReportError(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+
+        try {
+            $this->rowsHandler($fixture, $this->authorizer($operations, false))->handle(
+                $this->context,
+                self::RUN_ID,
+                new ReportRowsWindow(null, 50, $sort),
+            );
+        } finally {
+            self::assertSame([ReportOperation::VIEW, ReportOperation::VIEW_SENSITIVE], $operations);
+            self::assertCount(0, $fixture['rowQuery']->pageCalls());
+        }
+    }
+
+    public function test_audit_sort_is_authorized_before_provider_call(): void
+    {
+        $sort = new ReportWindowSort('audit_event', ReportSortDirection::DESC);
+        $fixture = $this->fixture(
+            new ReportOutputClassification(
+                ReportDataClassification::STANDARD,
+                [],
+                ['audit_event'],
+                false,
+                false,
+                false,
+            ),
+            columns: [['id' => 'name'], ['id' => 'audit_event']],
+            sort: $sort,
+        );
+        $operations = [];
+
+        $this->rowsHandler($fixture, $this->authorizer($operations))->handle(
+            $this->context,
+            self::RUN_ID,
+            new ReportRowsWindow(null, 50, $sort),
+        );
+
+        self::assertSame([ReportOperation::VIEW, ReportOperation::VIEW_AUDIT], $operations);
+        self::assertCount(1, $fixture['rowQuery']->pageCalls());
+    }
+
+    public function test_audit_sort_denial_happens_before_provider_call(): void
+    {
+        $sort = new ReportWindowSort('audit_event', ReportSortDirection::DESC);
+        $fixture = $this->fixture(
+            new ReportOutputClassification(
+                ReportDataClassification::STANDARD,
+                [],
+                ['audit_event'],
+                false,
+                false,
+                false,
+            ),
+            columns: [['id' => 'name'], ['id' => 'audit_event']],
+            sort: $sort,
+        );
+        $operations = [];
+
+        $this->expectReportError(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+
+        try {
+            $this->rowsHandler($fixture, $this->authorizer($operations, auditAllowed: false))->handle(
+                $this->context,
+                self::RUN_ID,
+                new ReportRowsWindow(null, 50, $sort),
+            );
+        } finally {
+            self::assertSame([ReportOperation::VIEW, ReportOperation::VIEW_AUDIT], $operations);
+            self::assertCount(0, $fixture['rowQuery']->pageCalls());
+        }
     }
 
     public function test_rows_include_signed_drill_down_tokens_declared_by_the_provider(): void
@@ -414,7 +542,9 @@ final class ReportReadHandlersTest extends TestCase
         bool $hasMore = false,
         int $limit = 50,
         array $drillTokenColumns = [],
+        ?ReportWindowSort $sort = null,
     ): array {
+        $sort ??= $this->sort;
         $definition = (new ReportDefinitionBuilder)
             ->columns($columns)
             ->permissionPolicy($permissions ?? new ReportPermissionPolicy(['reports.view'], ['reports.export'], [], []))
@@ -452,7 +582,7 @@ final class ReportReadHandlersTest extends TestCase
             null,
             $limit,
             $hasMore,
-            $this->sort,
+            $sort,
         );
         $rowQuery = new FakeReportRowQuery($page, []);
         $drillResult ??= new ReportDrillDownResult($rows, null, []);
@@ -502,12 +632,23 @@ final class ReportReadHandlersTest extends TestCase
             ->ready();
     }
 
-    private function authorizer(array &$operations): CurrentReportScopeAuthorizer&MockObject
+    private function authorizer(
+        array &$operations,
+        bool $sensitiveAllowed = true,
+        bool $auditAllowed = true,
+    ): CurrentReportScopeAuthorizer&MockObject
     {
         $authorizer = $this->createMock(CurrentReportScopeAuthorizer::class);
         $authorizer->method('authorizeExact')->willReturnCallback(
-            function (int $actorId, $scope, CurrentReportAuthorizationTarget $target) use (&$operations): CurrentReportAuthorization {
+            function (int $actorId, $scope, CurrentReportAuthorizationTarget $target) use (&$operations, $sensitiveAllowed, $auditAllowed): CurrentReportAuthorization {
                 $operations[] = $target->operation;
+
+                if ($target->operation === ReportOperation::VIEW_SENSITIVE && ! $sensitiveAllowed) {
+                    throw ReportContractException::fromCode(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+                }
+                if ($target->operation === ReportOperation::VIEW_AUDIT && ! $auditAllowed) {
+                    throw ReportContractException::fromCode(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+                }
 
                 return new CurrentReportAuthorization(
                     $this->context->actor,

--- a/tests/Unit/Reporting/Actions/ReportRunHandlersTest.php
+++ b/tests/Unit/Reporting/Actions/ReportRunHandlersTest.php
@@ -24,6 +24,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractExceptio
 use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunCoordinator;
 use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunExportSource;
+use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunResponseRedactor;
 use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunRetrySource;
 use App\BusinessModules\Core\Reporting\Application\Execution\ReportSnapshotSealValidator;
 use App\BusinessModules\Core\Reporting\Application\Execution\ReportSnapshotSealVerificationInput;
@@ -82,6 +83,7 @@ final class ReportRunHandlersTest extends TestCase
                 ['access', ReportAccessService::class],
                 ['runs', ReportRunStore::class],
                 ['clock', ReportExecutionClock::class],
+                ['responseRedactor', ReportRunResponseRedactor::class],
             ],
         );
         $this->assertMethod(ReportRunCoordinator::class, 'create', [
@@ -402,6 +404,7 @@ final class ReportRunHandlersTest extends TestCase
             ),
             $store,
             new FixedClock(new DateTimeImmutable('2026-07-29T09:30:00Z')),
+            new ReportRunResponseRedactor,
         );
 
         (new RetryReportRunHandler($coordinator))->handle($context, $store->run->id, new IdempotencyKey('retry-original-definition'));
@@ -425,6 +428,45 @@ final class ReportRunHandlersTest extends TestCase
         } catch (ReportContractException) {
             self::assertSame(3, $actorLoader->loads);
         }
+    }
+
+    public function test_get_redacts_persisted_sensitive_totals_after_permission_revocation(): void
+    {
+        $output = new ReportOutputClassification(
+            ReportDataClassification::STANDARD,
+            ['bac', 'approved_etc_minor'],
+            [],
+            false,
+            false,
+            false,
+        );
+        [$coordinator, $store, , $context] = $this->fixture(
+            $output,
+            ['reports.view', 'reports.run'],
+            [['id' => 'bac'], ['id' => 'approved_etc_minor'], ['id' => 'wip_minor']],
+        );
+        $storedTotals = [
+            'RUB' => [
+                'bac_minor' => 1_000,
+                'approved_etc_minor' => 300,
+                'wip_minor' => 700,
+            ],
+        ];
+        $store->run = (new ReportRunBuilder)
+            ->reportCode($store->query->definition->code)
+            ->definitionHash($store->query->definition->definitionHash)
+            ->contractVersion($store->query->definition->contractVersion)
+            ->formulaVersion($store->query->definition->formulaVersion)
+            ->sourceSchemaVersion($store->query->definition->sourceSchemaVersion)
+            ->rendererVersion($store->query->definition->rendererVersion)
+            ->queryHash($store->query->queryHash)
+            ->totals($storedTotals)
+            ->ready();
+
+        $visible = (new GetReportRunHandler($coordinator))->handle($context, $store->run->id);
+
+        self::assertSame(['RUB' => ['wip_minor' => 700]], $visible->totals);
+        self::assertSame($storedTotals, $store->run->totals);
     }
 
     public function test_cancel_uses_store_cas_at_exact_clock_instant_without_local_status_check(): void
@@ -491,9 +533,14 @@ final class ReportRunHandlersTest extends TestCase
         }
     }
 
-    private function fixture(?ReportOutputClassification $output = null, ?array $permissions = null): array
+    private function fixture(
+        ?ReportOutputClassification $output = null,
+        ?array $permissions = null,
+        ?array $columns = null,
+    ): array
     {
         $definition = (new ReportDefinitionBuilder)
+            ->columns($columns ?? [['id' => 'name']])
             ->permissionPolicy(new ReportPermissionPolicy(['reports.view'], ['reports.export'], [], []))
             ->outputClassification($output ?? new ReportOutputClassification(ReportDataClassification::STANDARD, [], [], false, false, false))
             ->payload();
@@ -511,7 +558,14 @@ final class ReportRunHandlersTest extends TestCase
             ),
         );
         $clock = new FixedClock(new DateTimeImmutable('2026-07-29T09:30:00.123456Z'));
-        $coordinator = new ReportRunCoordinator(new SingleDefinitionRegistry($published), $savedViews, $access, $store, $clock);
+        $coordinator = new ReportRunCoordinator(
+            new SingleDefinitionRegistry($published),
+            $savedViews,
+            $access,
+            $store,
+            $clock,
+            new ReportRunResponseRedactor,
+        );
 
         return [$coordinator, $store, $savedViews, $context, $actorLoader];
     }
@@ -823,7 +877,7 @@ final class RecordingRunStore implements ReportRunStore
 
     private array $idempotency = [];
 
-    public function __construct(public readonly ReportQuery $query, public readonly ReportRun $run) {}
+    public function __construct(public readonly ReportQuery $query, public ReportRun $run) {}
 
     public function createOrReuse(ReportExecutionContext $context, ReportQuery $query, ?ReportSavedViewRef $savedView, IdempotencyKey $idempotencyKey): ReportRun
     {

--- a/tests/Unit/Reporting/Catalog/ReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/ReportDefinitionRegistryTest.php
@@ -12,6 +12,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\LoadedReportManifest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportDataClassification;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ManifestReportCatalogMetadataRegistry;
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ManifestReportSchedulingCapabilityRegistry;
@@ -22,6 +23,7 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportManifestSema
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\YamlCandidateReportDefinitionRegistry;
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\YamlReportManifestLoader;
 use App\BusinessModules\Core\Reporting\Infrastructure\Validation\Draft202012SchemaValidator;
+use InvalidArgumentException;
 use LogicException;
 use Opis\JsonSchema\CompliantValidator;
 use PHPUnit\Framework\TestCase;
@@ -108,6 +110,9 @@ final class ReportDefinitionRegistryTest extends TestCase
         self::assertTrue($first->supportsSubscriptions);
         self::assertSame('reports', $first->sourceModule);
         self::assertSame(ReportCoreAccessMode::REPORTING_WORKSPACE, $first->coreAccessMode);
+        self::assertSame(ReportDataClassification::STANDARD, $first->outputClassification->defaultClassification);
+        self::assertSame([], $first->outputClassification->sensitiveColumnIds);
+        self::assertSame([], $first->outputClassification->auditColumnIds);
 
         $sourceRow = $row;
         $sourceRow['source_module'] = 'act-reporting';
@@ -123,6 +128,49 @@ final class ReportDefinitionRegistryTest extends TestCase
         self::assertSame('act-reporting', $source->sourceModule);
         self::assertSame(ReportCoreAccessMode::SOURCE_MODULE_REPORT, $source->coreAccessMode);
         self::assertNotSame($first->definitionHash->value, $source->definitionHash->value);
+    }
+
+    public function test_definition_factory_preserves_explicit_closed_output_classification(): void
+    {
+        $row = $this->manifest()->definitions[1];
+        $row['output_classification'] = [
+            'default_classification' => 'standard',
+            'sensitive_column_ids' => ['amount'],
+            'audit_column_ids' => ['evidence'],
+            'totals_sensitive' => true,
+            'totals_audit' => false,
+            'provenance_audit' => true,
+        ];
+        $row['columns'][] = ['id' => 'amount'];
+        $row['columns'][] = ['id' => 'evidence'];
+
+        $classification = $this->factory()->fromManifest($row)->outputClassification;
+
+        self::assertSame(ReportDataClassification::STANDARD, $classification->defaultClassification);
+        self::assertSame(['amount'], $classification->sensitiveColumnIds);
+        self::assertSame(['evidence'], $classification->auditColumnIds);
+        self::assertTrue($classification->totalsSensitive);
+        self::assertFalse($classification->totalsAudit);
+        self::assertTrue($classification->provenanceAudit);
+    }
+
+    public function test_definition_factory_rejects_open_output_classification_shape(): void
+    {
+        $row = $this->manifest()->definitions[1];
+        $row['output_classification'] = [
+            'default_classification' => 'standard',
+            'sensitive_column_ids' => [],
+            'audit_column_ids' => [],
+            'totals_sensitive' => false,
+            'totals_audit' => false,
+            'provenance_audit' => false,
+            'unexpected' => true,
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('report_manifest_definition_invalid');
+
+        $this->factory()->fromManifest($row);
     }
 
     public function test_manifest_semantics_reject_reports_as_source_module(): void

--- a/tests/Unit/Reporting/Contracts/ReportDefinitionContractTest.php
+++ b/tests/Unit/Reporting/Contracts/ReportDefinitionContractTest.php
@@ -89,8 +89,8 @@ final class ReportDefinitionContractTest extends TestCase
             false,
         );
 
-        self::assertTrue($standard->requiresSensitiveForRows());
-        self::assertTrue($standard->requiresAuditForRows());
+        self::assertFalse($standard->requiresSensitiveForRows());
+        self::assertFalse($standard->requiresAuditForRows());
         self::assertTrue($standard->requiresSensitiveForColumns(['cost']));
         self::assertFalse($standard->requiresSensitiveForColumns(['name']));
         self::assertTrue($standard->requiresAuditForColumns(['employee']));

--- a/tests/Unit/Reporting/WaveOne/ProjectFinanceOutputRedactorTest.php
+++ b/tests/Unit/Reporting/WaveOne/ProjectFinanceOutputRedactorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\WaveOne;
+
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\ProjectFinanceOutputRedactor;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectFinanceOutputRedactorTest extends TestCase
+{
+    private const SENSITIVE_FIELDS = [
+        'bac_minor',
+        'pv_minor',
+        'ev_minor',
+        'ac_minor',
+        'ctc_minor',
+        'eac_minor',
+        'forecast_variance_minor',
+    ];
+
+    public function test_wip_totals_hide_sensitive_fields_without_sensitive_visibility(): void
+    {
+        $totals = $this->totals();
+
+        $visible = (new ProjectFinanceOutputRedactor)->totals(
+            'wip_completion_forecast',
+            $totals,
+            false,
+        );
+
+        self::assertSame(['RUB' => ['wip_minor' => 300]], $visible);
+    }
+
+    public function test_wip_totals_remain_complete_with_sensitive_visibility(): void
+    {
+        $totals = $this->totals();
+
+        self::assertSame(
+            $totals,
+            (new ProjectFinanceOutputRedactor)->totals(
+                'wip_completion_forecast',
+                $totals,
+                true,
+            ),
+        );
+    }
+
+    private function totals(): array
+    {
+        return [
+            'RUB' => [
+                'wip_minor' => 300,
+                ...array_fill_keys(self::SENSITIVE_FIELDS, 100),
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Reporting/WaveOne/WipCompletionForecastPublishedContractTest.php
+++ b/tests/Unit/Reporting/WaveOne/WipCompletionForecastPublishedContractTest.php
@@ -38,6 +38,16 @@ final class WipCompletionForecastPublishedContractTest extends TestCase
         self::assertSame(['budgeting.wip_forecast.export'], $definition->permissionPolicy->exportPermissions);
         self::assertSame(['budgeting.wip_forecast.view_sensitive_costs'], $definition->permissionPolicy->sensitivePermissions);
         self::assertSame(['budgeting.wip_forecast.view_audit'], $definition->permissionPolicy->auditPermissions);
+        self::assertSame([
+            'ac',
+            'bac',
+            'cpi',
+            'ctc',
+            'eac',
+            'ev',
+            'forecast_variance',
+            'pv',
+        ], $definition->outputClassification->sensitiveColumnIds);
         self::assertSame(['csv', 'xlsx'], $definition->formats);
     }
 

--- a/tests/Unit/Reporting/Waves23/ProjectEvmControlPublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ProjectEvmControlPublishedContractTest.php
@@ -48,6 +48,15 @@ final class ProjectEvmControlPublishedContractTest extends TestCase
             $definition->permissionPolicy->sensitivePermissions,
         );
         self::assertSame([], $definition->permissionPolicy->auditPermissions);
+        self::assertSame([
+            'ac_minor',
+            'approved_etc_minor',
+            'cpi',
+            'cv_minor',
+            'eac_minor',
+            'tcpi',
+            'vac_minor',
+        ], $definition->outputClassification->sensitiveColumnIds);
         self::assertSame(['csv', 'xlsx'], $definition->formats);
         self::assertSame(5, $builtin->metadata()->manifestOrdinal);
         self::assertFalse($builtin->scheduling()->supportsSubscriptions);


### PR DESCRIPTION
Уточнена серверная visibility для source-module отчётов, классификация R05/R11, защита sensitive/audit сортировки и export capabilities. Добавлена redaction строк, итогов и сохранённых run по актуальным правам, включая отзыв разрешения после materialization. Добавлены регрессионные unit/contract тесты. Локально: php -l 21 PHP-файла и git diff --check успешно; PHPUnit и PHPStan не запускались, потому что vendor отсутствует. Независимое review: CLEAN.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enhanced report visibility logic to support sensitive and audit-specific permissions.</li>
<li>Refactored export permission checks to support both format-specific and aggregate permission requirements.</li>
<li>Updated report row authorization and response redaction logic to align with new visibility policies.</li>
<li>Added and updated unit tests to cover new permission-based visibility and export scenarios.</li>
</ul></div>