### PR TITLE
fix: исправлена проверка готовности источников отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportSourceReadiness.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportSourceReadiness.php
@@ -33,4 +33,13 @@ final readonly class ReportSourceReadiness
             throw new InvalidArgumentException('report_source_readiness_invalid');
         }
     }
+
+    public function isReady(): bool
+    {
+        return $this->status === ReportSourceReadinessStatus::READY
+            && $this->projectedCount === $this->eligibleCount
+            && $this->gapCount === 0
+            && $this->unknownCount === 0
+            && $this->verifiedAt !== null;
+    }
 }

--- a/app/Support/Reporting/DeterministicReadinessAccumulator.php
+++ b/app/Support/Reporting/DeterministicReadinessAccumulator.php
@@ -6,7 +6,7 @@ namespace App\Support\Reporting;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceReadiness;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSourceReadinessStatus;
-use DateTimeImmutable;
+use Carbon\CarbonImmutable;
 use InvalidArgumentException;
 
 final class DeterministicReadinessAccumulator
@@ -56,7 +56,7 @@ final class DeterministicReadinessAccumulator
             $watermark,
             $this->eligible->sha256(),
             $this->projected->sha256(),
-            new DateTimeImmutable,
+            CarbonImmutable::now(),
         );
     }
 }

--- a/app/Support/Reporting/ReportSourceReadinessFactory.php
+++ b/app/Support/Reporting/ReportSourceReadinessFactory.php
@@ -7,7 +7,7 @@ namespace App\Support\Reporting;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceReadiness;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSourceReadinessStatus;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
-use DateTimeImmutable;
+use Carbon\CarbonImmutable;
 use InvalidArgumentException;
 
 final readonly class ReportSourceReadinessFactory
@@ -42,7 +42,7 @@ final readonly class ReportSourceReadinessFactory
             watermark: $watermark,
             inputHash: hash('sha256', CanonicalJson::encode($eligible)),
             outputHash: hash('sha256', CanonicalJson::encode($projected)),
-            verifiedAt: new DateTimeImmutable,
+            verifiedAt: CarbonImmutable::now(),
         );
     }
 }

--- a/tests/Unit/Reporting/Support/ReportSourceReadinessTimestampTest.php
+++ b/tests/Unit/Reporting/Support/ReportSourceReadinessTimestampTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Support;
+
+use App\Support\Reporting\DeterministicReadinessAccumulator;
+use App\Support\Reporting\ReportSourceReadinessFactory;
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\TestCase;
+
+final class ReportSourceReadinessTimestampTest extends TestCase
+{
+    public function test_accumulator_returns_carbon_verified_timestamp(): void
+    {
+        $accumulator = new DeterministicReadinessAccumulator;
+        $accumulator->eligible(['id' => 1]);
+        $accumulator->projected(['id' => 1]);
+
+        $readiness = $accumulator->finish(0, 0, 'accepted-production:v1');
+
+        self::assertInstanceOf(CarbonImmutable::class, $readiness->verifiedAt);
+    }
+
+    public function test_factory_returns_carbon_verified_timestamp(): void
+    {
+        $readiness = (new ReportSourceReadinessFactory)->make(
+            [['id' => 1]],
+            [['id' => 1]],
+            0,
+            0,
+            'accepted-production:v1',
+        );
+
+        self::assertInstanceOf(CarbonImmutable::class, $readiness->verifiedAt);
+    }
+}

--- a/tests/Unit/Reporting/Waves23/ReportSourceReadinessContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportSourceReadinessContractTest.php
@@ -9,7 +9,8 @@ use App\BusinessModules\Core\Reporting\Application\Readiness\ReportCandidateRead
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceBackfillCursor;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceReadiness;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSourceReadinessStatus;
-use DateTimeImmutable;
+use Carbon\CarbonImmutable;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -27,7 +28,7 @@ final class ReportSourceReadinessContractTest extends TestCase
             watermark: 'event:81',
             inputHash: str_repeat('a', 64),
             outputHash: str_repeat('b', 64),
-            verifiedAt: new DateTimeImmutable('2026-07-30T10:00:00+03:00'),
+            verifiedAt: new CarbonImmutable('2026-07-30T10:00:00+03:00'),
         );
 
         (new ReportCandidateReadinessGate)->assertReady(
@@ -39,8 +40,10 @@ final class ReportSourceReadinessContractTest extends TestCase
     }
 
     #[Test]
-    public function coverage_gap_blocks_candidate_even_when_status_claims_ready(): void
+    public function coverage_gap_is_rejected_even_when_status_claims_ready(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $readiness = new ReportSourceReadiness(
             status: ReportSourceReadinessStatus::READY,
             eligibleCount: 12,
@@ -50,7 +53,23 @@ final class ReportSourceReadinessContractTest extends TestCase
             watermark: 'event:81',
             inputHash: str_repeat('a', 64),
             outputHash: str_repeat('b', 64),
-            verifiedAt: new DateTimeImmutable('2026-07-30T10:00:00+03:00'),
+            verifiedAt: new CarbonImmutable('2026-07-30T10:00:00+03:00'),
+        );
+    }
+
+    #[Test]
+    public function incomplete_projection_is_blocked_by_candidate_gate(): void
+    {
+        $readiness = new ReportSourceReadiness(
+            status: ReportSourceReadinessStatus::PARTIAL,
+            eligibleCount: 12,
+            projectedCount: 11,
+            gapCount: 1,
+            unknownCount: 0,
+            watermark: 'event:81',
+            inputHash: str_repeat('a', 64),
+            outputHash: str_repeat('b', 64),
+            verifiedAt: null,
         );
 
         $this->expectException(ReportContractException::class);


### PR DESCRIPTION
Устраняет несовместимый тип verifiedAt в общих фабриках готовности и восстанавливает отсутствующий контракт isReady для fail-closed gate. Добавлены целевые регрессионные тесты обоих фабричных путей и READY/PARTIAL инвариантов. Локально: php -l 5 файлов, git diff --check. PHPUnit/PHPStan не запускались: vendor отсутствует; дальнейшее доказательство — CI и основной deploy workflow.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added an `isReady()` method to `ReportSourceReadiness` DTO to encapsulate readiness validation logic.</li>
<li>Migrated `DateTimeImmutable` usage to `CarbonImmutable` in `DeterministicReadinessAccumulator` and `ReportSourceReadinessFactory`.</li>
<li>Added a new unit test `ReportSourceReadinessTimestampTest` to verify `CarbonImmutable` usage.</li>
<li>Updated `ReportSourceReadinessContractTest` to use `CarbonImmutable` and added new test cases for readiness validation.</li>
</ul></div>