### PR TITLE
feat: параметры отчёта принятой выработки

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/AcceptedProductionReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/AcceptedProductionReportOptionsController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\AcceptedProductionReportOptionsRequest;
+use App\Http\Responses\AdminResponse;
+use App\Models\Project;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionCandidateContract;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Options\AcceptedProductionOptionsService;
+use Illuminate\Http\JsonResponse;
+
+final readonly class AcceptedProductionReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private AcceptedProductionOptionsService $options,
+    ) {}
+
+    public function __invoke(AcceptedProductionReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, AcceptedProductionCandidateContract::CODE)['context'];
+        $project = $request->attributes->get('project');
+
+        return AdminResponse::success($this->options->options(
+            $context->scope,
+            $project instanceof Project ? (int) $project->getKey() : 0,
+            $request->asOf(),
+            $request->periodFrom(),
+            $request->periodTo(),
+        ));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -87,6 +87,7 @@ final readonly class AuthorizeReportDefinitionAccess
             'admin.reports.project-evm-control.runs.store',
             'admin.reports.project-evm-control.options',
             'admin.reports.accepted-production-progress.runs.store',
+            'admin.reports.accepted-production-progress.options',
             'admin.reports.wip-completion-forecast.runs.store',
             'admin.reports.wip-completion-forecast.options',
             'admin.reports.project-labor-cost.runs.store',

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/AcceptedProductionReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/AcceptedProductionReportOptionsRequest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use DateTimeImmutable;
+
+final class AcceptedProductionReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'as_of' => [
+                'required',
+                'string',
+                static function (string $attribute, mixed $value, callable $fail): void {
+                    if (ReportAsOfParser::parse($value) === null) {
+                        $fail(trans_message('reports.errors.report_request_invalid'));
+                    }
+                },
+            ],
+            'period_from' => ['required', 'string', 'date_format:Y-m-d'],
+            'period_to' => ['required', 'string', 'date_format:Y-m-d', 'after_or_equal:period_from'],
+            ...$this->forbiddenClientFieldsRules(),
+            'current_organization_id' => ['prohibited'],
+            'holding_organization_ids' => ['prohibited'],
+            'organization_ids' => ['prohibited'],
+            'project_id' => ['prohibited'],
+            'current_project_id' => ['prohibited'],
+            'project_ids' => ['prohibited'],
+            'scope' => ['prohibited'],
+            'actor_id' => ['prohibited'],
+        ];
+    }
+
+    protected function acceptedQueryFields(): array
+    {
+        return ['as_of', 'period_from', 'period_to'];
+    }
+
+    public function asOf(): DateTimeImmutable
+    {
+        $asOf = ReportAsOfParser::parse($this->validated('as_of'));
+        if ($asOf === null) {
+            $this->invalid(['as_of']);
+        }
+
+        return $asOf;
+    }
+
+    public function periodFrom(): DateTimeImmutable
+    {
+        return $this->date('period_from');
+    }
+
+    public function periodTo(): DateTimeImmutable
+    {
+        return $this->date('period_to');
+    }
+
+    private function date(string $field): DateTimeImmutable
+    {
+        $value = $this->validated($field);
+        $date = is_string($value) ? DateTimeImmutable::createFromFormat('!Y-m-d', $value) : false;
+        if (! $date instanceof DateTimeImmutable || $date->format('Y-m-d') !== $value) {
+            $this->invalid([$field]);
+        }
+
+        return $date;
+    }
+
+    private function invalid(array $fields): never
+    {
+        throw ReportContractException::fromCode(
+            ReportErrorCode::REPORT_REQUEST_INVALID,
+            ['fields' => $fields],
+        );
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMatrix;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\AcceptedProductionReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ContractSettlementExposureReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\HoldingPerformanceReportOptionsController;
@@ -153,6 +154,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'accepted_production_progress')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])
             ->name('accepted-production-progress.runs.store');
+        Route::get('/projects/{project}/accepted-production-progress/options', AcceptedProductionReportOptionsController::class)
+            ->defaults('reportCode', 'accepted_production_progress')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('accepted-production-progress.options');
         Route::post('/projects/{project}/wip-completion-forecast/runs', [ReportRunController::class, 'store'])
             ->defaults('reportCode', 'wip_completion_forecast')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])

--- a/app/Providers/CompletedWorkReportingServiceProvider.php
+++ b/app/Providers/CompletedWorkReportingServiceProvider.php
@@ -9,6 +9,9 @@ use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionCa
 use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionPublishedRuntimeBindingRegistrar;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionReportBindingFactory;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\DrillDown\AcceptedProductionDrillDownProvider;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Options\AcceptedProductionOptionsService;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Options\AcceptedProductionOptionsSource;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Options\CanonicalAcceptedProductionOptionsSource;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\Providers\AcceptedProductionReportProvider;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\Queries\AcceptedProductionRowQuery;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\Readiness\AcceptedProductionReadinessProbe;
@@ -31,6 +34,8 @@ final class CompletedWorkReportingServiceProvider extends ServiceProvider
         $this->app->scoped(AcceptedProductionReportProvider::class);
         $this->app->scoped(AcceptedProductionRowQuery::class);
         $this->app->scoped(AcceptedProductionDrillDownProvider::class);
+        $this->app->scoped(AcceptedProductionOptionsSource::class, CanonicalAcceptedProductionOptionsSource::class);
+        $this->app->scoped(AcceptedProductionOptionsService::class);
         $this->app->scoped(AcceptedProductionReadinessProbe::class);
         $this->app->singleton(AcceptedProductionCandidateContract::class);
         $this->app->scoped(AcceptedProductionReportBindingFactory::class);

--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsService.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsService.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CompletedWork\Reporting\AcceptedProduction\Options;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionBuiltinPublishedReport;
+use DateTimeImmutable;
+use Illuminate\Database\ConnectionInterface;
+
+final readonly class AcceptedProductionOptionsService
+{
+    public function __construct(
+        private AcceptedProductionOptionsSource $source,
+        private AcceptedProductionBuiltinPublishedReport $published,
+        private ConnectionInterface $connection,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function options(
+        ReportScope $scope,
+        int $projectId,
+        DateTimeImmutable $asOf,
+        DateTimeImmutable $periodFrom,
+        DateTimeImmutable $periodTo,
+    ): array {
+        if ($projectId < 1 || ! in_array($projectId, $scope->projectIds, true)) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+        }
+        if ($periodFrom > $periodTo) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_RANGE_INVALID);
+        }
+
+        $projectScope = $this->projectScope($scope, $projectId);
+        $query = new ReportQuery(
+            $this->published->definition()->payload(),
+            $projectScope,
+            new ReportFilterSet([
+                'organization_id' => $projectScope->organizationId,
+                'project_id' => $projectId,
+                'period_from' => $periodFrom->format('Y-m-d'),
+                'period_to' => $periodTo->format('Y-m-d'),
+            ]),
+            [],
+            $asOf,
+            'ru-RU',
+        );
+        $snapshot = $this->source->snapshot($projectScope, $query);
+        if (! $snapshot->available) {
+            return $this->unavailable($asOf, $periodFrom, $periodTo, $snapshot->reason ?? 'source_unavailable');
+        }
+
+        $works = $this->works($projectScope, $projectId, $snapshot->workIds);
+        $acts = $this->acts($projectScope, $projectId, $snapshot->actIds);
+        $contractors = $this->contractors($projectScope, $snapshot->contractorIds);
+        if (count($works) !== count($snapshot->workIds)
+            || count($acts) !== count($snapshot->actIds)
+            || count($contractors) !== count($snapshot->contractorIds)
+        ) {
+            return $this->unavailable($asOf, $periodFrom, $periodTo, 'source_reference_missing');
+        }
+
+        $units = $this->stringOptions($snapshot->unitCodes);
+        $zones = $this->stringOptions($snapshot->zones);
+        $statuses = [];
+        foreach ($snapshot->statuses as $status) {
+            $name = trans_message('reports.options.accepted_production_progress.statuses.'.$status);
+            if ($name === 'reports.options.accepted_production_progress.statuses.'.$status) {
+                return $this->unavailable($asOf, $periodFrom, $periodTo, 'source_unavailable');
+            }
+            $statuses[] = ['id' => $status, 'name' => $name];
+        }
+
+        return [
+            'available' => true,
+            'reason' => null,
+            'as_of' => $this->exactDateTime($asOf),
+            'period_from' => $periodFrom->format('Y-m-d'),
+            'period_to' => $periodTo->format('Y-m-d'),
+            'works' => $works,
+            'acts' => $acts,
+            'contractors' => $contractors,
+            'units' => $units,
+            'zones' => $zones,
+            'statuses' => $this->sorted($statuses),
+        ];
+    }
+
+    private function projectScope(ReportScope $scope, int $projectId): ReportScope
+    {
+        return new ReportScope(
+            $scope->organizationId,
+            $scope->holdingOrganizationIds,
+            [$projectId],
+            $scope->resources,
+            $scope->timezone,
+        );
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<array{id:int,name:string}>
+     */
+    private function works(ReportScope $scope, int $projectId, array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        $rows = $this->connection->table('completed_works as work')
+            ->join('work_types as work_type', function ($join): void {
+                $join->on('work_type.id', '=', 'work.work_type_id')
+                    ->on('work_type.organization_id', '=', 'work.organization_id');
+            })
+            ->where('work.organization_id', $scope->organizationId)
+            ->where('work.project_id', $projectId)
+            ->whereIn('work.id', $ids)
+            ->get(['work.id', 'work_type.name as work_type_name']);
+
+        $options = [];
+        foreach ($rows as $row) {
+            $id = (int) $row->id;
+            $name = trim((string) $row->work_type_name);
+            $options[] = [
+                'id' => $id,
+                'name' => $name === ''
+                    ? trans_message('reports.options.accepted_production_progress.work', ['id' => $id])
+                    : trans_message('reports.options.accepted_production_progress.work_with_name', [
+                        'id' => $id,
+                        'name' => $name,
+                    ]),
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<array{id:int,name:string}>
+     */
+    private function acts(ReportScope $scope, int $projectId, array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        $rows = $this->connection->table('contract_performance_acts as act')
+            ->join('contracts as contract', 'contract.id', '=', 'act.contract_id')
+            ->where('contract.organization_id', $scope->organizationId)
+            ->where('act.project_id', $projectId)
+            ->whereIn('act.id', $ids)
+            ->get(['act.id', 'act.act_document_number']);
+
+        $options = [];
+        foreach ($rows as $row) {
+            $id = (int) $row->id;
+            $number = trim((string) $row->act_document_number);
+            $options[] = [
+                'id' => $id,
+                'name' => $number === ''
+                    ? trans_message('reports.options.accepted_production_progress.act_by_id', ['id' => $id])
+                    : trans_message('reports.options.accepted_production_progress.act', ['number' => $number]),
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<array{id:int,name:string}>
+     */
+    private function contractors(ReportScope $scope, array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        $rows = $this->connection->table('contractors')
+            ->where('organization_id', $scope->organizationId)
+            ->whereIn('id', $ids)
+            ->get(['id', 'name']);
+
+        $options = [];
+        foreach ($rows as $row) {
+            $id = (int) $row->id;
+            $name = trim((string) $row->name);
+            $options[] = [
+                'id' => $id,
+                'name' => $name === ''
+                    ? trans_message('reports.options.accepted_production_progress.contractor', ['id' => $id])
+                    : $name,
+            ];
+        }
+
+        return $this->sorted($options);
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<array{id:string,name:string}>
+     */
+    private function stringOptions(array $values): array
+    {
+        return $this->sorted(array_map(
+            static fn (string $value): array => ['id' => $value, 'name' => $value],
+            $values,
+        ));
+    }
+
+    /**
+     * @template T of int|string
+     * @param  list<array{id:T,name:string}>  $items
+     * @return list<array{id:T,name:string}>
+     */
+    private function sorted(array $items): array
+    {
+        usort($items, static fn (array $left, array $right): int => strnatcasecmp(
+            (string) $left['name'],
+            (string) $right['name'],
+        ));
+
+        return $items;
+    }
+
+    /** @return array<string, mixed> */
+    private function unavailable(
+        DateTimeImmutable $asOf,
+        DateTimeImmutable $periodFrom,
+        DateTimeImmutable $periodTo,
+        string $reason,
+    ): array {
+        return [
+            'available' => false,
+            'reason' => $reason,
+            'as_of' => $this->exactDateTime($asOf),
+            'period_from' => $periodFrom->format('Y-m-d'),
+            'period_to' => $periodTo->format('Y-m-d'),
+            'works' => [],
+            'acts' => [],
+            'contractors' => [],
+            'units' => [],
+            'zones' => [],
+            'statuses' => [],
+        ];
+    }
+
+    private function exactDateTime(DateTimeImmutable $value): string
+    {
+        return $value->format('u') === '000000'
+            ? $value->format(DATE_ATOM)
+            : $value->format('Y-m-d\TH:i:s.uP');
+    }
+}

--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsSource.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsSource.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CompletedWork\Reporting\AcceptedProduction\Options;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+
+interface AcceptedProductionOptionsSource
+{
+    public function snapshot(ReportScope $scope, ReportQuery $query): AcceptedProductionOptionsSourceSnapshot;
+}

--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsSourceSnapshot.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsSourceSnapshot.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CompletedWork\Reporting\AcceptedProduction\Options;
+
+use InvalidArgumentException;
+
+final readonly class AcceptedProductionOptionsSourceSnapshot
+{
+    /**
+     * @param  list<int>  $workIds
+     * @param  list<int>  $actIds
+     * @param  list<int>  $contractorIds
+     * @param  list<string>  $unitCodes
+     * @param  list<string>  $zones
+     * @param  list<string>  $statuses
+     */
+    private function __construct(
+        public bool $available,
+        public ?string $reason,
+        public array $workIds,
+        public array $actIds,
+        public array $contractorIds,
+        public array $unitCodes,
+        public array $zones,
+        public array $statuses,
+    ) {}
+
+    /**
+     * @param  list<int>  $workIds
+     * @param  list<int>  $actIds
+     * @param  list<int>  $contractorIds
+     * @param  list<string>  $unitCodes
+     * @param  list<string>  $zones
+     * @param  list<string>  $statuses
+     */
+    public static function available(
+        array $workIds,
+        array $actIds,
+        array $contractorIds,
+        array $unitCodes,
+        array $zones,
+        array $statuses,
+    ): self {
+        return new self(
+            true,
+            null,
+            self::positiveIds($workIds),
+            self::positiveIds($actIds),
+            self::positiveIds($contractorIds),
+            self::strings($unitCodes),
+            self::strings($zones),
+            self::strings($statuses),
+        );
+    }
+
+    public static function unavailable(string $reason): self
+    {
+        if (! in_array($reason, ['source_incomplete', 'source_unavailable'], true)) {
+            throw new InvalidArgumentException('accepted_production_options_reason_invalid');
+        }
+
+        return new self(false, $reason, [], [], [], [], [], []);
+    }
+
+    /**
+     * @param  list<int>  $values
+     * @return list<int>
+     */
+    private static function positiveIds(array $values): array
+    {
+        $ids = [];
+        foreach ($values as $value) {
+            if (! is_int($value) || $value < 1) {
+                throw new InvalidArgumentException('accepted_production_options_source_invalid');
+            }
+            $ids[$value] = $value;
+        }
+        $ids = array_values($ids);
+        sort($ids, SORT_NUMERIC);
+
+        return $ids;
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private static function strings(array $values): array
+    {
+        $strings = [];
+        foreach ($values as $value) {
+            if (! is_string($value) || trim($value) === '') {
+                throw new InvalidArgumentException('accepted_production_options_source_invalid');
+            }
+            $normalized = trim($value);
+            $strings[$normalized] = $normalized;
+        }
+        $strings = array_values($strings);
+        natcasesort($strings);
+
+        return array_values($strings);
+    }
+}

--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/CanonicalAcceptedProductionOptionsSource.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/CanonicalAcceptedProductionOptionsSource.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CompletedWork\Reporting\AcceptedProduction\Options;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\DTO\AcceptedProductionUniverseEntry;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Models\ProductionAcceptanceEvent;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Services\AcceptedProductionEventUniverse;
+use InvalidArgumentException;
+
+final readonly class CanonicalAcceptedProductionOptionsSource implements AcceptedProductionOptionsSource
+{
+    public function __construct(private AcceptedProductionEventUniverse $universe) {}
+
+    public function snapshot(ReportScope $scope, ReportQuery $query): AcceptedProductionOptionsSourceSnapshot
+    {
+        try {
+            $stream = $this->universe->stream($scope, $query);
+            if ($stream->gapCount() > 0) {
+                return AcceptedProductionOptionsSourceSnapshot::unavailable('source_incomplete');
+            }
+
+            $workIds = [];
+            $actIds = [];
+            $contractorIds = [];
+            $unitCodes = [];
+            $zones = [];
+            $statuses = [];
+
+            foreach ($stream->entries() as $entry) {
+                if (! $entry instanceof AcceptedProductionUniverseEntry) {
+                    return AcceptedProductionOptionsSourceSnapshot::unavailable('source_unavailable');
+                }
+                $event = $entry->latestEvent();
+                if (! $this->valid($entry, $event, $scope)) {
+                    return AcceptedProductionOptionsSourceSnapshot::unavailable('source_unavailable');
+                }
+
+                $workIds[] = (int) $event->work_id;
+                $actIds[] = (int) $event->performance_act_id;
+                if ($event->contractor_id !== null) {
+                    $contractorIds[] = (int) $event->contractor_id;
+                }
+                $unitCodes[] = trim((string) $event->unit_code);
+                if ($event->zone !== null && trim((string) $event->zone) !== '') {
+                    $zones[] = trim((string) $event->zone);
+                }
+                $statuses[] = (string) $event->event_type;
+            }
+
+            return AcceptedProductionOptionsSourceSnapshot::available(
+                $workIds,
+                $actIds,
+                $contractorIds,
+                $unitCodes,
+                $zones,
+                $statuses,
+            );
+        } catch (InvalidArgumentException) {
+            return AcceptedProductionOptionsSourceSnapshot::unavailable('source_unavailable');
+        }
+    }
+
+    private function valid(
+        AcceptedProductionUniverseEntry $entry,
+        ?ProductionAcceptanceEvent $event,
+        ReportScope $scope,
+    ): bool {
+        if ($event === null
+            || (int) $event->work_id < 1
+            || (int) $event->performance_act_id < 1
+            || (int) $event->project_id < 1
+            || ! in_array((int) $event->project_id, $scope->projectIds, true)
+            || trim((string) $event->unit_code) === ''
+            || ! in_array((string) $event->event_type, ['accepted', 'reversed'], true)
+            || (int) ($entry->candidate['work_id'] ?? 0) !== (int) $event->work_id
+            || (int) ($entry->candidate['performance_act_id'] ?? 0) !== (int) $event->performance_act_id
+            || (int) ($entry->candidate['project_id'] ?? 0) !== (int) $event->project_id
+            || (string) ($entry->candidate['event_type'] ?? '') !== (string) $event->event_type
+        ) {
+            return false;
+        }
+
+        return $event->contractor_id === null || (int) $event->contractor_id > 0;
+    }
+}

--- a/lang/ru/reports.php
+++ b/lang/ru/reports.php
@@ -94,6 +94,17 @@ return [
         'format_invalid' => 'Выбран некорректный формат отчета.',
     ],
     'options' => [
+        'accepted_production_progress' => [
+            'work' => 'Работа №:id',
+            'work_with_name' => 'Работа №:id — :name',
+            'act' => 'Акт №:number',
+            'act_by_id' => 'Акт №:id',
+            'contractor' => 'Подрядчик №:id',
+            'statuses' => [
+                'accepted' => 'Принято',
+                'reversed' => 'Отменено',
+            ],
+        ],
         'contract_settlement_exposure' => [
             'directions' => [
                 'receivable' => 'Дебиторская задолженность',

--- a/tests/Unit/CompletedWork/Reporting/AcceptedProductionOptionsServiceTest.php
+++ b/tests/Unit/CompletedWork/Reporting/AcceptedProductionOptionsServiceTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\CompletedWork\Reporting;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionBuiltinPublishedReport;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionCandidateContract;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Options\AcceptedProductionOptionsService;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Options\AcceptedProductionOptionsSource;
+use App\Services\CompletedWork\Reporting\AcceptedProduction\Options\AcceptedProductionOptionsSourceSnapshot;
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Eloquent\Model;
+use Tests\TestCase;
+
+final class AcceptedProductionOptionsServiceTest extends TestCase
+{
+    private Capsule $database;
+
+    private ConnectionInterface $connection;
+
+    private ?ConnectionResolverInterface $previousResolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->previousResolver = Model::getConnectionResolver();
+        $this->database = new Capsule;
+        $this->database->addConnection(['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+        $this->database->setAsGlobal();
+        $this->database->bootEloquent();
+        $this->connection = $this->database->getConnection();
+
+        foreach ([
+            'CREATE TABLE work_types (id INTEGER PRIMARY KEY, organization_id INTEGER, name TEXT, code TEXT NULL)',
+            'CREATE TABLE completed_works (id INTEGER PRIMARY KEY, organization_id INTEGER, project_id INTEGER, work_type_id INTEGER)',
+            'CREATE TABLE contracts (id INTEGER PRIMARY KEY, organization_id INTEGER)',
+            'CREATE TABLE contract_performance_acts (id INTEGER PRIMARY KEY, contract_id INTEGER, project_id INTEGER, act_document_number TEXT NULL)',
+            'CREATE TABLE contractors (id INTEGER PRIMARY KEY, organization_id INTEGER, name TEXT)',
+        ] as $statement) {
+            $this->connection->statement($statement);
+        }
+
+        $this->connection->table('work_types')->insert([
+            ['id' => 11, 'organization_id' => 1, 'name' => 'Бетонирование', 'code' => 'БТ'],
+            ['id' => 12, 'organization_id' => 2, 'name' => 'Чужая работа', 'code' => null],
+        ]);
+        $this->connection->table('completed_works')->insert([
+            ['id' => 101, 'organization_id' => 1, 'project_id' => 10, 'work_type_id' => 11],
+            ['id' => 102, 'organization_id' => 2, 'project_id' => 20, 'work_type_id' => 12],
+        ]);
+        $this->connection->table('contracts')->insert([
+            ['id' => 201, 'organization_id' => 1],
+            ['id' => 202, 'organization_id' => 2],
+        ]);
+        $this->connection->table('contract_performance_acts')->insert([
+            ['id' => 301, 'contract_id' => 201, 'project_id' => 10, 'act_document_number' => 'А-7'],
+            ['id' => 302, 'contract_id' => 202, 'project_id' => 20, 'act_document_number' => 'Ч-1'],
+        ]);
+        $this->connection->table('contractors')->insert([
+            ['id' => 401, 'organization_id' => 1, 'name' => 'Монолит'],
+            ['id' => 402, 'organization_id' => 2, 'name' => 'Чужой подрядчик'],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousResolver === null) {
+            Model::unsetConnectionResolver();
+        } else {
+            Model::setConnectionResolver($this->previousResolver);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_options_resolve_only_canonical_source_references_inside_server_scope(): void
+    {
+        $options = $this->service(AcceptedProductionOptionsSourceSnapshot::available(
+            workIds: [101],
+            actIds: [301],
+            contractorIds: [401],
+            unitCodes: ['м3'],
+            zones: ['Секция 1'],
+            statuses: ['accepted', 'reversed'],
+        ))->options(
+            $this->scope(),
+            10,
+            new DateTimeImmutable('2026-08-06T14:15:16.123456+03:00'),
+            new DateTimeImmutable('2026-08-01'),
+            new DateTimeImmutable('2026-08-06'),
+        );
+
+        self::assertTrue($options['available']);
+        self::assertNull($options['reason']);
+        self::assertSame('2026-08-06T14:15:16.123456+03:00', $options['as_of']);
+        self::assertSame('2026-08-01', $options['period_from']);
+        self::assertSame('2026-08-06', $options['period_to']);
+        self::assertSame([['id' => 101, 'name' => 'Работа №101 — Бетонирование']], $options['works']);
+        self::assertSame([['id' => 301, 'name' => 'Акт №А-7']], $options['acts']);
+        self::assertSame([['id' => 401, 'name' => 'Монолит']], $options['contractors']);
+        self::assertSame([['id' => 'м3', 'name' => 'м3']], $options['units']);
+        self::assertSame([['id' => 'Секция 1', 'name' => 'Секция 1']], $options['zones']);
+        self::assertSame([
+            ['id' => 'reversed', 'name' => 'Отменено'],
+            ['id' => 'accepted', 'name' => 'Принято'],
+        ], $options['statuses']);
+    }
+
+    public function test_missing_scoped_reference_makes_all_options_unavailable(): void
+    {
+        $options = $this->service(AcceptedProductionOptionsSourceSnapshot::available(
+            workIds: [102],
+            actIds: [302],
+            contractorIds: [402],
+            unitCodes: ['шт'],
+            zones: [],
+            statuses: ['accepted'],
+        ))->options(
+            $this->scope(),
+            10,
+            new DateTimeImmutable('2026-08-06T14:15:16+03:00'),
+            new DateTimeImmutable('2026-08-01'),
+            new DateTimeImmutable('2026-08-06'),
+        );
+
+        self::assertFalse($options['available']);
+        self::assertSame('source_reference_missing', $options['reason']);
+        self::assertSame([], $options['works']);
+        self::assertSame([], $options['acts']);
+        self::assertSame([], $options['contractors']);
+        self::assertSame([], $options['units']);
+    }
+
+    public function test_incomplete_source_never_returns_partial_options(): void
+    {
+        $options = $this->service(
+            AcceptedProductionOptionsSourceSnapshot::unavailable('source_incomplete'),
+        )->options(
+            $this->scope(),
+            10,
+            new DateTimeImmutable('2026-08-06T14:15:16+03:00'),
+            new DateTimeImmutable('2026-08-01'),
+            new DateTimeImmutable('2026-08-06'),
+        );
+
+        self::assertFalse($options['available']);
+        self::assertSame('source_incomplete', $options['reason']);
+        self::assertSame([], $options['works']);
+        self::assertSame([], $options['statuses']);
+    }
+
+    public function test_trusted_route_project_narrows_authorized_multi_project_scope(): void
+    {
+        $options = $this->service(AcceptedProductionOptionsSourceSnapshot::available(
+            workIds: [101],
+            actIds: [301],
+            contractorIds: [401],
+            unitCodes: ['м3'],
+            zones: [],
+            statuses: ['accepted'],
+        ))->options(
+            $this->scope([10, 20]),
+            10,
+            new DateTimeImmutable('2026-08-06T14:15:16+03:00'),
+            new DateTimeImmutable('2026-08-01'),
+            new DateTimeImmutable('2026-08-06'),
+        );
+
+        self::assertTrue($options['available']);
+        self::assertSame([['id' => 101, 'name' => 'Работа №101 — Бетонирование']], $options['works']);
+    }
+
+    public function test_route_project_outside_authorized_scope_is_rejected(): void
+    {
+        $this->expectException(ReportContractException::class);
+
+        try {
+            $this->service(AcceptedProductionOptionsSourceSnapshot::available(
+                workIds: [],
+                actIds: [],
+                contractorIds: [],
+                unitCodes: [],
+                zones: [],
+                statuses: [],
+            ))->options(
+                $this->scope([10]),
+                20,
+                new DateTimeImmutable('2026-08-06T14:15:16+03:00'),
+                new DateTimeImmutable('2026-08-01'),
+                new DateTimeImmutable('2026-08-06'),
+            );
+        } catch (ReportContractException $exception) {
+            self::assertSame(ReportErrorCode::REPORT_SCOPE_FORBIDDEN, $exception->errorCode);
+
+            throw $exception;
+        }
+    }
+
+    public function test_narrowing_keeps_other_project_resource_restrictions_fail_closed(): void
+    {
+        $resource = new ReportScopedResource('work', 102, 20);
+        $options = $this->service(
+            AcceptedProductionOptionsSourceSnapshot::available(
+                workIds: [],
+                actIds: [],
+                contractorIds: [],
+                unitCodes: [],
+                zones: [],
+                statuses: [],
+            ),
+            [$resource],
+        )->options(
+            $this->scope([10, 20], [$resource]),
+            10,
+            new DateTimeImmutable('2026-08-06T14:15:16+03:00'),
+            new DateTimeImmutable('2026-08-01'),
+            new DateTimeImmutable('2026-08-06'),
+        );
+
+        self::assertTrue($options['available']);
+        self::assertSame([], $options['works']);
+    }
+
+    /** @param list<ReportScopedResource> $expectedResources */
+    private function service(
+        AcceptedProductionOptionsSourceSnapshot $snapshot,
+        array $expectedResources = [],
+    ): AcceptedProductionOptionsService {
+        $source = new class($snapshot, $expectedResources) implements AcceptedProductionOptionsSource
+        {
+            /** @param list<ReportScopedResource> $expectedResources */
+            public function __construct(
+                private readonly AcceptedProductionOptionsSourceSnapshot $snapshot,
+                private readonly array $expectedResources,
+            ) {}
+
+            public function snapshot(ReportScope $scope, ReportQuery $query): AcceptedProductionOptionsSourceSnapshot
+            {
+                if ($scope->projectIds !== [10]
+                    || $query->scope->projectIds !== [10]
+                    || $query->filters->values['project_id'] !== 10
+                    || array_map(
+                        static fn (ReportScopedResource $resource): array => $resource->canonicalIdentity(),
+                        $scope->resources,
+                    ) !== array_map(
+                        static fn (ReportScopedResource $resource): array => $resource->canonicalIdentity(),
+                        $this->expectedResources,
+                    )
+                ) {
+                    throw new \LogicException('accepted_production_options_project_scope_invalid');
+                }
+
+                return $this->snapshot;
+            }
+        };
+
+        return new AcceptedProductionOptionsService(
+            $source,
+            new AcceptedProductionBuiltinPublishedReport(new AcceptedProductionCandidateContract),
+            $this->connection,
+        );
+    }
+
+    /**
+     * @param  list<int>  $projectIds
+     * @param  list<ReportScopedResource>  $resources
+     */
+    private function scope(array $projectIds = [10], array $resources = []): ReportScope
+    {
+        return new ReportScope(1, [1], $projectIds, $resources, new DateTimeZone('Europe/Moscow'));
+    }
+}

--- a/tests/Unit/Reporting/Http/AcceptedProductionOptionsRequestContractTest.php
+++ b/tests/Unit/Reporting/Http/AcceptedProductionOptionsRequestContractTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Http;
+
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\AcceptedProductionReportOptionsRequest;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use PHPUnit\Framework\TestCase;
+
+final class AcceptedProductionOptionsRequestContractTest extends TestCase
+{
+    public function test_client_cannot_replace_server_owned_context(): void
+    {
+        $rules = (new AcceptedProductionReportOptionsRequest)->rules();
+
+        foreach ([
+            'organization_id',
+            'current_organization_id',
+            'holding_organization_ids',
+            'organization_ids',
+            'project_id',
+            'current_project_id',
+            'project_ids',
+            'user_id',
+            'actor_id',
+            'scope',
+            'permissions',
+        ] as $field) {
+            self::assertContains('prohibited', $rules[$field]);
+        }
+    }
+
+    public function test_options_require_exact_as_of_and_period_boundaries(): void
+    {
+        $rules = (new AcceptedProductionReportOptionsRequest)->rules();
+
+        self::assertSame(['required', 'string'], array_slice($rules['as_of'], 0, 2));
+        self::assertSame(['required', 'string', 'date_format:Y-m-d'], $rules['period_from']);
+        self::assertSame(
+            ['required', 'string', 'date_format:Y-m-d', 'after_or_equal:period_from'],
+            $rules['period_to'],
+        );
+
+        $parsed = ReportAsOfParser::parse('2026-08-06T14:15:16.123456+03:00');
+        self::assertNotNull($parsed);
+        self::assertSame('123456', $parsed->format('u'));
+    }
+}

--- a/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
+++ b/tests/Unit/Reporting/Http/ProjectMarginCanonicalRouteContractTest.php
@@ -38,6 +38,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("Route::post('/projects/{project}/project-evm-control/runs'", $routes);
         self::assertStringContainsString("Route::get('/projects/{project}/project-evm-control/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/accepted-production-progress/runs'", $routes);
+        self::assertStringContainsString("Route::get('/projects/{project}/accepted-production-progress/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/wip-completion-forecast/runs'", $routes);
         self::assertStringContainsString("Route::get('/projects/{project}/wip-completion-forecast/options'", $routes);
         self::assertStringContainsString("Route::post('/projects/{project}/project-labor-cost/runs'", $routes);
@@ -47,7 +48,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("Route::post('/workforce-capacity/runs'", $routes);
         self::assertStringContainsString("Route::get('/workforce-capacity/options'", $routes);
         self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
-        self::assertSame(13, substr_count($routes, "'report.project-scope'"));
+        self::assertSame(14, substr_count($routes, "'report.project-scope'"));
 
         $middlewareFile = (new ReflectionClass(AuthorizeReportDefinitionAccess::class))->getFileName();
         self::assertIsString($middlewareFile);
@@ -58,6 +59,7 @@ final class ProjectMarginCanonicalRouteContractTest extends TestCase
         self::assertStringContainsString("'admin.reports.project-evm-control.runs.store'", $middleware);
         self::assertStringContainsString("'admin.reports.project-evm-control.options'", $middleware);
         self::assertStringContainsString("'admin.reports.accepted-production-progress.runs.store'", $middleware);
+        self::assertStringContainsString("'admin.reports.accepted-production-progress.options'", $middleware);
         self::assertStringContainsString("'admin.reports.wip-completion-forecast.runs.store'", $middleware);
         self::assertStringContainsString("'admin.reports.wip-completion-forecast.options'", $middleware);
         self::assertStringContainsString('private function genericCreateRun', $middleware);


### PR DESCRIPTION
Добавлен отдельный project-scoped options endpoint для R08: значения берутся из канонического event-universe, клиентский organization/project context запрещён, неполные источники и отсутствующие scoped-ссылки не возвращают частичные данные. Проверки: php -l для 13 изменённых PHP-файлов, git diff --check, независимое review CLEAN. PHPUnit/PHPStan локально недоступны из-за отсутствующего vendor.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new API endpoint to retrieve options for the 'accepted-production-progress' report.</li>
<li>Implemented AcceptedProductionReportOptionsController and AcceptedProductionReportOptionsRequest to handle report option requests.</li>
<li>Registered new services (AcceptedProductionOptionsService and AcceptedProductionOptionsSource) in the CompletedWorkReportingServiceProvider.</li>
<li>Updated middleware to authorize access to the new report options endpoint.</li>
<li>Added unit tests to verify the new request contract and service functionality.</li>
</ul></div>