### PR TITLE
fix[reports]: учтены разрывы истории изменений

### DIFF
--- a/database/migrations/2026_08_06_000210_create_change_claim_history_checkpoints.php
+++ b/database/migrations/2026_08_06_000210_create_change_claim_history_checkpoints.php
@@ -93,6 +93,7 @@ WITH boundary AS MATERIALIZED (
     SELECT
         request.organization_id,
         request.id,
+        version.id AS latest_version_id,
         jsonb_build_object(
             'request', to_jsonb(request),
             'project', COALESCE(to_jsonb(request_project), 'null'::jsonb),
@@ -126,6 +127,14 @@ WITH boundary AS MATERIALIZED (
       ON request_allocation.id = request.reporting_contract_project_allocation_id
     LEFT JOIN contracts AS request_contract
       ON request_contract.id = request_allocation.contract_id
+    LEFT JOIN LATERAL (
+        SELECT source.id
+        FROM change_request_versions AS source
+        WHERE source.organization_id = request.organization_id
+          AND source.change_request_id = request.id
+        ORDER BY source.id DESC
+        LIMIT 1
+    ) AS version ON true
     LEFT JOIN LATERAL (
         SELECT source.*
         FROM change_management_impacts AS source
@@ -162,6 +171,14 @@ WITH boundary AS MATERIALIZED (
         encode(sha256(convert_to(source_identity::text, 'UTF8')), 'hex') AS source_hash
     FROM request_projection
     WHERE unprojectable
+), request_version_gaps AS MATERIALIZED (
+    SELECT
+        organization_id,
+        'request_version_missing'::text AS gap_kind,
+        id AS source_id,
+        encode(sha256(convert_to(source_identity::text, 'UTF8')), 'hex') AS source_hash
+    FROM request_projection
+    WHERE latest_version_id IS NULL
 ), version_gaps AS MATERIALIZED (
     SELECT
         version.organization_id,
@@ -211,6 +228,18 @@ WITH boundary AS MATERIALIZED (
                'YYYY-MM-DD"T"HH24:MI:SS'
            ) || '+00:00'
        ))
+), version_workflow_event_gaps AS MATERIALIZED (
+    SELECT
+        version.organization_id,
+        'version_workflow_event_missing'::text AS gap_kind,
+        version.id AS source_id,
+        version.source_hash
+    FROM change_request_versions AS version
+    LEFT JOIN change_workflow_events AS event
+      ON event.organization_id = version.organization_id
+     AND event.change_request_id = version.change_request_id
+     AND event.version = version.version
+    WHERE event.id IS NULL
 ), workflow_event_gaps AS MATERIALIZED (
     SELECT
         event.organization_id,
@@ -238,6 +267,18 @@ WITH boundary AS MATERIALIZED (
                'YYYY-MM-DD"T"HH24:MI:SS'
            ) || '+00:00'
        ))
+), claim_link_missing_gaps AS MATERIALIZED (
+    SELECT
+        claim.organization_id,
+        'claim_link_missing'::text AS gap_kind,
+        claim.id AS source_id,
+        encode(sha256(convert_to(to_jsonb(claim)::text, 'UTF8')), 'hex') AS source_hash
+    FROM change_management_claims AS claim
+    LEFT JOIN change_claim_links AS link
+      ON link.organization_id = claim.organization_id
+     AND link.change_claim_id = claim.id
+    WHERE claim.change_request_id IS NOT NULL
+      AND link.id IS NULL
 ), claim_link_gaps AS MATERIALIZED (
     SELECT
         link.organization_id,
@@ -307,9 +348,15 @@ WITH boundary AS MATERIALIZED (
 ), integrity_gaps AS MATERIALIZED (
     SELECT * FROM request_gaps
     UNION ALL
+    SELECT * FROM request_version_gaps
+    UNION ALL
     SELECT * FROM version_gaps
     UNION ALL
+    SELECT * FROM version_workflow_event_gaps
+    UNION ALL
     SELECT * FROM workflow_event_gaps
+    UNION ALL
+    SELECT * FROM claim_link_missing_gaps
     UNION ALL
     SELECT * FROM claim_link_gaps
     UNION ALL

--- a/tests/Architecture/Reporting/ChangeClaimHistoryBoundaryContractTest.php
+++ b/tests/Architecture/Reporting/ChangeClaimHistoryBoundaryContractTest.php
@@ -52,8 +52,11 @@ final class ChangeClaimHistoryBoundaryContractTest extends TestCase
         self::assertStringContainsString('change_claim_history_checkpoints_append_only', $migration);
         foreach ([
             'request_source_incomplete',
+            'request_version_missing',
             'version_scope_drift',
+            'version_workflow_event_missing',
             'workflow_event_scope_drift',
+            'claim_link_missing',
             'claim_link_scope_drift',
             'ledger_scope_drift',
         ] as $gapKind) {
@@ -106,6 +109,14 @@ final class ChangeClaimHistoryBoundaryContractTest extends TestCase
         self::assertStringNotContainsString('INSERT INTO change_workflow_events', $migration);
         self::assertStringNotContainsString('ChangeClaimBackfill', $migration);
         self::assertStringNotContainsString('ChangeWorkflowEventRecorder', $migration);
+        self::assertStringContainsString(
+            'source.change_request_id = request.id',
+            $migration,
+        );
+        self::assertStringContainsString('latest_version_id IS NULL', $migration);
+        self::assertStringContainsString('event.id IS NULL', $migration);
+        self::assertStringContainsString('claim.change_request_id IS NOT NULL', $migration);
+        self::assertStringContainsString('link.id IS NULL', $migration);
     }
 
     #[Test]

--- a/tests/Feature/Reporting/FinanceOwnerPostgresContractTest.php
+++ b/tests/Feature/Reporting/FinanceOwnerPostgresContractTest.php
@@ -21,7 +21,9 @@ use App\Models\Organization;
 use App\Models\Project;
 use App\Models\User;
 use DateTimeImmutable;
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionMethod;
 use Tests\Support\Reporting\PostgresProcessRaceHarness;
@@ -238,6 +240,135 @@ WHERE checkpoint.source_hash IS DISTINCT FROM encode(sha256(convert_to(jsonb_bui
     'unprojectable_legacy_set_hash', checkpoint.unprojectable_legacy_set_hash
 )::text, 'UTF8')), 'hex')
 SQL));
+    }
+
+    #[Test]
+    public function change_claim_checkpoint_counts_inverse_coverage_gaps_with_a_stable_set_hash(): void
+    {
+        $organization = Organization::factory()->create();
+        $project = Project::factory()->create(['organization_id' => $organization->id]);
+        $user = User::factory()->create();
+        $recordedAt = new DateTimeImmutable('2026-08-06T18:15:30+00:00');
+        $contractorId = (int) DB::table('contractors')->insertGetId([
+            'organization_id' => $organization->id,
+            'name' => 'PG inverse coverage contractor',
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+        $contractId = (int) DB::table('contracts')->insertGetId([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'contractor_id' => $contractorId,
+            'number' => 'PG-INVERSE-'.bin2hex(random_bytes(4)),
+            'date' => '2026-08-06',
+            'total_amount' => '1000.00',
+            'currency' => 'RUB',
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+        $allocationId = (int) DB::table('contract_project_allocations')->insertGetId([
+            'contract_id' => $contractId,
+            'project_id' => $project->id,
+            'allocation_type' => 'fixed',
+            'allocated_amount' => '1000.00',
+            'is_active' => true,
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+
+        $missingVersionId = $this->insertLegacyChangeRequest(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $allocationId,
+            'missing-version',
+            $recordedAt,
+        );
+        $missingEventId = $this->insertLegacyChangeRequest(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $allocationId,
+            'missing-event',
+            $recordedAt,
+        );
+        $controlId = $this->insertLegacyChangeRequest(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $allocationId,
+            'control',
+            $recordedAt,
+        );
+
+        $missingEventVersionId = $this->insertChangeRequestVersion(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $contractId,
+            $allocationId,
+            $missingEventId,
+            $recordedAt,
+        );
+        $controlVersionId = $this->insertChangeRequestVersion(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $contractId,
+            $allocationId,
+            $controlId,
+            $recordedAt,
+        );
+        $this->insertChangeWorkflowEvent(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $controlId,
+            $recordedAt,
+        );
+        $missingLinkClaimId = $this->insertChangeClaim(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $missingEventId,
+            'missing-link',
+            $recordedAt,
+        );
+        $controlClaimId = $this->insertChangeClaim(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $user->id,
+            $controlId,
+            'control',
+            $recordedAt,
+        );
+        $this->insertChangeClaimLink(
+            (int) $organization->id,
+            $controlVersionId,
+            $controlClaimId,
+            $recordedAt,
+        );
+
+        self::assertGreaterThan(0, $missingVersionId);
+        self::assertGreaterThan(0, $missingEventVersionId);
+        self::assertGreaterThan(0, $missingLinkClaimId);
+
+        $this->rebuildChangeClaimHistoryCheckpoint();
+        $first = DB::table('change_claim_history_checkpoints')
+            ->where('organization_id', $organization->id)
+            ->sole();
+        self::assertSame(3, (int) $first->unprojectable_legacy_count);
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/D', trim((string) $first->unprojectable_legacy_set_hash));
+
+        $this->rebuildChangeClaimHistoryCheckpoint();
+        $second = DB::table('change_claim_history_checkpoints')
+            ->where('organization_id', $organization->id)
+            ->sole();
+        self::assertSame(3, (int) $second->unprojectable_legacy_count);
+        self::assertSame(
+            trim((string) $first->unprojectable_legacy_set_hash),
+            trim((string) $second->unprojectable_legacy_set_hash),
+        );
     }
 
     #[Test]
@@ -869,6 +1000,164 @@ SQL));
         } finally {
             DB::rollBack();
         }
+    }
+
+    private function insertLegacyChangeRequest(
+        int $organizationId,
+        int $projectId,
+        int $userId,
+        int $allocationId,
+        string $suffix,
+        DateTimeImmutable $recordedAt,
+    ): int {
+        $changeRequestId = (int) DB::table('change_management_change_requests')->insertGetId([
+            'organization_id' => $organizationId,
+            'project_id' => $projectId,
+            'created_by_user_id' => $userId,
+            'change_number' => 'PG-INVERSE-'.strtoupper($suffix).'-'.bin2hex(random_bytes(4)),
+            'title' => 'Inverse coverage '.$suffix,
+            'reason' => 'postgres_contract',
+            'description' => 'Inverse coverage contract fixture',
+            'initiator_type' => 'internal',
+            'status' => 'draft',
+            'reporting_currency' => 'RUB',
+            'reporting_contract_project_allocation_id' => $allocationId,
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+        DB::table('change_management_impacts')->insert([
+            'organization_id' => $organizationId,
+            'change_request_id' => $changeRequestId,
+            'cost_delta' => '100.00',
+            'schedule_delta_days' => 2,
+            'requires_contract_change' => false,
+            'requires_estimate_revision' => false,
+            'requires_procurement_update' => false,
+            'requires_customer_approval' => false,
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+
+        return $changeRequestId;
+    }
+
+    private function insertChangeRequestVersion(
+        int $organizationId,
+        int $projectId,
+        int $userId,
+        int $contractId,
+        int $allocationId,
+        int $changeRequestId,
+        DateTimeImmutable $recordedAt,
+    ): int {
+        $payload = [
+            'approved_cost_minor' => null,
+            'approved_schedule_days' => null,
+            'change_request_id' => $changeRequestId,
+            'contract_id' => $contractId,
+            'contract_project_allocation_id' => $allocationId,
+            'currency' => 'RUB',
+            'currency_source' => 'change_request_monetary_context',
+            'effective_at' => $recordedAt->format(DATE_ATOM),
+            'initiator_type' => 'internal',
+            'initiator_user_id' => $userId,
+            'organization_id' => $organizationId,
+            'owner_user_id' => null,
+            'project_id' => $projectId,
+            'proposed_cost_minor' => 10_000,
+            'proposed_schedule_days' => 2,
+            'reason' => 'postgres_contract',
+            'status' => 'draft',
+            'version' => 1,
+        ];
+
+        return (int) DB::table('change_request_versions')->insertGetId([
+            ...$payload,
+            'source_hash' => hash('sha256', CanonicalJson::encode($payload)),
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+    }
+
+    private function insertChangeWorkflowEvent(
+        int $organizationId,
+        int $projectId,
+        int $userId,
+        int $changeRequestId,
+        DateTimeImmutable $recordedAt,
+    ): void {
+        $payload = [
+            'actor_id' => $userId,
+            'change_request_id' => $changeRequestId,
+            'current_status' => 'draft',
+            'event_type' => 'create',
+            'occurred_at' => $recordedAt->format(DATE_ATOM),
+            'organization_id' => $organizationId,
+            'prior_status' => null,
+            'project_id' => $projectId,
+            'version' => 1,
+        ];
+        DB::table('change_workflow_events')->insert([
+            ...$payload,
+            'event_hash' => hash('sha256', CanonicalJson::encode($payload)),
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+    }
+
+    private function insertChangeClaim(
+        int $organizationId,
+        int $projectId,
+        int $userId,
+        int $changeRequestId,
+        string $suffix,
+        DateTimeImmutable $recordedAt,
+    ): int {
+        return (int) DB::table('change_management_claims')->insertGetId([
+            'organization_id' => $organizationId,
+            'project_id' => $projectId,
+            'change_request_id' => $changeRequestId,
+            'created_by_user_id' => $userId,
+            'claim_number' => 'PG-CLAIM-'.strtoupper($suffix).'-'.bin2hex(random_bytes(4)),
+            'title' => 'Inverse coverage '.$suffix,
+            'description' => 'Inverse coverage claim fixture',
+            'amount' => '125.00',
+            'status' => 'submitted',
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+    }
+
+    private function insertChangeClaimLink(
+        int $organizationId,
+        int $versionId,
+        int $claimId,
+        DateTimeImmutable $recordedAt,
+    ): void {
+        $payload = [
+            'change_claim_id' => $claimId,
+            'change_request_version_id' => $versionId,
+            'claim_amount_minor' => 12_500,
+            'claim_version' => 1,
+            'currency' => 'RUB',
+            'organization_id' => $organizationId,
+            'relationship_type' => 'claim',
+        ];
+        DB::table('change_claim_links')->insert([
+            ...$payload,
+            'source_hash' => hash('sha256', CanonicalJson::encode($payload)),
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+    }
+
+    private function rebuildChangeClaimHistoryCheckpoint(): void
+    {
+        Schema::drop('change_claim_history_checkpoints');
+        $migration = require dirname(__DIR__, 3)
+            .'/database/migrations/2026_08_06_000210_create_change_claim_history_checkpoints.php';
+        self::assertInstanceOf(Migration::class, $migration);
+        $migration->up();
     }
 
     private function createContractSettlementFoundationSchema(): void


### PR DESCRIPTION
Checkpoint R14 теперь fail-closed учитывает legacy-заявки без immutable version, версии без workflow event и связанные claims без immutable link. Добавлены architecture и isolated PostgreSQL contract-сценарии с точным gap count и стабильным set hash. Проверено: php -l трёх файлов, git diff --cached --check, независимое review CLEAN. Локальный PostgreSQL не запускался по запрету DB-команд; исходный deploy 31123486635 отменён до начала шагов.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added new integrity gap checks to the change claim history migration: request_version_missing, version_workflow_event_missing, and claim_link_missing.</li>
<li>Updated the migration SQL to identify and report these missing data relationships.</li>
<li>Added corresponding test cases in ChangeClaimHistoryBoundaryContractTest to verify the new gap detection logic.</li>
<li>Implemented a new feature test in FinanceOwnerPostgresContractTest to validate the integrity gap reporting with actual database records.</li>
</ul></div>