### PR TITLE
feat[reports]: подключён неизменяемый runtime R01

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/EloquentProjectPortfolioHealthSourceReader.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/EloquentProjectPortfolioHealthSourceReader.php
@@ -50,6 +50,7 @@ final readonly class EloquentProjectPortfolioHealthSourceReader implements Proje
                     static fn (string $kind): array => ['code' => 'owner_source_scope_incompatible', 'kind' => $kind],
                     ProjectPortfolioHealthSourceTupleAssembler::REQUIRED_KINDS,
                 ),
+                'calendar' => [],
             ];
         }
         $ownerRequest = [
@@ -270,8 +271,9 @@ final readonly class EloquentProjectPortfolioHealthSourceReader implements Proje
         if ($responsibilityCenterIds === null || $counterpartyIds === null || $currencies === null) {
             $gaps[] = ['code' => 'liquidity_source_scope_invalid', 'kind' => 'portfolio_liquidity'];
 
-            return ['components' => $components, 'gaps' => $gaps];
+            return ['components' => $components, 'gaps' => $gaps, 'calendar' => []];
         }
+        $calendar = [];
         try {
             $source = $this->liquidity->read(
                 $context->scope->organizationId,
@@ -317,7 +319,7 @@ final readonly class EloquentProjectPortfolioHealthSourceReader implements Proje
             $gaps[] = ['code' => 'liquidity_source_unavailable', 'kind' => 'portfolio_liquidity'];
         }
 
-        return ['components' => $components, 'gaps' => $gaps];
+        return ['components' => $components, 'gaps' => $gaps, 'calendar' => $calendar];
     }
 
     /** @return array<string, array{formula:string,schema:string}> */

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableOwnerPayloadBuilder.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableOwnerPayloadBuilder.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\Enums\CurrencyCode;
+use InvalidArgumentException;
+
+final class ProjectPortfolioHealthImmutableOwnerPayloadBuilder
+{
+    private const KINDS = [
+        'project_margin',
+        'wip_completion_forecast',
+        'budget_plan_fact',
+    ];
+
+    private const RISK_RANK = [
+        'low' => 1,
+        'medium' => 2,
+        'high' => 3,
+        'critical' => 4,
+    ];
+
+    public function build(array $rowsByKind): array
+    {
+        foreach (self::KINDS as $kind) {
+            if (! isset($rowsByKind[$kind])
+                || ! is_array($rowsByKind[$kind])
+                || ! array_is_list($rowsByKind[$kind])
+                || $rowsByKind[$kind] === []) {
+                throw new InvalidArgumentException('project_portfolio_health_owner_rows_invalid');
+            }
+        }
+
+        $marginRows = $this->marginRows($rowsByKind['project_margin']);
+        $wipRows = $this->wipRows($rowsByKind['wip_completion_forecast']);
+        $forecastMargins = [];
+        foreach ($marginRows as $row) {
+            $forecastMargins[$this->payloadKey($row)] = $row['forecast']['gross_margin'];
+        }
+        foreach ($wipRows as &$row) {
+            $key = $this->payloadKey($row);
+            if (isset($forecastMargins[$key])) {
+                $row['metrics']['forecast_gross_margin'] = $forecastMargins[$key];
+            }
+        }
+        unset($row);
+
+        return [
+            'project_margin' => ['rows' => $marginRows],
+            'wip_completion_forecast' => ['rows' => $wipRows],
+            'budget_plan_fact' => ['rows' => $this->planFactRows($rowsByKind['budget_plan_fact'])],
+        ];
+    }
+
+    private function marginRows(array $rows): array
+    {
+        $buckets = [];
+        foreach ($rows as $row) {
+            $identity = $this->identity($row);
+            $key = $identity['key'];
+            $buckets[$key] ??= [
+                ...$identity,
+                'actual_revenue_minor' => 0,
+                'actual_cost_minor' => 0,
+                'forecast_revenue_minor' => 0,
+                'forecast_cost_minor' => 0,
+                'source_refs' => [],
+            ];
+            $this->assertSameProject($buckets[$key], $identity);
+            foreach ([
+                'actual_revenue_minor',
+                'actual_cost_minor',
+                'forecast_revenue_minor',
+                'forecast_cost_minor',
+            ] as $field) {
+                $buckets[$key][$field] = $this->checkedAdd(
+                    $buckets[$key][$field],
+                    $this->minor($row[$field] ?? null),
+                );
+            }
+            $this->mergeSourceRefs($buckets[$key]['source_refs'], $row['source_refs'] ?? null);
+        }
+
+        return $this->sorted(array_map(function (array $bucket): array {
+            $actualRevenue = $this->money($bucket['actual_revenue_minor']);
+            $actualCost = $this->money($bucket['actual_cost_minor']);
+            $forecastRevenue = $this->money($bucket['forecast_revenue_minor']);
+            $forecastCost = $this->money($bucket['forecast_cost_minor']);
+
+            return [
+                'project' => ['id' => $bucket['project_id'], 'name' => $bucket['project_name']],
+                'currency' => $bucket['currency'],
+                'actual' => [
+                    'revenue' => $actualRevenue,
+                    'cost' => $actualCost,
+                    'gross_margin' => $this->money($this->checkedSubtract(
+                        $bucket['actual_revenue_minor'],
+                        $bucket['actual_cost_minor'],
+                    )),
+                ],
+                'forecast' => [
+                    'revenue' => $forecastRevenue,
+                    'cost' => $forecastCost,
+                    'gross_margin' => $this->money($this->checkedSubtract(
+                        $bucket['forecast_revenue_minor'],
+                        $bucket['forecast_cost_minor'],
+                    )),
+                ],
+                'source_refs' => array_values($bucket['source_refs']),
+            ];
+        }, array_values($buckets)));
+    }
+
+    private function wipRows(array $rows): array
+    {
+        $buckets = [];
+        foreach ($rows as $row) {
+            $identity = $this->identity($row);
+            $key = $identity['key'];
+            $buckets[$key] ??= [
+                ...$identity,
+                'ac_minor' => 0,
+                'wip_minor' => 0,
+                'ctc_minor' => 0,
+                'eac_minor' => 0,
+                'source_refs' => [],
+            ];
+            $this->assertSameProject($buckets[$key], $identity);
+            foreach (['ac_minor', 'wip_minor', 'ctc_minor', 'eac_minor'] as $field) {
+                $buckets[$key][$field] = $this->checkedAdd(
+                    $buckets[$key][$field],
+                    $this->minor($row[$field] ?? null),
+                );
+            }
+            $this->mergeSourceRefs($buckets[$key]['source_refs'], $row['source_refs'] ?? null);
+        }
+
+        return $this->sorted(array_map(function (array $bucket): array {
+            return [
+                'project' => ['id' => $bucket['project_id'], 'name' => $bucket['project_name']],
+                'currency' => $bucket['currency'],
+                'metrics' => [
+                    'wip' => $this->money($bucket['wip_minor']),
+                    'wip_total' => $this->money($bucket['wip_minor']),
+                    'ftc' => $this->money($this->checkedSubtract($bucket['eac_minor'], $bucket['ac_minor'])),
+                    'eac' => $this->money($bucket['eac_minor']),
+                    'ctc' => $this->money($bucket['ctc_minor']),
+                ],
+                'source_refs' => array_values($bucket['source_refs']),
+            ];
+        }, array_values($buckets)));
+    }
+
+    private function planFactRows(array $rows): array
+    {
+        $buckets = [];
+        foreach ($rows as $row) {
+            $identity = $this->identity($row);
+            $key = $identity['key'];
+            $risk = $row['risk'] ?? null;
+            if (! is_string($risk) || ! array_key_exists($risk, self::RISK_RANK)) {
+                throw new InvalidArgumentException('project_portfolio_health_owner_risk_invalid');
+            }
+            $buckets[$key] ??= [
+                ...$identity,
+                'variance_minor' => 0,
+                'risk' => 'low',
+                'source_refs' => [],
+            ];
+            $this->assertSameProject($buckets[$key], $identity);
+            $buckets[$key]['variance_minor'] = $this->checkedAdd(
+                $buckets[$key]['variance_minor'],
+                $this->minor($row['variance_minor'] ?? null),
+            );
+            if (self::RISK_RANK[$risk] > self::RISK_RANK[$buckets[$key]['risk']]) {
+                $buckets[$key]['risk'] = $risk;
+            }
+            $this->mergeSourceRefs($buckets[$key]['source_refs'], $row['source_refs'] ?? null);
+        }
+
+        return $this->sorted(array_map(function (array $bucket): array {
+            return [
+                'project' => ['id' => $bucket['project_id'], 'name' => $bucket['project_name']],
+                'currency' => $bucket['currency'],
+                'variance_amount' => $this->money($bucket['variance_minor']),
+                'risk_level' => $bucket['risk'],
+                'source_refs' => array_values($bucket['source_refs']),
+            ];
+        }, array_values($buckets)));
+    }
+
+    private function identity(mixed $row): array
+    {
+        if (! is_array($row)
+            || ! is_string($row['row_key'] ?? null)
+            || trim($row['row_key']) === ''
+            || (! is_int($row['project_id'] ?? null)
+                && (! is_string($row['project_id'] ?? null)
+                    || preg_match('/^[1-9][0-9]*$/D', $row['project_id']) !== 1))
+            || (int) $row['project_id'] < 1
+            || ! is_string($row['project_name'] ?? null)
+            || trim($row['project_name']) === ''
+            || ! is_string($row['currency'] ?? null)) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_row_invalid');
+        }
+        $currency = mb_strtoupper(trim($row['currency']));
+        if (CurrencyCode::tryFrom($currency) === null) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_currency_invalid');
+        }
+        $projectId = (int) $row['project_id'];
+
+        return [
+            'key' => $projectId.'|'.$currency,
+            'project_id' => $projectId,
+            'project_name' => trim($row['project_name']),
+            'currency' => $currency,
+        ];
+    }
+
+    private function assertSameProject(array $bucket, array $identity): void
+    {
+        if ($bucket['project_id'] !== $identity['project_id']
+            || $bucket['project_name'] !== $identity['project_name']
+            || $bucket['currency'] !== $identity['currency']) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_identity_conflict');
+        }
+    }
+
+    private function mergeSourceRefs(array &$target, mixed $sourceRefs): void
+    {
+        if (! is_array($sourceRefs) || ! array_is_list($sourceRefs)) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_source_refs_invalid');
+        }
+        foreach ($sourceRefs as $sourceRef) {
+            if (! is_array($sourceRef)
+                || ! is_string($sourceRef['type'] ?? null)
+                || trim($sourceRef['type']) === ''
+                || (! is_int($sourceRef['id'] ?? null) && ! is_string($sourceRef['id'] ?? null))
+                || trim((string) $sourceRef['id']) === ''
+                || (is_int($sourceRef['id']) && $sourceRef['id'] < 1)) {
+                throw new InvalidArgumentException('project_portfolio_health_owner_source_refs_invalid');
+            }
+            $type = trim($sourceRef['type']);
+            $id = $sourceRef['id'];
+            $target[$type.':'.(string) $id] = ['type' => $type, 'id' => $id];
+        }
+        ksort($target, SORT_STRING);
+    }
+
+    private function minor(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (! is_string($value) || preg_match('/^-?(?:0|[1-9][0-9]*)$/D', $value) !== 1) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_minor_invalid');
+        }
+        $normalized = (int) $value;
+        if ((string) $normalized !== ltrim($value, '+')) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_minor_invalid');
+        }
+
+        return $normalized;
+    }
+
+    private function checkedAdd(int $left, int $right): int
+    {
+        if (($right > 0 && $left > PHP_INT_MAX - $right)
+            || ($right < 0 && $left < PHP_INT_MIN - $right)) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_minor_overflow');
+        }
+
+        return $left + $right;
+    }
+
+    private function checkedSubtract(int $left, int $right): int
+    {
+        if (($right < 0 && $left > PHP_INT_MAX + $right)
+            || ($right > 0 && $left < PHP_INT_MIN + $right)) {
+            throw new InvalidArgumentException('project_portfolio_health_owner_minor_overflow');
+        }
+
+        return $left - $right;
+    }
+
+    private function money(int $minor): string
+    {
+        $whole = intdiv($minor, 100);
+        $fraction = abs($minor % 100);
+        $prefix = $minor < 0 && $whole === 0 ? '-' : '';
+
+        return $prefix.$whole.'.'.str_pad((string) $fraction, 2, '0', STR_PAD_LEFT);
+    }
+
+    private function sorted(array $rows): array
+    {
+        usort($rows, static fn (array $left, array $right): int => [
+            $left['project']['id'],
+            $left['currency'],
+        ] <=> [
+            $right['project']['id'],
+            $right['currency'],
+        ]);
+
+        return $rows;
+    }
+
+    private function payloadKey(array $row): string
+    {
+        $project = is_array($row['project'] ?? null) ? $row['project'] : [];
+
+        return (string) ($project['id'] ?? '').'|'.(string) ($row['currency'] ?? '');
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableProjectionService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableProjectionService.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResult;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportFreshnessStatus;
+use App\BusinessModules\Features\Budgeting\DTOs\CfoCommandCenterFilters;
+use App\BusinessModules\Features\Budgeting\Services\CfoProjectPortfolioAggregator;
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+final readonly class ProjectPortfolioHealthImmutableProjectionService
+{
+    public function __construct(
+        private ProjectPortfolioHealthImmutableSource $sources,
+        private BudgetingPortfolioProjectionService $snapshots,
+        private CfoProjectPortfolioAggregator $aggregator,
+    ) {}
+
+    public function materialize(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): ReportSnapshotRef {
+        $this->assertQuery($context, $query);
+        $projectIds = $this->effectiveProjectIds($context, $query);
+        $selection = $this->sources->load($context, $query);
+        try {
+            $projects = $selection->projects();
+        } catch (InvalidArgumentException) {
+            $this->unavailable();
+        }
+        if (! isset($projects) || array_keys($projects) !== $projectIds) {
+            $this->unavailable();
+        }
+        $filters = $this->filters($context, $query, $projectIds);
+        $progress->advance(20);
+        $margin = $selection->ownerPayloads['project_margin'];
+        $progress->advance(40);
+        $wip = $selection->ownerPayloads['wip_completion_forecast'];
+        $planFact = $selection->ownerPayloads['budget_plan_fact'];
+        $progress->advance(60);
+
+        $projection = $this->aggregator->buildResult(
+            $filters,
+            $projects,
+            $margin,
+            $wip,
+            $planFact['rows'],
+            $selection->calendar,
+            $query->asOf->format(DATE_ATOM),
+            max(1, count($projects)),
+            seedProjects: false,
+        );
+        if ($projection->rows === []) {
+            $this->unavailable();
+        }
+
+        try {
+            $snapshot = $this->snapshots->persistHealth(
+                $context,
+                $query,
+                $projection,
+                $selection->sourceHash(),
+                $selection->watermarks(),
+                $selection->sourceRefs(),
+                ReportFreshnessStatus::FRESH,
+                [],
+            );
+        } catch (InvalidArgumentException) {
+            $this->unavailable();
+        }
+        $progress->advance(100);
+
+        return $snapshot;
+    }
+
+    public function result(
+        ReportExecutionContext $context,
+        ReportSnapshotRef $snapshot,
+    ): ReportResult {
+        return $this->snapshots->result(
+            $context,
+            $snapshot,
+            BudgetingPortfolioProjectionService::HEALTH_CODE,
+        );
+    }
+
+    private function assertQuery(ReportExecutionContext $context, ReportQuery $query): void
+    {
+        if ($query->definition->code !== BudgetingPortfolioProjectionService::HEALTH_CODE) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR);
+        }
+        if ($query->scope->canonicalIdentity() !== $context->scope->canonicalIdentity()) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+        }
+    }
+
+    private function filters(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        array $projectIds,
+    ): CfoCommandCenterFilters {
+        $values = $query->filters->values;
+        $periodStart = $this->dateFilter(
+            $values['period_from'] ?? null,
+            $query->asOf->format('Y-m-d'),
+        );
+        $periodEnd = $this->dateFilter(
+            $values['period_to'] ?? null,
+            $query->asOf->format('Y-m-d'),
+        );
+        if ($periodEnd < $periodStart) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_RANGE_INVALID);
+        }
+        $responsibilityCenterIds = $this->positiveIds($values['responsibility_center_ids'] ?? []);
+        $counterpartyIds = $this->positiveIds($values['counterparty_ids'] ?? []);
+
+        return new CfoCommandCenterFilters(
+            organizationId: $context->scope->organizationId,
+            periodStart: $periodStart,
+            periodEnd: $periodEnd,
+            projectId: count($projectIds) === 1 ? $projectIds[0] : null,
+            projectManagerUserId: $this->firstPositiveInt($values['manager_ids'] ?? null),
+            projectStatus: $this->firstString($values['project_statuses'] ?? null),
+            responsibilityCenterId: count($responsibilityCenterIds) === 1
+                ? $responsibilityCenterIds[0]
+                : null,
+            counterpartyId: count($counterpartyIds) === 1 ? $counterpartyIds[0] : null,
+            currency: $this->singleCurrency($values['currencies'] ?? null),
+            itemLimit: 50,
+        );
+    }
+
+    private function effectiveProjectIds(ReportExecutionContext $context, ReportQuery $query): array
+    {
+        $scopeIds = $context->scope->projectIds;
+        if ($scopeIds === []) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+        }
+        $filterIds = $this->positiveIds($query->filters->values['project_ids'] ?? []);
+        if ($filterIds === []) {
+            return $scopeIds;
+        }
+        $effectiveIds = array_values(array_intersect($scopeIds, $filterIds));
+        if (count($effectiveIds) !== count($filterIds)) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+        }
+
+        return $effectiveIds;
+    }
+
+    private function positiveIds(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            return [];
+        }
+        $ids = [];
+        foreach ($value as $id) {
+            if ((is_int($id) || (is_string($id) && ctype_digit($id))) && (int) $id > 0) {
+                $ids[(int) $id] = (int) $id;
+            }
+        }
+        $ids = array_values($ids);
+        sort($ids, SORT_NUMERIC);
+
+        return $ids;
+    }
+
+    private function strings(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $value,
+            static fn (mixed $item): bool => is_string($item) && trim($item) !== '',
+        ));
+    }
+
+    private function firstPositiveInt(mixed $value): ?int
+    {
+        return $this->positiveIds($value)[0] ?? null;
+    }
+
+    private function firstString(mixed $value): ?string
+    {
+        return $this->strings($value)[0] ?? null;
+    }
+
+    private function singleCurrency(mixed $value): ?string
+    {
+        $currencies = $this->strings($value);
+
+        return count($currencies) === 1 ? mb_strtoupper($currencies[0]) : null;
+    }
+
+    private function dateFilter(mixed $value, string $default): string
+    {
+        $candidate = is_string($value) ? $value : $this->firstString($value);
+        if ($candidate === null) {
+            return $default;
+        }
+        $date = DateTimeImmutable::createFromFormat('!Y-m-d', $candidate);
+        if (! $date instanceof DateTimeImmutable || $date->format('Y-m-d') !== $candidate) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_RANGE_INVALID);
+        }
+
+        return $candidate;
+    }
+
+    private function unavailable(): never
+    {
+        throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSource.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSource.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\Models\ProjectFinanceSnapshot;
+use App\Support\Reporting\StableReportingSourceView;
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+final readonly class ProjectPortfolioHealthImmutableSource
+{
+    public function __construct(
+        private ProjectPortfolioHealthSourceReader $sources,
+        private ProjectPortfolioHealthImmutableOwnerPayloadBuilder $payloads,
+        private StableReportingSourceView $stableView,
+    ) {}
+
+    public function load(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+    ): ProjectPortfolioHealthImmutableSourceSelection {
+        return $this->stableView->capture(fn (): ProjectPortfolioHealthImmutableSourceSelection => $this->capture(
+            $context,
+            $query,
+        ));
+    }
+
+    private function capture(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+    ): ProjectPortfolioHealthImmutableSourceSelection {
+        try {
+            $read = $this->sources->read($context, $query);
+        } catch (InvalidArgumentException) {
+            $this->unavailable();
+        }
+        if (! is_array($read['components'] ?? null)
+            || ! array_is_list($read['components'])
+            || ! is_array($read['gaps'] ?? null)
+            || ! array_is_list($read['gaps'])
+            || ! is_array($read['calendar'] ?? null)
+            || ! array_is_list($read['calendar'])) {
+            $this->unavailable();
+        }
+        foreach ($read['calendar'] as $item) {
+            if (! $item instanceof PaymentCalendarItem) {
+                $this->unavailable();
+            }
+        }
+        try {
+            $tuple = (new ProjectPortfolioHealthSourceTupleAssembler)->assemble(
+                $read['components'],
+                $read['gaps'],
+            );
+        } catch (InvalidArgumentException) {
+            $this->unavailable();
+        }
+        if (! isset($tuple) || ! $tuple->isReady()) {
+            $this->unavailable();
+        }
+
+        $rowsByKind = [];
+        $rowCounts = [];
+        foreach ($tuple->components as $component) {
+            if ($component->kind === 'portfolio_liquidity') {
+                continue;
+            }
+            $snapshot = ProjectFinanceSnapshot::query()
+                ->whereKey($component->snapshotId)
+                ->where('organization_id', $context->scope->organizationId)
+                ->where('report_code', $component->kind)
+                ->where('source_hash', $component->sourceHash)
+                ->first();
+            if (! $snapshot instanceof ProjectFinanceSnapshot) {
+                $this->unavailable();
+            }
+            $rows = $snapshot->rows()
+                ->where('organization_id', $context->scope->organizationId)
+                ->where('report_code', $component->kind)
+                ->orderBy('row_key')
+                ->get();
+            $asOf = $snapshot->as_of?->getTimestamp();
+            $expectedAsOf = (new DateTimeImmutable($component->asOf))->getTimestamp();
+            $version = trim((string) $snapshot->formula_version)
+                .'|'.trim((string) $snapshot->source_schema_version);
+            if ($asOf !== $expectedAsOf
+                || $version !== $component->version
+                || (string) $snapshot->quality_status !== 'complete'
+                || (int) $snapshot->row_count !== $rows->count()
+                || (int) $snapshot->coverage_numerator !== $rows->count()
+                || (int) $snapshot->coverage_denominator !== $rows->count()
+                || $rows->isEmpty()) {
+                $this->unavailable();
+            }
+            $rowsByKind[$component->kind] = $rows
+                ->map(static fn (object $row): array => $row->toArray())
+                ->all();
+            $rowCounts[$component->kind] = $rows->count();
+        }
+
+        try {
+            $ownerPayloads = $this->payloads->build($rowsByKind);
+
+            return new ProjectPortfolioHealthImmutableSourceSelection(
+                $tuple,
+                $ownerPayloads,
+                $read['calendar'],
+                $rowCounts,
+            );
+        } catch (InvalidArgumentException) {
+            $this->unavailable();
+        }
+    }
+
+    private function unavailable(): never
+    {
+        throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSourceSelection.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSourceSelection.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceRef;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use InvalidArgumentException;
+
+final readonly class ProjectPortfolioHealthImmutableSourceSelection
+{
+    public function __construct(
+        public ProjectPortfolioHealthSourceTuple $tuple,
+        public array $ownerPayloads,
+        public array $calendar,
+        private array $rowCounts,
+    ) {
+        if (! $tuple->isReady()
+            || ! isset(
+                $ownerPayloads['project_margin']['rows'],
+                $ownerPayloads['wip_completion_forecast']['rows'],
+                $ownerPayloads['budget_plan_fact']['rows'],
+            )) {
+            throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+        }
+        foreach (['project_margin', 'wip_completion_forecast', 'budget_plan_fact'] as $kind) {
+            if (! is_array($ownerPayloads[$kind]['rows'])
+                || ! array_is_list($ownerPayloads[$kind]['rows'])
+                || $ownerPayloads[$kind]['rows'] === []
+                || ! is_int($rowCounts[$kind] ?? null)
+                || $rowCounts[$kind] < 1) {
+                throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+            }
+        }
+        if (! array_is_list($calendar)) {
+            throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+        }
+        foreach ($calendar as $item) {
+            if (! $item instanceof PaymentCalendarItem) {
+                throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+            }
+        }
+        $this->projects();
+    }
+
+    public function sourceHash(): Sha256Hash
+    {
+        return new Sha256Hash($this->tuple->watermark);
+    }
+
+    public function sourceRefs(): array
+    {
+        $refs = [];
+        foreach ($this->tuple->components as $component) {
+            $rowCount = $component->kind === 'portfolio_liquidity'
+                ? count($this->calendar)
+                : $this->rowCounts[$component->kind];
+            $refs[] = new ReportSourceRef(
+                source: $component->kind,
+                snapshotKind: $component->kind,
+                snapshotId: $this->identifier($component->snapshotId, 'snapshot'),
+                schemaVersion: $this->identifier($component->version, 'schema'),
+                watermark: 'watermark_'.substr($component->sourceHash, 0, 24),
+                rowCount: $rowCount,
+                hash: new Sha256Hash($component->sourceHash),
+            );
+        }
+
+        return $refs;
+    }
+
+    public function watermarks(): array
+    {
+        $watermarks = ['source_tuple' => $this->tuple->watermark];
+        foreach ($this->tuple->components as $component) {
+            $watermarks[$component->kind] = $component->sourceHash;
+        }
+        ksort($watermarks, SORT_STRING);
+
+        return $watermarks;
+    }
+
+    public function projects(): array
+    {
+        $projects = [];
+        foreach ($this->ownerPayloads as $payload) {
+            foreach ($payload['rows'] as $row) {
+                $project = is_array($row['project'] ?? null) ? $row['project'] : [];
+                $id = $project['id'] ?? null;
+                $name = $project['name'] ?? null;
+                if (! is_int($id) || $id < 1 || ! is_string($name) || trim($name) === '') {
+                    throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+                }
+                if (isset($projects[$id]) && $projects[$id]['name'] !== $name) {
+                    throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+                }
+                $projects[$id] = ['id' => $id, 'name' => $name, 'status' => null];
+            }
+        }
+        if ($projects === []) {
+            throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+        }
+        ksort($projects, SORT_NUMERIC);
+
+        return $projects;
+    }
+
+    private function identifier(string $value, string $prefix): string
+    {
+        $normalized = preg_replace('/[^a-z0-9_]/', '_', mb_strtolower(trim($value)));
+        if (! is_string($normalized) || $normalized === '' || preg_match('/^[a-z]/D', $normalized) !== 1) {
+            $normalized = $prefix.'_'.substr(hash('sha256', $value), 0, 24);
+        }
+
+        return substr($normalized, 0, 64);
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthProvider.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthProvider.php
@@ -13,7 +13,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 
 final readonly class ProjectPortfolioHealthProvider implements ReportDataProvider
 {
-    public function __construct(private BudgetingPortfolioProjectionService $projection) {}
+    public function __construct(private ProjectPortfolioHealthImmutableProjectionService $projection) {}
 
     public function materialize(ReportExecutionContext $context, ReportQuery $query, ReportProgress $progress): ReportSnapshotRef
     {
@@ -21,7 +21,6 @@ final readonly class ProjectPortfolioHealthProvider implements ReportDataProvide
             $context,
             $query,
             $progress,
-            BudgetingPortfolioProjectionService::HEALTH_CODE,
         );
     }
 
@@ -30,7 +29,6 @@ final readonly class ProjectPortfolioHealthProvider implements ReportDataProvide
         return $this->projection->result(
             $context,
             $snapshot,
-            BudgetingPortfolioProjectionService::HEALTH_CODE,
         );
     }
 }

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceReader.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceReader.php
@@ -9,6 +9,6 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 
 interface ProjectPortfolioHealthSourceReader
 {
-    /** @return array{components:list<ProjectPortfolioHealthSourceComponent>,gaps:list<array{code:string,kind?:string}>} */
+    /** @return array{components:list<ProjectPortfolioHealthSourceComponent>,gaps:list<array{code:string,kind?:string}>,calendar:list<\App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem>} */
     public function read(ReportExecutionContext $context, ReportQuery $query): array;
 }

--- a/app/BusinessModules/Features/Budgeting/Services/CfoProjectPortfolioAggregator.php
+++ b/app/BusinessModules/Features/Budgeting/Services/CfoProjectPortfolioAggregator.php
@@ -49,8 +49,17 @@ final class CfoProjectPortfolioAggregator
         array $calendarItems,
         string $generatedAt,
         int $itemLimit,
+        bool $seedProjects = true,
     ): ProjectPortfolioProjectionResult {
-        $rows = $this->rows($filters, $projects, $marginReport, $wipReport, $planFactItems, $calendarItems);
+        $rows = $this->rows(
+            $filters,
+            $projects,
+            $marginReport,
+            $wipReport,
+            $planFactItems,
+            $calendarItems,
+            $seedProjects,
+        );
         $summary = $this->summary($projects, $rows, $marginReport, $wipReport);
 
         return ProjectPortfolioProjectionResult::fromAggregator($rows, [
@@ -77,16 +86,19 @@ final class CfoProjectPortfolioAggregator
         array $wipReport,
         array $planFactItems,
         array $calendarItems,
+        bool $seedProjects,
     ): array {
         $rows = [];
 
-        foreach ($projects as $project) {
-            if (! is_array($project) || ! isset($project['id'])) {
-                continue;
-            }
+        if ($seedProjects) {
+            foreach ($projects as $project) {
+                if (! is_array($project) || ! isset($project['id'])) {
+                    continue;
+                }
 
-            $currency = $this->currency($filters->currency);
-            $rows[$this->key((int) $project['id'], $currency)] = $this->emptyRow($project, $currency, $filters);
+                $currency = $this->currency($filters->currency);
+                $rows[$this->key((int) $project['id'], $currency)] = $this->emptyRow($project, $currency, $filters);
+            }
         }
 
         foreach (($marginReport['rows'] ?? []) as $row) {

--- a/tests/Support/Budgeting/project_portfolio_health_immutable_owner_payload_harness.php
+++ b/tests/Support/Budgeting/project_portfolio_health_immutable_owner_payload_harness.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/../../../app/Enums/CurrencyCode.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableOwnerPayloadBuilder.php';
+
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthImmutableOwnerPayloadBuilder;
+
+$sourceRefs = static fn (string $type, int $id): array => [['type' => $type, 'id' => $id]];
+
+$payload = (new ProjectPortfolioHealthImmutableOwnerPayloadBuilder)->build([
+    'project_margin' => [
+        [
+            'row_key' => 'margin-1',
+            'project_id' => 10,
+            'project_name' => 'Проект 10',
+            'currency' => 'RUB',
+            'actual_revenue_minor' => 10050,
+            'actual_cost_minor' => 7025,
+            'forecast_revenue_minor' => 15000,
+            'forecast_cost_minor' => 9000,
+            'source_refs' => $sourceRefs('approved_act', 101),
+        ],
+    ],
+    'wip_completion_forecast' => [
+        [
+            'row_key' => 'wip-1',
+            'project_id' => 10,
+            'project_name' => 'Проект 10',
+            'currency' => 'RUB',
+            'ac_minor' => 4000,
+            'wip_minor' => 1200,
+            'ctc_minor' => 8000,
+            'eac_minor' => 10000,
+            'source_refs' => $sourceRefs('earned_value', 201),
+        ],
+        [
+            'row_key' => 'wip-2',
+            'project_id' => 10,
+            'project_name' => 'Проект 10',
+            'currency' => 'RUB',
+            'ac_minor' => 1000,
+            'wip_minor' => 300,
+            'ctc_minor' => 2000,
+            'eac_minor' => 2500,
+            'source_refs' => $sourceRefs('actual_cost', 202),
+        ],
+    ],
+    'budget_plan_fact' => [
+        [
+            'row_key' => 'plan-1',
+            'project_id' => 10,
+            'project_name' => 'Проект 10',
+            'currency' => 'RUB',
+            'variance_minor' => -250,
+            'risk' => 'medium',
+            'source_refs' => $sourceRefs('budget_line', 301),
+        ],
+        [
+            'row_key' => 'plan-2',
+            'project_id' => 10,
+            'project_name' => 'Проект 10',
+            'currency' => 'RUB',
+            'variance_minor' => 100,
+            'risk' => 'high',
+            'source_refs' => $sourceRefs('budget_line', 302),
+        ],
+    ],
+]);
+
+assert($payload['project_margin']['rows'][0]['actual']['revenue'] === '100.50');
+assert($payload['project_margin']['rows'][0]['actual']['cost'] === '70.25');
+assert($payload['project_margin']['rows'][0]['forecast']['gross_margin'] === '60.00');
+assert($payload['wip_completion_forecast']['rows'][0]['metrics']['wip_total'] === '15.00');
+assert($payload['wip_completion_forecast']['rows'][0]['metrics']['ftc'] === '75.00');
+assert($payload['wip_completion_forecast']['rows'][0]['metrics']['eac'] === '125.00');
+assert($payload['wip_completion_forecast']['rows'][0]['metrics']['ctc'] === '100.00');
+assert($payload['wip_completion_forecast']['rows'][0]['metrics']['forecast_gross_margin'] === '60.00');
+assert($payload['budget_plan_fact']['rows'][0]['variance_amount'] === '-1.50');
+assert($payload['budget_plan_fact']['rows'][0]['risk_level'] === 'high');
+assert(count($payload['wip_completion_forecast']['rows'][0]['source_refs']) === 2);
+
+$failedClosed = false;
+try {
+    (new ProjectPortfolioHealthImmutableOwnerPayloadBuilder)->build([
+        'project_margin' => [],
+        'wip_completion_forecast' => [],
+        'budget_plan_fact' => [],
+    ]);
+} catch (InvalidArgumentException) {
+    $failedClosed = true;
+}
+assert($failedClosed);
+
+$persistedShape = [
+    'project_margin' => [[...$payload['project_margin']['rows'][0],
+        'row_key' => 'persisted-margin',
+        'project_id' => 10,
+        'project_name' => 'Проект 10',
+        'actual_revenue_minor' => 10050,
+        'actual_cost_minor' => 7025,
+        'forecast_revenue_minor' => 15000,
+        'forecast_cost_minor' => 9000,
+        'source_refs' => [],
+    ]],
+    'wip_completion_forecast' => [[
+        'row_key' => 'persisted-wip',
+        'project_id' => 10,
+        'project_name' => 'Проект 10',
+        'currency' => 'RUB',
+        'ac_minor' => 5000,
+        'wip_minor' => 1500,
+        'ctc_minor' => 10000,
+        'eac_minor' => 12500,
+        'source_refs' => [],
+    ]],
+    'budget_plan_fact' => [[
+        'row_key' => 'persisted-plan-fact',
+        'project_id' => 10,
+        'project_name' => 'Проект 10',
+        'currency' => 'RUB',
+        'variance_minor' => -150,
+        'risk' => 'high',
+        'source_refs' => [],
+    ]],
+];
+$persistedPayload = (new ProjectPortfolioHealthImmutableOwnerPayloadBuilder)->build($persistedShape);
+assert($persistedPayload['project_margin']['rows'][0]['source_refs'] === []);
+assert($persistedPayload['wip_completion_forecast']['rows'][0]['source_refs'] === []);
+assert($persistedPayload['budget_plan_fact']['rows'][0]['source_refs'] === []);
+
+echo "project_portfolio_health_immutable_owner_payload_harness: ok\n";

--- a/tests/Unit/Budgeting/CfoProjectPortfolioAggregatorTest.php
+++ b/tests/Unit/Budgeting/CfoProjectPortfolioAggregatorTest.php
@@ -184,6 +184,30 @@ final class CfoProjectPortfolioAggregatorTest extends TestCase
         $this->assertSame('155000.00', $result['items'][0]['metrics']['forecast_revenue']);
     }
 
+    public function test_immutable_projection_does_not_seed_a_phantom_default_currency_row(): void
+    {
+        $result = (new CfoProjectPortfolioAggregator)->buildResult(
+            filters: $this->filters(),
+            projects: [7 => ['id' => 7, 'name' => 'Business Center', 'status' => null]],
+            marginReport: ['rows' => [[
+                'project' => ['id' => 7, 'name' => 'Business Center'],
+                'currency' => 'USD',
+                'actual' => ['revenue' => '100.00', 'cost' => '80.00', 'gross_margin' => '20.00'],
+                'forecast' => ['revenue' => '110.00', 'cost' => '85.00', 'gross_margin' => '25.00'],
+            ]]],
+            wipReport: ['rows' => []],
+            planFactItems: [],
+            calendarItems: [],
+            generatedAt: '2026-06-09T10:00:00+03:00',
+            itemLimit: 5,
+            seedProjects: false,
+        );
+
+        $this->assertCount(1, $result->rows);
+        $this->assertSame('USD', $result->rows[0]->currency);
+        $this->assertSame([['type' => 'project', 'id' => 7]], $result->rows[0]->sourceRefs);
+    }
+
     private function filters(): CfoCommandCenterFilters
     {
         return new CfoCommandCenterFilters(

--- a/tests/Unit/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableOwnerPayloadBuilderTest.php
+++ b/tests/Unit/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableOwnerPayloadBuilderTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthImmutableOwnerPayloadBuilder;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ProjectPortfolioHealthImmutableOwnerPayloadBuilderTest extends TestCase
+{
+    #[Test]
+    public function it_aggregates_exact_minor_units_and_preserves_the_worst_plan_fact_risk(): void
+    {
+        $payload = (new ProjectPortfolioHealthImmutableOwnerPayloadBuilder)->build([
+            'project_margin' => [$this->marginRow()],
+            'wip_completion_forecast' => [
+                $this->wipRow('wip-1', 4_000, 1_200, 8_000, 10_000, 'earned_value', 201),
+                $this->wipRow('wip-2', 1_000, 300, 2_000, 2_500, 'actual_cost', 202),
+            ],
+            'budget_plan_fact' => [
+                $this->planFactRow('plan-1', -250, 'medium', 301),
+                $this->planFactRow('plan-2', 100, 'high', 302),
+            ],
+        ]);
+
+        self::assertSame('100.50', $payload['project_margin']['rows'][0]['actual']['revenue']);
+        self::assertSame('70.25', $payload['project_margin']['rows'][0]['actual']['cost']);
+        self::assertSame('60.00', $payload['project_margin']['rows'][0]['forecast']['gross_margin']);
+        self::assertSame('15.00', $payload['wip_completion_forecast']['rows'][0]['metrics']['wip_total']);
+        self::assertSame('75.00', $payload['wip_completion_forecast']['rows'][0]['metrics']['ftc']);
+        self::assertSame('125.00', $payload['wip_completion_forecast']['rows'][0]['metrics']['eac']);
+        self::assertSame('60.00', $payload['wip_completion_forecast']['rows'][0]['metrics']['forecast_gross_margin']);
+        self::assertSame('-1.50', $payload['budget_plan_fact']['rows'][0]['variance_amount']);
+        self::assertSame('high', $payload['budget_plan_fact']['rows'][0]['risk_level']);
+        self::assertCount(2, $payload['wip_completion_forecast']['rows'][0]['source_refs']);
+    }
+
+    #[Test]
+    public function it_fails_closed_when_any_mandatory_owner_payload_is_empty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ProjectPortfolioHealthImmutableOwnerPayloadBuilder)->build([
+            'project_margin' => [],
+            'wip_completion_forecast' => [],
+            'budget_plan_fact' => [],
+        ]);
+    }
+
+    #[Test]
+    public function it_accepts_the_existing_persisted_owner_row_shape_without_drill_refs(): void
+    {
+        $margin = $this->marginRow();
+        $margin['source_refs'] = [];
+        $wip = $this->wipRow('wip-1', 4_000, 1_200, 8_000, 10_000, 'earned_value', 201);
+        $wip['source_refs'] = [];
+        $planFact = $this->planFactRow('plan-1', -250, 'medium', 301);
+        $planFact['source_refs'] = [];
+
+        $payload = (new ProjectPortfolioHealthImmutableOwnerPayloadBuilder)->build([
+            'project_margin' => [$margin],
+            'wip_completion_forecast' => [$wip],
+            'budget_plan_fact' => [$planFact],
+        ]);
+
+        self::assertSame([], $payload['project_margin']['rows'][0]['source_refs']);
+        self::assertSame([], $payload['wip_completion_forecast']['rows'][0]['source_refs']);
+        self::assertSame([], $payload['budget_plan_fact']['rows'][0]['source_refs']);
+    }
+
+    private function marginRow(): array
+    {
+        return [
+            ...$this->identity('margin-1'),
+            'actual_revenue_minor' => 10_050,
+            'actual_cost_minor' => 7_025,
+            'forecast_revenue_minor' => 15_000,
+            'forecast_cost_minor' => 9_000,
+            'source_refs' => [['type' => 'approved_act', 'id' => 101]],
+        ];
+    }
+
+    private function wipRow(
+        string $rowKey,
+        int $ac,
+        int $wip,
+        int $ctc,
+        int $eac,
+        string $sourceType,
+        int $sourceId,
+    ): array {
+        return [
+            ...$this->identity($rowKey),
+            'ac_minor' => $ac,
+            'wip_minor' => $wip,
+            'ctc_minor' => $ctc,
+            'eac_minor' => $eac,
+            'source_refs' => [['type' => $sourceType, 'id' => $sourceId]],
+        ];
+    }
+
+    private function planFactRow(string $rowKey, int $variance, string $risk, int $sourceId): array
+    {
+        return [
+            ...$this->identity($rowKey),
+            'variance_minor' => $variance,
+            'risk' => $risk,
+            'source_refs' => [['type' => 'budget_line', 'id' => $sourceId]],
+        ];
+    }
+
+    private function identity(string $rowKey): array
+    {
+        return [
+            'row_key' => $rowKey,
+            'project_id' => 10,
+            'project_name' => 'Проект 10',
+            'currency' => 'RUB',
+        ];
+    }
+}

--- a/tests/Unit/Reporting/WaveOne/BudgetingPortfolioSourceTest.php
+++ b/tests/Unit/Reporting/WaveOne/BudgetingPortfolioSourceTest.php
@@ -24,6 +24,7 @@ use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\DTO\PortfolioLiqu
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\DTO\ProjectPortfolioHealthRow;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\DTO\ProjectPortfolioProjectionResult;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityProvider;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthImmutableProjectionService;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthProvider;
 use App\BusinessModules\Features\Budgeting\Services\CfoProjectPortfolioAggregator;
 use DateTimeImmutable;
@@ -273,15 +274,56 @@ final class BudgetingPortfolioSourceTest extends TestCase
     }
 
     #[Test]
-    public function project_portfolio_health_fails_closed_until_every_owner_source_is_versioned(): void
+    public function immutable_materializer_rejects_client_projects_when_server_scope_is_empty(): void
     {
+        $timezone = new DateTimeZone('UTC');
+        $scope = new ReportScope(1, [1], [], [], $timezone);
+        $context = new ReportExecutionContext(
+            new ReportActor(7, 'active', ['reports.view']),
+            $scope,
+            new ReportVisibility(true, false, false, false, false, false, false),
+            new AuthorizationDecisionContext('http', 1, [1], [], [], $timezone, 'scope-test', null),
+        );
+        $query = new ReportQuery(
+            (new ReportDefinitionBuilder)->code(BudgetingPortfolioProjectionService::HEALTH_CODE)->payload(),
+            $scope,
+            new ReportFilterSet(['project_ids' => [11]]),
+            [],
+            new DateTimeImmutable('2026-07-29T00:00:00+00:00'),
+            'ru',
+        );
+        $materializer = (new ReflectionClass(ProjectPortfolioHealthImmutableProjectionService::class))
+            ->newInstanceWithoutConstructor();
+
+        try {
+            $materializer->materialize($context, $query, new ReportProgress(0));
+            self::fail('Client project IDs must not expand an empty server-owned scope.');
+        } catch (ReportContractException $exception) {
+            self::assertSame(ReportErrorCode::REPORT_SCOPE_FORBIDDEN, $exception->errorCode);
+        }
+    }
+
+    #[Test]
+    public function project_portfolio_health_materializes_only_from_the_exact_immutable_source_tuple(): void
+    {
+        $provider = file_get_contents(
+            dirname(__DIR__, 4)
+            .'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthProvider.php',
+        );
         $source = file_get_contents(
             dirname(__DIR__, 4)
-            .'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/BudgetingPortfolioProjectionService.php',
+            .'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableProjectionService.php',
         );
 
+        self::assertIsString($provider);
         self::assertIsString($source);
-        self::assertStringContainsString('assertImmutableHealthCoverage', $source);
-        self::assertStringContainsString('ReportErrorCode::REPORT_SOURCE_UNAVAILABLE', $source);
+        self::assertStringContainsString('ProjectPortfolioHealthImmutableProjectionService $projection', $provider);
+        self::assertStringContainsString('ProjectPortfolioHealthImmutableSource $sources', $source);
+        self::assertStringContainsString('$selection = $this->sources->load($context, $query);', $source);
+        self::assertStringContainsString('$selection->sourceHash()', $source);
+        self::assertStringNotContainsString('assertImmutableHealthCoverage', $source);
+        self::assertStringNotContainsString('$this->marginReports->report(', $source);
+        self::assertStringNotContainsString('$this->wipReports->report(', $source);
+        self::assertStringNotContainsString('$this->planFactReports->report(', $source);
     }
 }


### PR DESCRIPTION
## Что изменено
- R01 читает только точный неизменяемый tuple owner snapshots и выбранный liquidity calendar в существующей REPEATABLE READ границе
- project scope берётся только из server context; пустой scope и клиентское расширение отклоняются
- расчёты выполняются в minor units с раздельными валютами и проверкой overflow
- реальная persisted shape с пустыми row refs поддержана без фиктивных ссылок; report-level provenance сохраняется
- опубликованный R04 не затронут: BudgetingPortfolioProjectionService остался неизменным

## Проверки
- php -l: 12/12 файлов
- assertions-enabled harnesses: 5/5
- git diff --check
- независимое review: CLEAN
- PHPUnit/PHPStan локально не запускались: vendor отсутствует; ожидается CI

## Граница релиза
Только backend runtime R01. Без публикации каталога, options, admin UI, migrations, config и workflow.