### PR TITLE
fix[reports]: обеспечить точность фильтров R01

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/EloquentProjectPortfolioHealthSourceReader.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/EloquentProjectPortfolioHealthSourceReader.php
@@ -22,8 +22,11 @@ use App\BusinessModules\Features\Budgeting\Models\EpmDataMartSnapshot;
 use App\BusinessModules\Features\Budgeting\Models\ResponsibilityCenter;
 use App\BusinessModules\Features\Budgeting\Services\EpmDataMartPayloadProjector;
 use App\Enums\CurrencyCode;
+use App\Models\Project;
+use App\Models\User;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use InvalidArgumentException;
 
 final readonly class EloquentProjectPortfolioHealthSourceReader implements ProjectPortfolioHealthSourceReader
@@ -51,6 +54,19 @@ final readonly class EloquentProjectPortfolioHealthSourceReader implements Proje
                     ProjectPortfolioHealthSourceTupleAssembler::REQUIRED_KINDS,
                 ),
                 'calendar' => [],
+                'projects' => [],
+            ];
+        }
+        $projectReferences = $this->projectReferences($context->scope->organizationId, $projectIds);
+        if ($projectReferences === null) {
+            return [
+                'components' => [],
+                'gaps' => array_map(
+                    static fn (string $kind): array => ['code' => 'owner_source_scope_incompatible', 'kind' => $kind],
+                    ProjectPortfolioHealthSourceTupleAssembler::REQUIRED_KINDS,
+                ),
+                'calendar' => [],
+                'projects' => [],
             ];
         }
         $ownerRequest = [
@@ -271,7 +287,12 @@ final readonly class EloquentProjectPortfolioHealthSourceReader implements Proje
         if ($responsibilityCenterIds === null || $counterpartyIds === null || $currencies === null) {
             $gaps[] = ['code' => 'liquidity_source_scope_invalid', 'kind' => 'portfolio_liquidity'];
 
-            return ['components' => $components, 'gaps' => $gaps, 'calendar' => []];
+            return [
+                'components' => $components,
+                'gaps' => $gaps,
+                'calendar' => [],
+                'projects' => $projectReferences,
+            ];
         }
         $calendar = [];
         try {
@@ -319,7 +340,47 @@ final readonly class EloquentProjectPortfolioHealthSourceReader implements Proje
             $gaps[] = ['code' => 'liquidity_source_unavailable', 'kind' => 'portfolio_liquidity'];
         }
 
-        return ['components' => $components, 'gaps' => $gaps, 'calendar' => $calendar];
+        return [
+            'components' => $components,
+            'gaps' => $gaps,
+            'calendar' => $calendar,
+            'projects' => $projectReferences,
+        ];
+    }
+
+    private function projectReferences(int $organizationId, array $projectIds): ?array
+    {
+        $projects = Project::query()
+            ->accessibleByOrganization($organizationId)
+            ->whereIn('id', $projectIds)
+            ->with(['users' => static function (BelongsToMany $query): void {
+                $query
+                    ->wherePivot('role', 'project_manager')
+                    ->wherePivot('is_active', true)
+                    ->select('users.id');
+            }])
+            ->orderBy('id')
+            ->get(['id', 'status']);
+        if ($projects->count() !== count($projectIds)) {
+            return null;
+        }
+        $references = $projects->map(static function (Project $project): array {
+            $managerIds = $project->users
+                ->map(static fn (User $manager): int => (int) $manager->getKey())
+                ->filter(static fn (int $managerId): bool => $managerId > 0)
+                ->unique()
+                ->sort()
+                ->values()
+                ->all();
+
+            return [
+                'id' => (int) $project->getKey(),
+                'status' => is_string($project->status) ? trim($project->status) : '',
+                'manager_ids' => $managerIds,
+            ];
+        })->all();
+
+        return array_column($references, 'id') === $projectIds ? $references : null;
     }
 
     /** @return array<string, array{formula:string,schema:string}> */

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableProjectionService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableProjectionService.php
@@ -13,6 +13,8 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportFreshnessStatus;
 use App\BusinessModules\Features\Budgeting\DTOs\CfoCommandCenterFilters;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\DTO\ProjectPortfolioHealthRow;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\DTO\ProjectPortfolioProjectionResult;
 use App\BusinessModules\Features\Budgeting\Services\CfoProjectPortfolioAggregator;
 use DateTimeImmutable;
 use InvalidArgumentException;
@@ -23,6 +25,7 @@ final readonly class ProjectPortfolioHealthImmutableProjectionService
         private ProjectPortfolioHealthImmutableSource $sources,
         private BudgetingPortfolioProjectionService $snapshots,
         private CfoProjectPortfolioAggregator $aggregator,
+        private ProjectPortfolioHealthRuntimeFilter $runtimeFilters,
     ) {}
 
     public function materialize(
@@ -41,6 +44,12 @@ final readonly class ProjectPortfolioHealthImmutableProjectionService
         if (! isset($projects) || array_keys($projects) !== $projectIds) {
             $this->unavailable();
         }
+        $values = $query->filters->values;
+        $projects = $this->runtimeFilters->projects(
+            $projects,
+            array_key_exists('manager_ids', $values) ? $values['manager_ids'] : [],
+            array_key_exists('project_statuses', $values) ? $values['project_statuses'] : [],
+        );
         $filters = $this->filters($context, $query, $projectIds);
         $progress->advance(20);
         $margin = $selection->ownerPayloads['project_margin'];
@@ -60,10 +69,19 @@ final readonly class ProjectPortfolioHealthImmutableProjectionService
             max(1, count($projects)),
             seedProjects: false,
         );
-        if ($projection->rows === []) {
-            $this->unavailable();
+        $riskRowIndexes = $this->runtimeFilters->riskRowIndexes(
+            array_map(
+                static fn (ProjectPortfolioHealthRow $row): string => $row->riskLevel,
+                $projection->rows,
+            ),
+            array_key_exists('risk_levels', $values) ? $values['risk_levels'] : [],
+        );
+        if (count($riskRowIndexes) !== count($projection->rows)) {
+            $projection = ProjectPortfolioProjectionResult::fromRows(array_map(
+                static fn (int $index): ProjectPortfolioHealthRow => $projection->rows[$index],
+                $riskRowIndexes,
+            ), $query->asOf->format(DATE_ATOM), max(1, count($projects)));
         }
-
         try {
             $snapshot = $this->snapshots->persistHealth(
                 $context,
@@ -129,8 +147,6 @@ final readonly class ProjectPortfolioHealthImmutableProjectionService
             periodStart: $periodStart,
             periodEnd: $periodEnd,
             projectId: count($projectIds) === 1 ? $projectIds[0] : null,
-            projectManagerUserId: $this->firstPositiveInt($values['manager_ids'] ?? null),
-            projectStatus: $this->firstString($values['project_statuses'] ?? null),
             responsibilityCenterId: count($responsibilityCenterIds) === 1
                 ? $responsibilityCenterIds[0]
                 : null,
@@ -185,11 +201,6 @@ final readonly class ProjectPortfolioHealthImmutableProjectionService
             $value,
             static fn (mixed $item): bool => is_string($item) && trim($item) !== '',
         ));
-    }
-
-    private function firstPositiveInt(mixed $value): ?int
-    {
-        return $this->positiveIds($value)[0] ?? null;
     }
 
     private function firstString(mixed $value): ?string

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSource.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSource.php
@@ -46,7 +46,9 @@ final readonly class ProjectPortfolioHealthImmutableSource
             || ! is_array($read['gaps'] ?? null)
             || ! array_is_list($read['gaps'])
             || ! is_array($read['calendar'] ?? null)
-            || ! array_is_list($read['calendar'])) {
+            || ! array_is_list($read['calendar'])
+            || ! is_array($read['projects'] ?? null)
+            || ! array_is_list($read['projects'])) {
             $this->unavailable();
         }
         foreach ($read['calendar'] as $item) {
@@ -113,6 +115,7 @@ final readonly class ProjectPortfolioHealthImmutableSource
                 $ownerPayloads,
                 $read['calendar'],
                 $rowCounts,
+                $read['projects'],
             );
         } catch (InvalidArgumentException) {
             $this->unavailable();

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSourceSelection.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSourceSelection.php
@@ -7,15 +7,19 @@ namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
 use App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceRef;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use InvalidArgumentException;
 
 final readonly class ProjectPortfolioHealthImmutableSourceSelection
 {
+    private array $projectReferences;
+
     public function __construct(
         public ProjectPortfolioHealthSourceTuple $tuple,
         public array $ownerPayloads,
         public array $calendar,
         private array $rowCounts,
+        array $projectReferences,
     ) {
         if (! $tuple->isReady()
             || ! isset(
@@ -42,12 +46,16 @@ final readonly class ProjectPortfolioHealthImmutableSourceSelection
                 throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
             }
         }
+        $this->projectReferences = $this->normalizeProjectReferences($projectReferences);
         $this->projects();
     }
 
     public function sourceHash(): Sha256Hash
     {
-        return new Sha256Hash($this->tuple->watermark);
+        return new Sha256Hash(hash('sha256', CanonicalJson::encode([
+            'project_dimensions' => $this->projectReferences,
+            'source_tuple' => $this->tuple->watermark,
+        ])));
     }
 
     public function sourceRefs(): array
@@ -67,13 +75,26 @@ final readonly class ProjectPortfolioHealthImmutableSourceSelection
                 hash: new Sha256Hash($component->sourceHash),
             );
         }
+        $projectDimensionsHash = $this->projectDimensionsHash();
+        $refs[] = new ReportSourceRef(
+            source: 'project_dimensions',
+            snapshotKind: 'project_dimensions',
+            snapshotId: 'project_dimensions_'.substr($projectDimensionsHash, 0, 24),
+            schemaVersion: 'project_dimensions_v1',
+            watermark: 'watermark_'.substr($projectDimensionsHash, 0, 24),
+            rowCount: count($this->projectReferences),
+            hash: new Sha256Hash($projectDimensionsHash),
+        );
 
         return $refs;
     }
 
     public function watermarks(): array
     {
-        $watermarks = ['source_tuple' => $this->tuple->watermark];
+        $watermarks = [
+            'project_dimensions' => $this->projectDimensionsHash(),
+            'source_tuple' => $this->tuple->watermark,
+        ];
         foreach ($this->tuple->components as $component) {
             $watermarks[$component->kind] = $component->sourceHash;
         }
@@ -96,15 +117,66 @@ final readonly class ProjectPortfolioHealthImmutableSourceSelection
                 if (isset($projects[$id]) && $projects[$id]['name'] !== $name) {
                     throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
                 }
-                $projects[$id] = ['id' => $id, 'name' => $name, 'status' => null];
+                $projects[$id] = ['id' => $id, 'name' => $name];
             }
         }
         if ($projects === []) {
             throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
         }
         ksort($projects, SORT_NUMERIC);
+        if (array_keys($projects) !== array_column($this->projectReferences, 'id')) {
+            throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+        }
+        foreach ($this->projectReferences as $reference) {
+            $projects[$reference['id']]['status'] = $reference['status'];
+            $projects[$reference['id']]['manager_ids'] = $reference['manager_ids'];
+        }
 
         return $projects;
+    }
+
+    private function normalizeProjectReferences(array $references): array
+    {
+        if (! array_is_list($references) || $references === []) {
+            throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+        }
+        $normalized = [];
+        foreach ($references as $reference) {
+            if (! is_array($reference)
+                || ! is_int($reference['id'] ?? null)
+                || $reference['id'] < 1
+                || ! is_string($reference['status'] ?? null)
+                || trim($reference['status']) === ''
+                || ! is_array($reference['manager_ids'] ?? null)
+                || ! array_is_list($reference['manager_ids'])) {
+                throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+            }
+            $managerIds = [];
+            foreach ($reference['manager_ids'] as $managerId) {
+                if (! is_int($managerId) || $managerId < 1) {
+                    throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+                }
+                $managerIds[$managerId] = $managerId;
+            }
+            ksort($managerIds, SORT_NUMERIC);
+            $id = $reference['id'];
+            if (isset($normalized[$id])) {
+                throw new InvalidArgumentException('project_portfolio_health_source_selection_invalid');
+            }
+            $normalized[$id] = [
+                'id' => $id,
+                'status' => trim($reference['status']),
+                'manager_ids' => array_values($managerIds),
+            ];
+        }
+        ksort($normalized, SORT_NUMERIC);
+
+        return array_values($normalized);
+    }
+
+    private function projectDimensionsHash(): string
+    {
+        return hash('sha256', CanonicalJson::encode($this->projectReferences));
     }
 
     private function identifier(string $value, string $prefix): string

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthRuntimeFilter.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthRuntimeFilter.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+
+final class ProjectPortfolioHealthRuntimeFilter
+{
+    private const RISK_LEVELS = [
+        'low',
+        'medium',
+        'high',
+        'critical',
+    ];
+
+    public function projects(array $projects, mixed $managerIds, mixed $statuses): array
+    {
+        $managerIds = $this->positiveIds($managerIds);
+        $statuses = $this->strings($statuses);
+        $availableManagerIds = [];
+        $availableStatuses = [];
+
+        foreach ($projects as $project) {
+            if (! is_array($project)
+                || ! is_int($project['id'] ?? null)
+                || $project['id'] < 1
+                || ! is_string($project['status'] ?? null)
+                || trim($project['status']) === ''
+                || ! is_array($project['manager_ids'] ?? null)
+                || ! array_is_list($project['manager_ids'])) {
+                $this->sourceUnavailable();
+            }
+            $availableStatuses[$project['status']] = true;
+            foreach ($project['manager_ids'] as $managerId) {
+                if (! is_int($managerId) || $managerId < 1) {
+                    $this->sourceUnavailable();
+                }
+                $availableManagerIds[$managerId] = true;
+            }
+        }
+
+        foreach ($managerIds as $managerId) {
+            if (! isset($availableManagerIds[$managerId])) {
+                $this->valueNotFound();
+            }
+        }
+        foreach ($statuses as $status) {
+            if (! isset($availableStatuses[$status])) {
+                $this->valueNotFound();
+            }
+        }
+
+        $allowedManagers = array_fill_keys($managerIds, true);
+        $allowedStatuses = array_fill_keys($statuses, true);
+
+        return array_filter($projects, static function (array $project) use ($allowedManagers, $allowedStatuses): bool {
+            if ($allowedStatuses !== [] && ! isset($allowedStatuses[$project['status']])) {
+                return false;
+            }
+            if ($allowedManagers === []) {
+                return true;
+            }
+            foreach ($project['manager_ids'] as $managerId) {
+                if (isset($allowedManagers[$managerId])) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    public function riskRowIndexes(array $rowRiskLevels, mixed $riskLevels): array
+    {
+        $riskLevels = $this->strings($riskLevels);
+        if ($riskLevels === []) {
+            return array_keys($rowRiskLevels);
+        }
+        foreach ($riskLevels as $riskLevel) {
+            if (! in_array($riskLevel, self::RISK_LEVELS, true)) {
+                $this->valueNotFound();
+            }
+        }
+        $available = [];
+        foreach ($rowRiskLevels as $riskLevel) {
+            if (! is_string($riskLevel) || ! in_array($riskLevel, self::RISK_LEVELS, true)) {
+                $this->sourceUnavailable();
+            }
+            $available[$riskLevel] = true;
+        }
+        foreach ($riskLevels as $riskLevel) {
+            if (! isset($available[$riskLevel])) {
+                $this->valueNotFound();
+            }
+        }
+        $allowed = array_fill_keys($riskLevels, true);
+
+        return array_keys(array_filter(
+            $rowRiskLevels,
+            static fn (string $riskLevel): bool => isset($allowed[$riskLevel]),
+        ));
+    }
+
+    private function positiveIds(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            $this->valueNotFound();
+        }
+        $ids = [];
+        foreach ($value as $id) {
+            if ((! is_int($id) && (! is_string($id) || preg_match('/^[1-9][0-9]*$/D', $id) !== 1))
+                || (int) $id < 1) {
+                $this->valueNotFound();
+            }
+            $ids[(int) $id] = (int) $id;
+        }
+        ksort($ids, SORT_NUMERIC);
+
+        return array_values($ids);
+    }
+
+    private function strings(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            $this->valueNotFound();
+        }
+        $strings = [];
+        foreach ($value as $item) {
+            if (! is_string($item) || trim($item) === '') {
+                $this->valueNotFound();
+            }
+            $normalized = trim($item);
+            $strings[$normalized] = $normalized;
+        }
+        ksort($strings, SORT_STRING);
+
+        return array_values($strings);
+    }
+
+    private function valueNotFound(): never
+    {
+        throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+    }
+
+    private function sourceUnavailable(): never
+    {
+        throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceReader.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceReader.php
@@ -9,6 +9,6 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 
 interface ProjectPortfolioHealthSourceReader
 {
-    /** @return array{components:list<ProjectPortfolioHealthSourceComponent>,gaps:list<array{code:string,kind?:string}>,calendar:list<\App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem>} */
+    /** @return array{components:list<ProjectPortfolioHealthSourceComponent>,gaps:list<array{code:string,kind?:string}>,calendar:list<\App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem>,projects:list<array{id:int,status:string,manager_ids:list<int>}>} */
     public function read(ReportExecutionContext $context, ReportQuery $query): array;
 }

--- a/tests/Support/Budgeting/brick_math_harness_stub.php
+++ b/tests/Support/Budgeting/brick_math_harness_stub.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Math\Exception {
+    class MathException extends \RuntimeException
+    {
+    }
+}
+
+namespace Brick\Math {
+    use Brick\Math\Exception\MathException;
+
+    final class RoundingMode
+    {
+        public const HalfUp = 'half_up';
+    }
+
+    final class BigDecimal
+    {
+        private function __construct(private float $value, private ?int $scale = null)
+        {
+        }
+
+        public static function of(mixed $value): self
+        {
+            return new self(self::numeric($value));
+        }
+
+        public static function zero(): self
+        {
+            return new self(0.0);
+        }
+
+        public static function one(): self
+        {
+            return new self(1.0);
+        }
+
+        public function plus(mixed $value): self
+        {
+            return new self($this->value + self::numeric($value));
+        }
+
+        public function minus(mixed $value): self
+        {
+            return new self($this->value - self::numeric($value));
+        }
+
+        public function multipliedBy(mixed $value): self
+        {
+            return new self($this->value * self::numeric($value));
+        }
+
+        public function dividedBy(mixed $value, int $scale, mixed $roundingMode): self
+        {
+            $divisor = self::numeric($value);
+            if ($divisor === 0.0) {
+                throw new MathException('division_by_zero');
+            }
+
+            return (new self($this->value / $divisor))->toScale($scale, $roundingMode);
+        }
+
+        public function toScale(int $scale, mixed $roundingMode): self
+        {
+            return new self(round($this->value, $scale, PHP_ROUND_HALF_UP), $scale);
+        }
+
+        public function isZero(): bool
+        {
+            return $this->value === 0.0;
+        }
+
+        public function isNegative(): bool
+        {
+            return $this->value < 0.0;
+        }
+
+        public function isGreaterThan(mixed $value): bool
+        {
+            return $this->value > self::numeric($value);
+        }
+
+        public function compareTo(mixed $value): int
+        {
+            return $this->value <=> self::numeric($value);
+        }
+
+        public function abs(): self
+        {
+            return new self(abs($this->value));
+        }
+
+        public function __toString(): string
+        {
+            if ($this->scale !== null) {
+                return number_format($this->value, $this->scale, '.', '');
+            }
+
+            return rtrim(rtrim(sprintf('%.14F', $this->value), '0'), '.');
+        }
+
+        private static function numeric(mixed $value): float
+        {
+            if ($value instanceof self) {
+                return $value->value;
+            }
+            if ((! is_int($value) && ! is_float($value) && ! is_string($value))
+                || ! is_numeric($value)) {
+                throw new MathException('invalid_decimal');
+            }
+            $numeric = (float) $value;
+            if (! is_finite($numeric)) {
+                throw new MathException('invalid_decimal');
+            }
+
+            return $numeric;
+        }
+    }
+}

--- a/tests/Support/Budgeting/project_portfolio_health_runtime_filter_harness.php
+++ b/tests/Support/Budgeting/project_portfolio_health_runtime_filter_harness.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/brick_math_harness_stub.php';
+require_once __DIR__.'/../../../app/BusinessModules/Core/Reporting/Application/Errors/ReportErrorCode.php';
+require_once __DIR__.'/../../../app/BusinessModules/Core/Reporting/Application/Errors/ReportContractException.php';
+require_once __DIR__.'/../../../app/BusinessModules/Core/Reporting/Support/CanonicalJson.php';
+require_once __DIR__.'/../../../app/BusinessModules/Core/Reporting/Domain/ValueObjects/Sha256Hash.php';
+require_once __DIR__.'/../../../app/BusinessModules/Core/Reporting/Domain/DTO/ReportSourceRef.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/Support/PortfolioDecimal.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/DTO/ProjectPortfolioHealthRow.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/DTO/ProjectPortfolioProjectionResult.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceGap.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceComponent.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceTuple.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSourceTupleAssembler.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSourceSelection.php';
+require_once __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthRuntimeFilter.php';
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\DTO\ProjectPortfolioHealthRow;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\DTO\ProjectPortfolioProjectionResult;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthImmutableSourceSelection;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthRuntimeFilter;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthSourceComponent;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthSourceTuple;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthSourceTupleAssembler;
+
+$mode = $argv[1] ?? 'all';
+
+$tuple = static function (string $seed = 'source'): ProjectPortfolioHealthSourceTuple {
+    $components = [];
+    foreach (ProjectPortfolioHealthSourceTupleAssembler::REQUIRED_KINDS as $index => $kind) {
+        $components[] = new ProjectPortfolioHealthSourceComponent(
+            $kind,
+            'snapshot-'.($index + 1),
+            hash('sha256', $seed.'-'.($index + 1)),
+            '1.0.0|1.0.0',
+            '2026-08-07T00:00:00+00:00',
+        );
+    }
+
+    return (new ProjectPortfolioHealthSourceTupleAssembler)->assemble($components);
+};
+
+$ownerPayloads = static fn (): array => [
+    'project_margin' => ['rows' => [[
+        'project' => ['id' => 7, 'name' => 'Проект 7'],
+        'currency' => 'RUB',
+        'actual' => ['revenue' => '100.00', 'cost' => '80.00', 'gross_margin' => '20.00'],
+        'forecast' => ['revenue' => '100.00', 'cost' => '80.00', 'gross_margin' => '20.00'],
+        'source_refs' => [],
+    ]]],
+    'wip_completion_forecast' => ['rows' => [[
+        'project' => ['id' => 7, 'name' => 'Проект 7'],
+        'currency' => 'RUB',
+        'metrics' => ['wip' => '0.00', 'wip_total' => '0.00', 'ftc' => '0.00', 'eac' => '0.00', 'ctc' => '0.00'],
+        'source_refs' => [],
+    ]]],
+    'budget_plan_fact' => ['rows' => [[
+        'project' => ['id' => 7, 'name' => 'Проект 7'],
+        'currency' => 'RUB',
+        'variance_amount' => '0.00',
+        'risk_level' => 'low',
+        'source_refs' => [],
+    ]]],
+];
+
+$selection = static function (
+    array $projectReferences,
+    ?ProjectPortfolioHealthSourceTuple $sourceTuple = null,
+) use ($tuple, $ownerPayloads): ProjectPortfolioHealthImmutableSourceSelection {
+    $parameters = (new ReflectionClass(ProjectPortfolioHealthImmutableSourceSelection::class))
+        ->getConstructor()?->getParameters() ?? [];
+    $names = array_map(static fn (ReflectionParameter $parameter): string => $parameter->getName(), $parameters);
+    assert(in_array('projectReferences', $names, true), 'current project dimensions must be explicit immutable input');
+
+    return new ProjectPortfolioHealthImmutableSourceSelection(
+        $sourceTuple ?? $tuple(),
+        $ownerPayloads(),
+        [],
+        ['project_margin' => 1, 'wip_completion_forecast' => 1, 'budget_plan_fact' => 1],
+        $projectReferences,
+    );
+};
+
+$runtime = static function (): ProjectPortfolioHealthRuntimeFilter {
+    assert(class_exists(ProjectPortfolioHealthRuntimeFilter::class), 'runtime filter implementation is missing');
+
+    return new ProjectPortfolioHealthRuntimeFilter;
+};
+
+$row = static fn (int $projectId, string $riskLevel, int $riskRank, string $revenue): ProjectPortfolioHealthRow => new ProjectPortfolioHealthRow(
+    projectId: $projectId,
+    projectName: 'Проект '.$projectId,
+    currency: 'RUB',
+    revenue: $revenue,
+    cost: '10.00',
+    wip: '0.00',
+    ftc: '0.00',
+    eac: '0.00',
+    ctc: '0.00',
+    riskLevel: $riskLevel,
+    riskRank: $riskRank,
+    asOf: '2026-08-07',
+    sourceRefs: [['type' => 'project', 'id' => $projectId]],
+);
+
+$assertFilterError = static function (callable $callback): void {
+    try {
+        $callback();
+        assert(false, 'invalid or out-of-scope filter value must fail closed');
+    } catch (ReportContractException $exception) {
+        assert($exception->errorCode === ReportErrorCode::REPORT_FILTER_VALUE_NOT_FOUND);
+    }
+};
+
+if ($mode === 'identity' || $mode === 'all') {
+    $base = $selection([['id' => 7, 'status' => 'active', 'manager_ids' => [31, 33]]]);
+    $sameNormalized = $selection([['id' => 7, 'status' => 'active', 'manager_ids' => [33, 31, 31]]]);
+    $otherStatus = $selection([['id' => 7, 'status' => 'paused', 'manager_ids' => [31, 33]]]);
+    $otherManager = $selection([['id' => 7, 'status' => 'active', 'manager_ids' => [31, 34]]]);
+    $otherTuple = $selection(
+        [['id' => 7, 'status' => 'active', 'manager_ids' => [31, 33]]],
+        $tuple('other-source'),
+    );
+
+    assert($base->sourceHash()->value === $sameNormalized->sourceHash()->value);
+    assert($base->sourceHash()->value !== $otherStatus->sourceHash()->value);
+    assert($base->sourceHash()->value !== $otherManager->sourceHash()->value);
+    assert($base->sourceHash()->value !== $otherTuple->sourceHash()->value);
+    assert($base->watermarks()['project_dimensions'] === $sameNormalized->watermarks()['project_dimensions']);
+    assert($base->watermarks()['project_dimensions'] !== $otherStatus->watermarks()['project_dimensions']);
+    assert(count($base->sourceRefs()) === 5);
+    $componentIdentity = static fn (array $refs): array => array_map(
+        static fn (object $ref): array => [$ref->source, $ref->snapshotId, $ref->hash->value],
+        array_slice($refs, 0, -1),
+    );
+    assert($componentIdentity($base->sourceRefs()) === $componentIdentity($otherStatus->sourceRefs()));
+    assert($base->sourceRefs()[4]->source === 'project_dimensions');
+    assert($base->sourceRefs()[4]->hash->value !== $otherStatus->sourceRefs()[4]->hash->value);
+    assert($base->sourceRefs()[4]->watermark !== $otherManager->sourceRefs()[4]->watermark);
+    assert($base->projects()[7]['status'] === 'active');
+    assert($base->projects()[7]['manager_ids'] === [31, 33]);
+}
+
+if ($mode === 'manager_status' || $mode === 'all') {
+    $projects = [
+        7 => ['id' => 7, 'name' => 'Проект 7', 'status' => 'active', 'manager_ids' => [31, 33]],
+        8 => ['id' => 8, 'name' => 'Проект 8', 'status' => 'paused', 'manager_ids' => [32]],
+        9 => ['id' => 9, 'name' => 'Проект 9', 'status' => 'active', 'manager_ids' => []],
+    ];
+    $filtered = $runtime()->projects($projects, [31, 32], ['active']);
+
+    assert(array_keys($filtered) === [7]);
+}
+
+if ($mode === 'empty_intersection' || $mode === 'all') {
+    $projects = [
+        7 => ['id' => 7, 'name' => 'Проект 7', 'status' => 'active', 'manager_ids' => [31]],
+        8 => ['id' => 8, 'name' => 'Проект 8', 'status' => 'paused', 'manager_ids' => [32]],
+    ];
+    $filtered = $runtime()->projects($projects, [31], ['paused']);
+    assert($filtered === []);
+
+    $projectionService = file_get_contents(
+        __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableProjectionService.php',
+    );
+    assert(is_string($projectionService));
+    assert(! str_contains($projectionService, 'if ($projection->rows === [])'));
+}
+
+if ($mode === 'risk' || $mode === 'all') {
+    $filter = $runtime();
+    assert(method_exists($filter, 'riskRowIndexes'), 'final risk row filter is missing');
+    $projection = ProjectPortfolioProjectionResult::fromRows([
+        $row(7, 'low', 1, '20.00'),
+        $row(8, 'high', 3, '30.00'),
+        $row(9, 'critical', 4, '40.00'),
+    ], '2026-08-07T00:00:00+00:00', 50);
+    $indexes = $filter->riskRowIndexes(array_map(
+        static fn (ProjectPortfolioHealthRow $item): string => $item->riskLevel,
+        $projection->rows,
+    ), ['high', 'critical']);
+    $filteredProjection = ProjectPortfolioProjectionResult::fromRows(array_map(
+        static fn (int $index): ProjectPortfolioHealthRow => $projection->rows[$index],
+        $indexes,
+    ), '2026-08-07T00:00:00+00:00', 50);
+
+    assert($indexes === [1, 2]);
+    assert(array_map(
+        static fn (ProjectPortfolioHealthRow $item): string => $item->riskLevel,
+        $filteredProjection->rows,
+    ) === ['high', 'critical']);
+    assert($filteredProjection->totalsByCurrency['RUB']['revenue'] === '70.00');
+    assert($filteredProjection->totalsByCurrency['RUB']['cost'] === '20.00');
+    assert($filteredProjection->totalsByCurrency['RUB']['margin'] === '50.00');
+}
+
+if ($mode === 'invalid' || $mode === 'all') {
+    $projects = [
+        7 => ['id' => 7, 'name' => 'Проект 7', 'status' => 'active', 'manager_ids' => [31]],
+    ];
+
+    $assertFilterError(static fn () => $runtime()->projects($projects, [999], []));
+    $assertFilterError(static fn () => $runtime()->projects($projects, [], ['paused']));
+    $assertFilterError(static fn () => $runtime()->projects($projects, ['invalid'], []));
+    $assertFilterError(static fn () => $runtime()->riskRowIndexes(['low', 'high'], ['medium']));
+    $assertFilterError(static fn () => $runtime()->riskRowIndexes(['low', 'high'], ['unknown']));
+}
+
+if ($mode === 'wiring' || $mode === 'all') {
+    $projectionService = file_get_contents(
+        __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableProjectionService.php',
+    );
+    $sourceReader = file_get_contents(
+        __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/EloquentProjectPortfolioHealthSourceReader.php',
+    );
+    $immutableSource = file_get_contents(
+        __DIR__.'/../../../app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSource.php',
+    );
+    assert(is_string($projectionService));
+    assert(is_string($sourceReader));
+    assert(is_string($immutableSource));
+
+    $projectsPosition = strpos($projectionService, '$this->runtimeFilters->projects(');
+    $riskPosition = strpos($projectionService, '$this->runtimeFilters->riskRowIndexes(');
+    $persistPosition = strpos($projectionService, '$this->snapshots->persistHealth(');
+    assert(is_int($projectsPosition));
+    assert(is_int($riskPosition));
+    assert(is_int($persistPosition));
+    assert($projectsPosition < $riskPosition && $riskPosition < $persistPosition);
+    assert(str_contains($projectionService, 'ProjectPortfolioProjectionResult::fromRows(array_map('));
+    assert(! str_contains($projectionService, 'if ($projection->rows === [])'));
+
+    assert(str_contains($sourceReader, '->accessibleByOrganization($organizationId)'));
+    assert(str_contains($sourceReader, "->whereIn('id', \$projectIds)"));
+    assert(str_contains($sourceReader, "->wherePivot('role', 'project_manager')"));
+    assert(str_contains($sourceReader, "->wherePivot('is_active', true)"));
+    assert(str_contains($sourceReader, "'projects' => \$projectReferences"));
+    assert(str_contains($sourceReader, "array_column(\$references, 'id') === \$projectIds"));
+    assert(str_contains($immutableSource, "! is_array(\$read['projects'] ?? null)"));
+    assert(str_contains($immutableSource, "\$read['projects'],"));
+}
+
+echo "project_portfolio_health_runtime_filter_harness: {$mode}: ok\n";


### PR DESCRIPTION
## Что изменено
- статусы и активные руководители проектов захватываются в стабильной границе источника и входят в provenance R01
- multi-value фильтры руководителя и статуса реально сужают проекты
- фильтр риска применяется к итоговым строкам с пересчётом totals
- валидное пустое пересечение сохраняется как empty, недопустимые значения отклоняются fail-closed

## Проверки
- независимое review: CLEAN после исправления двух замечаний
- assertions-enabled R01 runtime harness: 7 режимов и all
- 5 существующих R01 harness
- php -l: 8/8
- git diff --check
- R04 fingerprint boundary неизменён

Миграции, routes, options, publication, UI, feature flags, workflow и инфраструктура не затронуты.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated EloquentProjectPortfolioHealthSourceReader to include project references in the returned report data.</li>
<li>Added a private projectReferences method to fetch project status and active project manager IDs.</li>
<li>Enhanced reporting logic to validate project existence and accessibility within the organization scope.</li>
<li>Updated related immutable projection services and sources to accommodate the new project data structure.</li>
<li>Added test harnesses to support validation of the new project portfolio health reporting logic.</li>
</ul></div>