### PR TITLE
feat[reports]: реальные scoped options R01

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ProjectPortfolioHealthReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ProjectPortfolioHealthReportOptionsController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ProjectPortfolioHealthReportOptionsRequest;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\BudgetingPortfolioProjectionService;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class ProjectPortfolioHealthReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private ProjectPortfolioHealthOptionsService $options,
+    ) {}
+
+    public function __invoke(ProjectPortfolioHealthReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization
+            ->createRun($request, BudgetingPortfolioProjectionService::HEALTH_CODE)['context'];
+
+        return AdminResponse::success($this->options->options($context->scope));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ProjectPortfolioHealthReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ProjectPortfolioHealthReportOptionsRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+final class ProjectPortfolioHealthReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            ...$this->forbiddenClientFieldsRules(),
+            'project_id' => ['prohibited'],
+            'scope' => ['prohibited'],
+        ];
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\HoldingPerformance
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\IntercompanyContractFlowReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PortfolioLiquidityReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectPortfolioHealthReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectEvmControlReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectLaborCostReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectMarginReportOptionsController;
@@ -99,6 +100,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'portfolio_liquidity')
             ->middleware(['report.organization-scope', $resourceAccess])
             ->name('portfolio-liquidity.options');
+        Route::get('/project-portfolio-health/options', ProjectPortfolioHealthReportOptionsController::class)
+            ->defaults('reportCode', 'project_portfolio_health')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('project-portfolio-health.options');
         Route::post('/intercompany-contract-flows/runs', [ReportRunController::class, 'store'])
             ->defaults('reportCode', 'intercompany_contract_flows')
             ->middleware($resourceAccess)

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Exceptions\ReportContractException;
+use App\Enums\CurrencyCode;
+use App\Models\Project;
+use App\Support\Reporting\StableReportingSourceView;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final readonly class ProjectPortfolioHealthOptionsService
+{
+    public function __construct(private StableReportingSourceView $sourceView) {}
+
+    public function options(ReportScope $scope): array
+    {
+        try {
+            return $this->sourceView->capture(fn (): array => $this->capture($scope));
+        } catch (ReportContractException $exception) {
+            throw $exception;
+        } catch (Throwable) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+        }
+    }
+
+    private function capture(ReportScope $scope): array
+    {
+        $projects = Project::accessibleByOrganization($scope->organizationId)
+            ->whereIn('id', $scope->projectIds)
+            ->orderBy('id')
+            ->get(['id', 'name', 'status']);
+        $projectIds = $projects->pluck('id')->map(static fn (mixed $id): int => (int) $id)->all();
+        $expectedProjectIds = $scope->projectIds;
+        sort($projectIds);
+        sort($expectedProjectIds);
+        if ($projectIds !== $expectedProjectIds) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+        }
+        if ($projects->contains(static fn (Project $project): bool => trim((string) $project->name) === '')) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+        }
+
+        $statuses = [];
+        foreach ($projects as $project) {
+            $status = trim((string) $project->status);
+            $name = trans_message('reports.options.project_portfolio_health.statuses.'.$status);
+            if (! in_array($status, ['active', 'completed', 'paused', 'cancelled'], true)
+                || $name === 'reports.options.project_portfolio_health.statuses.'.$status) {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+            }
+            $statuses[$status] = ['id' => $status, 'name' => $name];
+        }
+
+        $managers = DB::table('project_user')
+            ->join('users', 'users.id', '=', 'project_user.user_id')
+            ->whereIn('project_user.project_id', $projectIds)
+            ->where('project_user.role', 'project_manager')
+            ->where('project_user.is_active', true)
+            ->whereNull('users.deleted_at')
+            ->selectRaw("users.id, NULLIF(TRIM(CONCAT_WS(' ', users.last_name, users.first_name, users.middle_name)), '') AS name")
+            ->distinct()
+            ->orderBy('name')
+            ->orderBy('users.id')
+            ->get()
+            ->map(fn (object $manager): array => $this->choice($manager->id, $manager->name))
+            ->all();
+        if (count($managers) !== count(array_filter($managers, static fn (array $manager): bool => $manager['name'] !== ''))) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+        }
+
+        $responsibilityCenterIds = $this->dimensionIds('responsibility_center_id', $scope, $projectIds);
+        $counterpartyIds = $this->counterpartyIds($scope, $projectIds);
+        $currencies = $this->currencies($scope, $projectIds);
+        $today = CarbonImmutable::now($scope->timezone)->startOfDay();
+
+        return [
+            'period' => ['default_from' => $today->startOfMonth()->format('Y-m-d'), 'default_to' => $today->format('Y-m-d'), 'default_as_of' => $today->format('Y-m-d'), 'max_horizon_days' => 366],
+            'projects' => $this->sorted($projects->map(fn (Project $project): array => $this->choice($project->id, $project->name))->all()),
+            'managers' => $managers,
+            'project_statuses' => $this->sorted(array_values($statuses)),
+            'responsibility_centers' => $this->masterChoices('responsibility_centers', $responsibilityCenterIds, $scope->organizationId),
+            'counterparties' => $this->masterChoices('contractors', $counterpartyIds, $scope->organizationId),
+            'currencies' => $currencies,
+            'risk_levels' => $this->riskLevels(),
+        ];
+    }
+
+    private function dimensionIds(string $column, ReportScope $scope, array $projectIds): array
+    {
+        return $this->budgetLines($scope, $projectIds)->whereNotNull('budget_lines.'.$column)->pluck('budget_lines.'.$column)
+            ->merge(DB::table('payment_documents')->where('organization_id', $scope->organizationId)->whereIn('project_id', $projectIds)->whereNull('deleted_at')->whereNotNull($column)->pluck($column))
+            ->map(static fn (mixed $id): string => (string) $id)->unique()->sort()->values()->all();
+    }
+
+    private function counterpartyIds(ReportScope $scope, array $projectIds): array
+    {
+        return $this->budgetLines($scope, $projectIds)->whereNotNull('budget_lines.counterparty_id')->pluck('budget_lines.counterparty_id')
+            ->merge(DB::table('payment_documents')->where('organization_id', $scope->organizationId)->whereIn('project_id', $projectIds)->whereNull('deleted_at')
+                ->selectRaw('COALESCE(payee_contractor_id, payer_contractor_id) AS counterparty_id')->whereRaw('COALESCE(payee_contractor_id, payer_contractor_id) IS NOT NULL')->pluck('counterparty_id'))
+            ->map(static fn (mixed $id): string => (string) $id)->unique()->sort()->values()->all();
+    }
+
+    private function masterChoices(string $table, array $ids, int $organizationId): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        $choices = DB::table($table)->where('organization_id', $organizationId)->whereIn('id', $ids)->orderBy('name')->orderBy('id')->get(['id', 'name'])
+            ->map(fn (object $item): array => $this->choice($item->id, $item->name))->all();
+        if (count($choices) !== count($ids) || count(array_filter($choices, static fn (array $choice): bool => $choice['name'] !== '')) !== count($choices)) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+        }
+        return $choices;
+    }
+
+    private function currencies(ReportScope $scope, array $projectIds): array
+    {
+        $raw = $this->budgetLines($scope, $projectIds)->whereNotNull('budget_lines.currency')->pluck('budget_lines.currency')
+            ->merge(DB::table('payment_documents')->where('organization_id', $scope->organizationId)->whereIn('project_id', $projectIds)->whereNull('deleted_at')->whereNotNull('currency')->pluck('currency'));
+        $allowed = CurrencyCode::options();
+        $currencies = [];
+        foreach ($raw as $currency) {
+            $code = strtoupper(trim((string) $currency));
+            if (! isset($allowed[$code])) {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+            }
+            $currencies[$code] = ['id' => $code, 'name' => $allowed[$code]];
+        }
+        return $this->sorted(array_values($currencies));
+    }
+
+    private function riskLevels(): array
+    {
+        $choices = [];
+        foreach (['low', 'medium', 'high', 'critical'] as $risk) {
+            $name = trans_message('reports.options.project_portfolio_health.risk_levels.'.$risk);
+            if ($name === 'reports.options.project_portfolio_health.risk_levels.'.$risk) {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
+            }
+            $choices[] = ['id' => $risk, 'name' => $name];
+        }
+        return $choices;
+    }
+
+    private function budgetLines(ReportScope $scope, array $projectIds): \Illuminate\Database\Query\Builder
+    {
+        return DB::table('budget_lines')
+            ->join('budget_versions', 'budget_versions.id', '=', 'budget_lines.budget_version_id')
+            ->where('budget_versions.organization_id', $scope->organizationId)
+            ->whereIn('budget_lines.project_id', $projectIds)
+            ->whereNull('budget_lines.deleted_at');
+    }
+
+    private function choice(mixed $id, mixed $name): array
+    {
+        return ['id' => is_int($id) ? $id : (string) $id, 'name' => trim((string) $name)];
+    }
+
+    private function sorted(array $choices): array
+    {
+        usort($choices, static fn (array $left, array $right): int => [$left['name'], (string) $left['id']] <=> [$right['name'], (string) $right['id']]);
+        return $choices;
+    }
+}

--- a/lang/ru/reports.php
+++ b/lang/ru/reports.php
@@ -94,6 +94,20 @@ return [
         'format_invalid' => 'Выбран некорректный формат отчета.',
     ],
     'options' => [
+        'project_portfolio_health' => [
+            'statuses' => [
+                'active' => 'Активный',
+                'completed' => 'Завершён',
+                'paused' => 'Приостановлен',
+                'cancelled' => 'Отменён',
+            ],
+            'risk_levels' => [
+                'low' => 'Низкий',
+                'medium' => 'Средний',
+                'high' => 'Высокий',
+                'critical' => 'Критический',
+            ],
+        ],
         'accepted_production_progress' => [
             'work' => 'Работа №:id',
             'work_with_name' => 'Работа №:id — :name',

--- a/tests/Support/Budgeting/project_portfolio_health_options_harness.php
+++ b/tests/Support/Budgeting/project_portfolio_health_options_harness.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+assert_options_file('app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ProjectPortfolioHealthReportOptionsController.php');
+assert_options_file('app/BusinessModules/Core/Reporting/Http/Admin/Requests/ProjectPortfolioHealthReportOptionsRequest.php');
+assert_options_file('app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php');
+
+$root = dirname(__DIR__, 3);
+$routes = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/routes.php');
+$service = (string) file_get_contents($root.'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php');
+$request = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ProjectPortfolioHealthReportOptionsRequest.php');
+
+foreach ([
+    "Route::get('/project-portfolio-health/options'",
+    "->defaults('reportCode', 'project_portfolio_health')",
+    "'report.organization-scope', \$resourceAccess",
+] as $needle) {
+    assert(str_contains($routes, $needle), 'route contract missing: '.$needle);
+}
+
+foreach ([
+    'StableReportingSourceView',
+    'Project::accessibleByOrganization($scope->organizationId)',
+    '->whereIn(\'id\', $scope->projectIds)',
+    "->where('project_user.role', 'project_manager')",
+    "->where('project_user.is_active', true)",
+    'CurrencyCode::options()',
+    "'period'", "'projects'", "'managers'", "'project_statuses'", "'responsibility_centers'", "'counterparties'", "'currencies'", "'risk_levels'",
+    'REPORT_SOURCE_UNAVAILABLE',
+] as $needle) {
+    assert(str_contains($service, $needle), 'options contract missing: '.$needle);
+}
+
+foreach (["\$this->forbiddenClientFieldsRules()", "'project_id' => ['prohibited']", "'scope' => ['prohibited']"] as $needle) {
+    assert(str_contains($request, $needle), 'server-owned request contract missing: '.$needle);
+}
+
+assert(! str_contains($routes, "Route::post('/project-portfolio-health/runs'"), 'options release must not publish R01 run route');
+assert(! str_contains($routes, 'BuiltinPublishedReportDefinitionRegistry'), 'options release must not mutate registry');
+
+echo "project portfolio health options contract: OK\n";
+
+function assert_options_file(string $relative): void
+{
+    assert(is_file(dirname(__DIR__, 3).'/'.$relative), 'missing required file: '.$relative);
+}


### PR DESCRIPTION
## Что изменено
- добавлен изолированный server-scoped options endpoint для скрытого R01;
- организация, проекты и доступ определяются сервером;
- publication, binding, runtime и admin UI не затронуты.

## Проверки
- assertions-enabled options harness;
- php -l изменённых PHP-файлов;
- git diff --check.

Локальные PHPUnit и Larastan не запускались: в worktree отсутствует vendor.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a new Project Portfolio Health report options endpoint.</li>
<li>Created ProjectPortfolioHealthReportOptionsController to handle report option requests.</li>
<li>Implemented ProjectPortfolioHealthOptionsService to provide report configuration data.</li>
<li>Added a new route for project portfolio health options.</li>
<li>Defined a new request validation class for the report options.</li>
</ul></div>