### PR TITLE
fix[reports]: исправлен контракт детализации R07

### DIFF
--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/DrillDown/EloquentLookaheadReadinessDrillDownSource.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/DrillDown/EloquentLookaheadReadinessDrillDownSource.php
@@ -31,12 +31,12 @@ final readonly class EloquentLookaheadReadinessDrillDownSource implements Lookah
     public function findRow(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        string $token,
+        string $rowKey,
     ): ?array {
         return $this->reader->findRow(
             $context,
             $snapshot,
-            $this->reader->rowKeyFromToken($token),
+            $rowKey,
         );
     }
 

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/DrillDown/LookaheadReadinessDrillDownProvider.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/DrillDown/LookaheadReadinessDrillDownProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\DrillDown;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -36,9 +36,9 @@ final readonly class LookaheadReadinessDrillDownProvider implements ReportDrillD
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
-        $row = $this->source->findRow($context, $snapshot, $request->token);
+        $row = $this->source->findRow($context, $snapshot, $input->cell->rowKey);
         if ($row === null) {
             return new ReportDrillDownResult([], null, []);
         }
@@ -46,11 +46,11 @@ final readonly class LookaheadReadinessDrillDownProvider implements ReportDrillD
         $projectId = (int) $row['project_id'];
         $contextRows = $this->contextRows($context, $row, $projectId);
         $projectionVersion = $this->projectionVersion($row);
-        $cursor = DrillDownPageCursor::decode($request->cursor);
+        $cursor = DrillDownPageCursor::decode($input->cursor);
         [$rows, $remaining, $nextContextCursor] = $this->contextPage(
             $contextRows,
             $cursor,
-            $request->limit,
+            $input->limit,
         );
         if ($nextContextCursor !== null) {
             return new ReportDrillDownResult($rows, $nextContextCursor, []);

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/DrillDown/LookaheadReadinessDrillDownSource.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/DrillDown/LookaheadReadinessDrillDownSource.php
@@ -15,7 +15,7 @@ interface LookaheadReadinessDrillDownSource
     public function findRow(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        string $token,
+        string $rowKey,
     ): ?array;
 
     public function eventPage(

--- a/tests/Unit/Reporting/Waves23/DrillDownProviderPaginationTest.php
+++ b/tests/Unit/Reporting/Waves23/DrillDownProviderPaginationTest.php
@@ -8,7 +8,6 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\AuthorizationDecisionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportActor;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownCell;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
@@ -50,7 +49,7 @@ final class DrillDownProviderPaginationTest extends TestCase
             $result = $provider->drillDown(
                 $this->context(),
                 $this->snapshot('lookahead_readiness'),
-                new ReportDrillDownRequest('token', $cursor, 2),
+                new ReportDrillDownInput(new ReportDrillDownCell('row-1', 'drill'), $cursor, 2),
             );
             self::assertLessThanOrEqual(2, count($result->rows));
             foreach ($result->rows as $row) {
@@ -66,6 +65,7 @@ final class DrillDownProviderPaginationTest extends TestCase
             'work_constraint_event:12',
             'work_constraint_event:13',
         ], $keys);
+        self::assertSame(['row-1', 'row-1', 'row-1'], $source->requestedRowKeys);
         self::assertSame(2, $source->eventPageCalls);
     }
 
@@ -80,12 +80,12 @@ final class DrillDownProviderPaginationTest extends TestCase
         $first = $lookahead->drillDown(
             $this->context(),
             $this->snapshot('lookahead_readiness'),
-            new ReportDrillDownRequest('token', null, 1),
+            new ReportDrillDownInput(new ReportDrillDownCell('row-1', 'drill'), null, 1),
         );
         $second = $lookahead->drillDown(
             $this->context(),
             $this->snapshot('lookahead_readiness'),
-            new ReportDrillDownRequest('token', $first->nextCursor, 1),
+            new ReportDrillDownInput(new ReportDrillDownCell('row-1', 'drill'), $first->nextCursor, 1),
         );
 
         self::assertSame(['lookahead_task:7:11:13:17'], array_column($first->rows, 'row_key'));
@@ -322,6 +322,8 @@ final class FakeLookaheadDrillDownSource implements LookaheadReadinessDrillDownS
 {
     public int $eventPageCalls = 0;
 
+    public array $requestedRowKeys = [];
+
     public function __construct(
         private readonly array $row,
         private readonly array $events,
@@ -332,6 +334,8 @@ final class FakeLookaheadDrillDownSource implements LookaheadReadinessDrillDownS
         ReportSnapshotRef $snapshot,
         string $rowKey,
     ): ?array {
+        $this->requestedRowKeys[] = $rowKey;
+
         return $this->row;
     }
 


### PR DESCRIPTION
## Что изменено
- R07 принимает канонический ReportDrillDownInput
- строка детализации выбирается по проверенному rowKey ячейки
- пагинация использует cursor и limit канонического входа

## Проверки
- PHPUnit: 1 тест, 9 assertions
- Pint: 4 файла
- php -l: 3 runtime-файла
- git diff --check

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored drill-down input handling by replacing ReportDrillDownRequest with ReportDrillDownInput.</li>
<li>Updated drill-down methods to use rowKey instead of token for identifying rows.</li>
<li>Updated unit tests to reflect the new input structure and verify row key usage.</li>
</ul></div>