### PR TITLE
feat[reports]: опубликован отчёт R07

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -4,37 +4,38 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Core\Reporting\Infrastructure\Catalog;
 
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
+use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceBuiltinPublishedReport;
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
-use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
-use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
-use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureBuiltinPublishedReport;
-use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
-use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityBuiltinPublishedReport;
-use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
-use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
-use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
-use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportDefinitionRegistry
 {
@@ -67,9 +68,14 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         CustomerSlaBuiltinPublishedReport $customerSla,
         HoldingPerformanceBuiltinPublishedReport $holdingPerformance,
         IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
+        ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
     ) {
         $byCode = [];
-        foreach ([$projectMargin->definition(), $budgetPlanFact->definition(), $portfolioLiquidity->definition(), $projectPortfolioHealth->definition(), $projectEvmControl->definition(), $wipCompletionForecast->definition(), $contractSettlementExposure->definition(), $baselineScheduleVariance->definition(), $acceptedProduction->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $handoverReadiness->definition(), $contractorScorecard->definition(), $customerSla->definition(), $holdingPerformance->definition(), $intercompanyContractFlow->definition()] as $definition) {
+        $definitions = [$projectMargin->definition(), $budgetPlanFact->definition(), $portfolioLiquidity->definition(), $projectPortfolioHealth->definition(), $projectEvmControl->definition(), $wipCompletionForecast->definition(), $contractSettlementExposure->definition(), $baselineScheduleVariance->definition(), $acceptedProduction->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $handoverReadiness->definition(), $contractorScorecard->definition(), $customerSla->definition(), $holdingPerformance->definition(), $intercompanyContractFlow->definition()];
+        if ($lookaheadReadiness !== null) {
+            $definitions[] = $lookaheadReadiness->definition();
+        }
+        foreach ($definitions as $definition) {
             $byCode[$definition->code] = $definition;
         }
         ksort($byCode, SORT_STRING);

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -4,35 +4,36 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Core\Reporting\Infrastructure\Catalog;
 
-use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
 use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceBuiltinPublishedReport;
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportCatalogMetadataRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
-use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureBuiltinPublishedReport;
-use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
-use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityBuiltinPublishedReport;
-use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
-use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
-use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
-use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatalogMetadataRegistry
 {
@@ -62,10 +63,16 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private CustomerSlaBuiltinPublishedReport $customerSla,
         private HoldingPerformanceBuiltinPublishedReport $holdingPerformance,
         private IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
+        private ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
     {
+        if ($this->lookaheadReadiness !== null
+            && $code === $this->lookaheadReadiness->metadata()->code) {
+            return $this->lookaheadReadiness->metadata();
+        }
+
         return match ($code) {
             $this->projectMargin->metadata()->code => $this->projectMargin->metadata(),
             $this->budgetPlanFact->metadata()->code => $this->budgetPlanFact->metadata(),

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -4,35 +4,36 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Core\Reporting\Infrastructure\Catalog;
 
-use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
 use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceBuiltinPublishedReport;
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSchedulingCapabilityRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
-use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureBuiltinPublishedReport;
-use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
-use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityBuiltinPublishedReport;
-use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
-use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
-use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
-use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
 
 final readonly class BuiltinReportSchedulingCapabilityRegistry implements ReportSchedulingCapabilityRegistry
 {
@@ -62,10 +63,16 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private CustomerSlaBuiltinPublishedReport $customerSla,
         private HoldingPerformanceBuiltinPublishedReport $holdingPerformance,
         private IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
+        private ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
     {
+        if ($this->lookaheadReadiness !== null
+            && $code === $this->lookaheadReadiness->scheduling()->code) {
+            return $this->lookaheadReadiness->scheduling();
+        }
+
         return match ($code) {
             $this->projectMargin->scheduling()->code => $this->projectMargin->scheduling(),
             $this->budgetPlanFact->scheduling()->code => $this->budgetPlanFact->scheduling(),

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -12,11 +12,10 @@ use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\IntercompanyContra
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\LookaheadReadinessReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PayrollReadinessReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\PortfolioLiquidityReportOptionsController;
-use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectPortfolioHealthReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectEvmControlReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectLaborCostReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectMarginReportOptionsController;
-use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\WipCompletionForecastReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ProjectPortfolioHealthReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportCatalogController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportDrillDownController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportExportController;
@@ -25,6 +24,7 @@ use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportRunControlle
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportSavedViewController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportSubscriptionController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ReportWorkspacePreferencesController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\WipCompletionForecastReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\WorkforceCapacityReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\AuthorizeReportDefinitionAccess;
 use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\RenderReportErrors;
@@ -160,6 +160,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'lookahead_readiness')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])
             ->name('lookahead-readiness.options');
+        Route::post('/projects/{project}/lookahead-readiness/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'lookahead_readiness')
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('lookahead-readiness.runs.store');
         Route::post('/projects/{project}/accepted-production-progress/runs', [ReportRunController::class, 'store'])
             ->defaults('reportCode', 'accepted_production_progress')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessBuiltinPublishedReport.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class LookaheadReadinessBuiltinPublishedReport
+{
+    public const MANIFEST_ORDINAL = 7;
+
+    public function __construct(private LookaheadReadinessCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            LookaheadReadinessCandidateContract::CODE,
+            'reports.catalog.lookahead_readiness',
+            ReportCatalogGroup::PROJECTS,
+            'schedule',
+            'constraint_task_window',
+            2,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(LookaheadReadinessCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return $this->contract->document('published');
+    }
+}

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessCandidateContract.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessCandidateContract.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Services\LookaheadReadinessFormula;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Services\LookaheadReadinessSnapshotMaterializer;
@@ -69,8 +70,29 @@ final readonly class LookaheadReadinessCandidateContract
         }
     }
 
-    private function document(): array
+    public function assertDefinition(ReportDefinition $definition): void
     {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'schedule-management'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || array_column($definition->filters, 'id') !== array_column($this->filters(), 'id')
+            || array_column($definition->columns, 'id') !== array_column($this->columns(), 'id')
+            || array_column($definition->sorts, 'id') !== array_column($this->sorts(), 'id')
+            || $definition->formats !== $this->formats()
+            || $definition->permissionPolicy->viewPermissions !== ['schedule.view']
+            || $definition->permissionPolicy->exportPermissions !== ['schedule.reports.export']) {
+            throw new InvalidArgumentException('lookahead_readiness_candidate_definition_invalid');
+        }
+    }
+
+    public function document(string $publication = 'blocked'): array
+    {
+        if (! in_array($publication, ['blocked', 'published'], true)) {
+            throw new InvalidArgumentException('lookahead_readiness_publication_state_invalid');
+        }
+
         return [
             'code' => self::CODE,
             'title_key' => 'reports.catalog.lookahead_readiness',
@@ -87,7 +109,7 @@ final readonly class LookaheadReadinessCandidateContract
             'versions' => ['contract' => '1.0.0', 'formula' => self::FORMULA_VERSION, 'source_schema' => self::SOURCE_SCHEMA_VERSION, 'renderer' => '1.0.0'],
             'semantic_fingerprints' => ['formula' => self::FORMULA_HASH, 'source' => self::SOURCE_HASH],
             'permissions' => ['view' => ['schedule.view'], 'export' => ['schedule.reports.export'], 'sensitive' => [], 'audit' => []],
-            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => 'blocked'],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => $publication],
             'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
         ];
     }

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class LookaheadReadinessPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private LookaheadReadinessReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(LookaheadReadinessCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+
+            throw $exception;
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessReportBindingFactory.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/Lookahead/LookaheadReadinessReportBindingFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\DrillDown\LookaheadReadinessDrillDownProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Providers\LookaheadReadinessReportProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Queries\LookaheadReadinessRowQuery;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Readiness\LookaheadReadinessProbe;
+
+final readonly class LookaheadReadinessReportBindingFactory
+{
+    public function __construct(
+        private LookaheadReadinessReportProvider $provider,
+        private LookaheadReadinessRowQuery $rows,
+        private LookaheadReadinessDrillDownProvider $drillDown,
+        private LookaheadReadinessProbe $readiness,
+        private LookaheadReadinessCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->rows,
+            $this->drillDown,
+            $this->readiness,
+        );
+    }
+}

--- a/app/BusinessModules/Features/ScheduleManagement/ScheduleManagementServiceProvider.php
+++ b/app/BusinessModules/Features/ScheduleManagement/ScheduleManagementServiceProvider.php
@@ -12,11 +12,19 @@ use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVa
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceQueryService;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceReportBindingFactory;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\HistoricalScheduleTaskStateQuery;
-use App\BusinessModules\Features\ScheduleManagement\Reporting\Readiness\BaselineScheduleVarianceReadinessProbe;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\DrillDown\LookaheadReadinessDrillDownProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessReportBindingFactory;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Providers\LookaheadReadinessReportProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Queries\LookaheadReadinessRowQuery;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Readiness\LookaheadReadinessProbe;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Services\LookaheadReadinessSnapshotMaterializer;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\LookaheadReadiness\Contracts\LookaheadReadinessAuthorizer;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\LookaheadReadiness\Contracts\LookaheadReadinessSourceStore;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\LookaheadReadiness\Services\EloquentLookaheadReadinessSourceStore;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\LookaheadReadiness\Services\LaravelLookaheadReadinessAuthorizer;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Readiness\BaselineScheduleVarianceReadinessProbe;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -47,6 +55,14 @@ class ScheduleManagementServiceProvider extends ServiceProvider
         $this->app->singleton(BaselineScheduleVarianceCandidateContract::class);
         $this->app->scoped(BaselineScheduleVarianceReportBindingFactory::class);
         $this->app->scoped(BaselineScheduleVariancePublishedRuntimeBindingRegistrar::class);
+        $this->app->singleton(LookaheadReadinessCandidateContract::class);
+        $this->app->scoped(LookaheadReadinessSnapshotMaterializer::class);
+        $this->app->scoped(LookaheadReadinessReportProvider::class);
+        $this->app->scoped(LookaheadReadinessRowQuery::class);
+        $this->app->scoped(LookaheadReadinessDrillDownProvider::class);
+        $this->app->scoped(LookaheadReadinessProbe::class);
+        $this->app->scoped(LookaheadReadinessReportBindingFactory::class);
+        $this->app->scoped(LookaheadReadinessPublishedRuntimeBindingRegistrar::class);
     }
 
     public function boot(): void
@@ -55,6 +71,7 @@ class ScheduleManagementServiceProvider extends ServiceProvider
             ReportDefinitionBindingAssembler::class,
             function (ReportDefinitionBindingAssembler $assembler): void {
                 $this->app->make(BaselineScheduleVariancePublishedRuntimeBindingRegistrar::class)->register($assembler);
+                $this->app->make(LookaheadReadinessPublishedRuntimeBindingRegistrar::class)->register($assembler);
             },
         );
 

--- a/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
+++ b/tests/Unit/Reporting/Catalog/BuiltinPublishedReportDefinitionRegistryTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Reporting\Catalog;
 
-use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
-use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowCandidateContract;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
+use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardCandidateContract;
 use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceBuiltinPublishedReport;
 use App\BusinessModules\Core\MultiOrganization\Reporting\HoldingPerformanceCandidateContract;
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowBuiltinPublishedReport;
+use App\BusinessModules\Core\MultiOrganization\Reporting\IntercompanyContractFlowCandidateContract;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportCatalogMetadataRegistry;
@@ -23,34 +25,30 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\DatabaseReportCata
 use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\DatabaseReportSchedulingCapabilityRegistry;
 use App\BusinessModules\Core\Reporting\ReportingCatalogServiceProvider;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlCandidateContract;
-use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
-use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureBuiltinPublishedReport;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureCandidateContract;
-use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
-use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskCandidateContract;
-use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
-use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardCandidateContract;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleBuiltinPublishedReport;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\ProcurementCycleCandidateContract;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Supply\SupplyReliabilityCandidateContract;
-use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
-use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
-use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowBuiltinPublishedReport;
 use App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\QualityDefectFlowCandidateContract;
 use App\BusinessModules\Features\SafetyManagement\Reporting\Admission\WorkforceAdmissionBuiltinPublishedReport;
@@ -59,14 +57,20 @@ use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Safe
 use App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\SafetyIncidentActionsCandidateContract;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceBuiltinPublishedReport;
 use App\BusinessModules\Features\ScheduleManagement\Reporting\BaselineScheduleVarianceCandidateContract;
-use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
-use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessCandidateContract;
-use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardBuiltinPublishedReport;
-use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\ContractorScorecardCandidateContract;
-use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
-use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessCandidateContract;
+use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostBuiltinPublishedReport;
+use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\AttendanceExecutionCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessCandidateContract;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityBuiltinPublishedReport;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\WorkforceCapacityCandidateContract;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionBuiltinPublishedReport;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\AcceptedProductionCandidateContract;
+use App\Services\Customer\Reporting\Sla\CustomerSlaBuiltinPublishedReport;
+use App\Services\Customer\Reporting\Sla\CustomerSlaCandidateContract;
 use Illuminate\Foundation\Application;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -208,6 +212,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->projectMargin(),
             new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract),
             $this->portfolioLiquidity(),
+            $this->projectPortfolioHealth(),
             $this->projectEvmControl(),
             $this->wipCompletionForecast(),
             $this->contractSettlementExposure(),
@@ -229,10 +234,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->customerSla(),
             $this->holdingPerformance(),
             $this->intercompanyContractFlow(),
+            $this->lookaheadReadiness(),
         );
         $registry = new CompositePublishedReportDefinitionRegistry($builtins, $this->registry([]));
 
-        self::assertSame(['accepted_production_progress', 'attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'contract_settlement_exposure', 'contractor_scorecard', 'customer_sla', 'handover_readiness', 'holding_performance', 'intercompany_contract_flows', 'inventory_risk', 'payroll_readiness', 'portfolio_liquidity', 'procurement_cycle', 'project_evm_control', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'wip_completion_forecast', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
+        self::assertSame(['accepted_production_progress', 'attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'contract_settlement_exposure', 'contractor_scorecard', 'customer_sla', 'handover_readiness', 'holding_performance', 'intercompany_contract_flows', 'inventory_risk', 'lookahead_readiness', 'payroll_readiness', 'portfolio_liquidity', 'procurement_cycle', 'project_evm_control', 'project_labor_cost', 'project_margin', 'project_portfolio_health', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'wip_completion_forecast', 'workforce_admission', 'workforce_capacity'], $registry->publishedCodes());
         self::assertSame('project_margin', $registry->published('project_margin')->code);
         $definition = $registry->published('budget_plan_fact');
         $payload = $definition->payload();
@@ -253,6 +259,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->projectMargin(),
             new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract),
             $this->portfolioLiquidity(),
+            $this->projectPortfolioHealth(),
             $this->projectEvmControl(),
             $this->wipCompletionForecast(),
             $this->contractSettlementExposure(),
@@ -274,15 +281,18 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
             $this->customerSla(),
             $this->holdingPerformance(),
             $this->intercompanyContractFlow(),
+            $this->lookaheadReadiness(),
         );
 
         $expectedModules = [
             'budget_plan_fact' => 'budgeting',
             'portfolio_liquidity' => 'budgeting',
+            'project_portfolio_health' => 'budgeting',
             'project_evm_control' => 'budgeting',
             'wip_completion_forecast' => 'budgeting',
             'contract_settlement_exposure' => 'contract-management',
             'baseline_schedule_variance' => 'schedule-management',
+            'lookahead_readiness' => 'schedule-management',
             'accepted_production_progress' => 'contract-management',
             'project_margin' => 'budgeting',
             'project_labor_cost' => 'time-tracking',
@@ -317,11 +327,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->portfolioLiquidity(), $this->projectEvmControl(), $this->wipCompletionForecast(), $this->contractSettlementExposure(), $this->baselineScheduleVariance(), $this->acceptedProduction(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->contractorScorecard(), $this->customerSla(), $this->holdingPerformance(), $this->intercompanyContractFlow()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->portfolioLiquidity(), $this->projectPortfolioHealth(), $this->projectEvmControl(), $this->wipCompletionForecast(), $this->contractSettlementExposure(), $this->baselineScheduleVariance(), $this->acceptedProduction(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->contractorScorecard(), $this->customerSla(), $this->holdingPerformance(), $this->intercompanyContractFlow(), $this->lookaheadReadiness()),
             $this->registry(['ordinary_report' => $builtin]),
         );
 
-        self::assertSame(['accepted_production_progress', 'attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'contract_settlement_exposure', 'contractor_scorecard', 'customer_sla', 'handover_readiness', 'holding_performance', 'intercompany_contract_flows', 'inventory_risk', 'payroll_readiness', 'portfolio_liquidity', 'procurement_cycle', 'project_evm_control', 'project_labor_cost', 'project_margin', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'wip_completion_forecast', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
+        self::assertSame(['accepted_production_progress', 'attendance_execution', 'baseline_schedule_variance', 'budget_plan_fact', 'contract_settlement_exposure', 'contractor_scorecard', 'customer_sla', 'handover_readiness', 'holding_performance', 'intercompany_contract_flows', 'inventory_risk', 'lookahead_readiness', 'payroll_readiness', 'portfolio_liquidity', 'procurement_cycle', 'project_evm_control', 'project_labor_cost', 'project_margin', 'project_portfolio_health', 'quality_defect_flow', 'safety_incident_actions', 'supplier_award_competitiveness', 'supply_reliability', 'wip_completion_forecast', 'workforce_admission', 'workforce_capacity', 'ordinary_report'], $registry->publishedCodes());
         self::assertSame($builtin, $registry->published('ordinary_report'));
     }
 
@@ -329,7 +339,7 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     {
         $builtin = (new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract))->definition();
         $registry = new CompositePublishedReportDefinitionRegistry(
-            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->portfolioLiquidity(), $this->projectEvmControl(), $this->wipCompletionForecast(), $this->contractSettlementExposure(), $this->baselineScheduleVariance(), $this->acceptedProduction(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->contractorScorecard(), $this->customerSla(), $this->holdingPerformance(), $this->intercompanyContractFlow()),
+            new BuiltinPublishedReportDefinitionRegistry($this->projectMargin(), new BudgetPlanFactBuiltinPublishedReport(new BudgetPlanFactCandidateContract), $this->portfolioLiquidity(), $this->projectPortfolioHealth(), $this->projectEvmControl(), $this->wipCompletionForecast(), $this->contractSettlementExposure(), $this->baselineScheduleVariance(), $this->acceptedProduction(), $this->projectLaborCost(), $this->payrollReadiness(), $this->workforceCapacity(), $this->procurementCycle(), $this->supplierAward(), $this->supplyReliability(), $this->inventoryRisk(), $this->attendanceExecution(), $this->qualityDefectFlow(), $this->safetyIncidentActions(), $this->workforceAdmission(), $this->handoverReadiness(), $this->contractorScorecard(), $this->customerSla(), $this->holdingPerformance(), $this->intercompanyContractFlow(), $this->lookaheadReadiness()),
             $this->registry(['budget_plan_fact' => $builtin]),
         );
 
@@ -378,6 +388,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
         return new PortfolioLiquidityBuiltinPublishedReport(new PortfolioLiquidityCandidateContract);
     }
 
+    private function projectPortfolioHealth(): ProjectPortfolioHealthBuiltinPublishedReport
+    {
+        return new ProjectPortfolioHealthBuiltinPublishedReport(new ProjectPortfolioHealthCandidateContract);
+    }
+
     private function projectEvmControl(): ProjectEvmControlBuiltinPublishedReport
     {
         return new ProjectEvmControlBuiltinPublishedReport(new ProjectEvmControlCandidateContract);
@@ -401,6 +416,11 @@ final class BuiltinPublishedReportDefinitionRegistryTest extends TestCase
     private function baselineScheduleVariance(): BaselineScheduleVarianceBuiltinPublishedReport
     {
         return new BaselineScheduleVarianceBuiltinPublishedReport(new BaselineScheduleVarianceCandidateContract);
+    }
+
+    private function lookaheadReadiness(): LookaheadReadinessBuiltinPublishedReport
+    {
+        return new LookaheadReadinessBuiltinPublishedReport(new LookaheadReadinessCandidateContract);
     }
 
     private function acceptedProduction(): AcceptedProductionBuiltinPublishedReport

--- a/tests/Unit/Reporting/Waves23/LookaheadReadinessPublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/LookaheadReadinessPublishedContractTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\DrillDown\LookaheadReadinessDrillDownProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessBuiltinPublishedReport;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessCandidateContract;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\LookaheadReadinessReportBindingFactory;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Providers\LookaheadReadinessReportProvider;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Queries\LookaheadReadinessRowQuery;
+use App\BusinessModules\Features\ScheduleManagement\Reporting\Lookahead\Readiness\LookaheadReadinessProbe;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class LookaheadReadinessPublishedContractTest extends TestCase
+{
+    public function test_published_definition_preserves_verified_r07_contract(): void
+    {
+        $published = new LookaheadReadinessBuiltinPublishedReport(new LookaheadReadinessCandidateContract);
+        $definition = $published->definition()->payload();
+
+        self::assertSame('lookahead_readiness', $definition->code);
+        self::assertSame('lookahead_readiness.v1', $definition->formulaVersion);
+        self::assertSame('lookahead_events_v1', $definition->sourceSchemaVersion);
+        self::assertSame('published', $definition->publicationReadiness->value);
+        self::assertSame(7, $published->metadata()->manifestOrdinal);
+        self::assertFalse($published->scheduling()->supportsSubscriptions);
+    }
+
+    public function test_authoritative_registries_and_project_run_route_include_r07(): void
+    {
+        $root = dirname(__DIR__, 4);
+        $definitionRegistry = file_get_contents($root.'/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php');
+        $metadataRegistry = file_get_contents($root.'/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php');
+        $schedulingRegistry = file_get_contents($root.'/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php');
+        $routes = file_get_contents($root.'/app/BusinessModules/Core/Reporting/routes.php');
+
+        foreach ([$definitionRegistry, $metadataRegistry, $schedulingRegistry] as $source) {
+            self::assertIsString($source);
+            self::assertStringContainsString('LookaheadReadinessBuiltinPublishedReport', $source);
+        }
+        self::assertIsString($routes);
+        self::assertStringContainsString("Route::post('/projects/{project}/lookahead-readiness/runs'", $routes);
+        self::assertStringContainsString("->defaults('reportCode', 'lookahead_readiness')", $routes);
+    }
+
+    public function test_runtime_binding_registers_the_verified_r07_components(): void
+    {
+        $contract = new LookaheadReadinessCandidateContract;
+        $definition = (new LookaheadReadinessBuiltinPublishedReport($contract))->definition();
+        $provider = (new ReflectionClass(LookaheadReadinessReportProvider::class))->newInstanceWithoutConstructor();
+        $rows = (new ReflectionClass(LookaheadReadinessRowQuery::class))->newInstanceWithoutConstructor();
+        $drillDown = new LookaheadReadinessDrillDownProvider;
+        $readiness = (new ReflectionClass(LookaheadReadinessProbe::class))->newInstanceWithoutConstructor();
+        $assembler = new LookaheadReadinessCapturingBindingAssembler;
+        $registrar = new LookaheadReadinessPublishedRuntimeBindingRegistrar(
+            new LookaheadReadinessPublishedRegistry($definition),
+            new LookaheadReadinessReportBindingFactory(
+                $provider,
+                $rows,
+                $drillDown,
+                $readiness,
+                $contract,
+            ),
+        );
+
+        $registrar->register($assembler);
+
+        $binding = $assembler->bindings[LookaheadReadinessCandidateContract::CODE];
+        self::assertSame($provider, $binding->dataProvider);
+        self::assertSame($rows, $binding->rowQuery);
+        self::assertSame($drillDown, $binding->drillDownProvider);
+        self::assertSame($readiness, $binding->readinessProbe);
+    }
+}
+
+final class LookaheadReadinessCapturingBindingAssembler implements ReportDefinitionBindingAssembler
+{
+    public array $bindings = [];
+
+    public function register(ReportDefinitionBinding $binding): void
+    {
+        $this->bindings[$binding->code] = $binding;
+    }
+
+    public function assemble(ReportDefinitionRegistry $registry): ReportDefinitionBindingMap
+    {
+        throw new LogicException('not_used');
+    }
+}
+
+final readonly class LookaheadReadinessPublishedRegistry implements ReportDefinitionRegistry
+{
+    public function __construct(private PublishedReportDefinition $definition) {}
+
+    public function published(string $code): PublishedReportDefinition
+    {
+        return $code === LookaheadReadinessCandidateContract::CODE
+            ? $this->definition
+            : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+    }
+
+    public function publishedCodes(): array
+    {
+        return [LookaheadReadinessCandidateContract::CODE];
+    }
+
+    public function manifestSha256(): Sha256Hash
+    {
+        return new Sha256Hash(str_repeat('a', 64));
+    }
+}


### PR DESCRIPTION
## Что изменено
- R07 добавлен в единые серверные реестры каталога, metadata и scheduling
- зарегистрован канонический runtime binding с readiness и drill-down
- добавлен project-scoped endpoint запуска без клиентской подмены контекста
- публикация закреплена проверкой неизменяемых formula/source fingerprints

## Проверки
- publication/catalog: 9 тестов, 178 assertions
- drill-down regression: 1 тест, 9 assertions
- Pint: 11 файлов
- git diff --check
- PHPStan: bootstrap остановлен общей storage_configuration_invalid (известная граница окружения)