### PR TITLE
feat: публикация управленческого P&L

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -15,6 +15,7 @@ use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
@@ -69,11 +70,15 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         HoldingPerformanceBuiltinPublishedReport $holdingPerformance,
         IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
         ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
+        ?ManagementPnlBuiltinPublishedReport $managementPnl = null,
     ) {
         $byCode = [];
         $definitions = [$projectMargin->definition(), $budgetPlanFact->definition(), $portfolioLiquidity->definition(), $projectPortfolioHealth->definition(), $projectEvmControl->definition(), $wipCompletionForecast->definition(), $contractSettlementExposure->definition(), $baselineScheduleVariance->definition(), $acceptedProduction->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $handoverReadiness->definition(), $contractorScorecard->definition(), $customerSla->definition(), $holdingPerformance->definition(), $intercompanyContractFlow->definition()];
         if ($lookaheadReadiness !== null) {
             $definitions[] = $lookaheadReadiness->definition();
+        }
+        if ($managementPnl !== null) {
+            $definitions[] = $managementPnl->definition();
         }
         foreach ($definitions as $definition) {
             $byCode[$definition->code] = $definition;

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportCatalogMetadataReg
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
 use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
@@ -64,6 +65,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private HoldingPerformanceBuiltinPublishedReport $holdingPerformance,
         private IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
         private ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
+        private ?ManagementPnlBuiltinPublishedReport $managementPnl = null,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -71,6 +73,10 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         if ($this->lookaheadReadiness !== null
             && $code === $this->lookaheadReadiness->metadata()->code) {
             return $this->lookaheadReadiness->metadata();
+        }
+        if ($this->managementPnl !== null
+            && $code === $this->managementPnl->metadata()->code) {
+            return $this->managementPnl->metadata();
         }
 
         return match ($code) {

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSchedulingCapabili
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
 use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\InventoryRiskBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
@@ -64,6 +65,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private HoldingPerformanceBuiltinPublishedReport $holdingPerformance,
         private IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
         private ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
+        private ?ManagementPnlBuiltinPublishedReport $managementPnl = null,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -71,6 +73,10 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         if ($this->lookaheadReadiness !== null
             && $code === $this->lookaheadReadiness->scheduling()->code) {
             return $this->lookaheadReadiness->scheduling();
+        }
+        if ($this->managementPnl !== null
+            && $code === $this->managementPnl->scheduling()->code) {
+            return $this->managementPnl->scheduling();
         }
 
         return match ($code) {

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -134,6 +134,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'management_pnl')
             ->middleware(['report.organization-scope', $resourceAccess])
             ->name('management-pnl.options');
+        Route::post('/management-pnl/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'management_pnl')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('management-pnl.runs.store');
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');

--- a/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
+++ b/app/BusinessModules/Features/Budgeting/BudgetingServiceProvider.php
@@ -15,22 +15,29 @@ use App\BusinessModules\Features\Budgeting\Models\BudgetLimitReservation;
 use App\BusinessModules\Features\Budgeting\Models\BudgetVersion;
 use App\BusinessModules\Features\Budgeting\Models\CashGapOpeningBalance;
 use App\BusinessModules\Features\Budgeting\Reporting\BudgetPlanFactCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlComponentSet;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlProjectionService;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlProvider;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlQueryService;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\Readiness\ManagementPnlReadinessProbe;
 use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\Services\ManagementPnlOptionsService;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\BudgetingPortfolioQueryService;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\EloquentProjectPortfolioHealthSourceReader;
-use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityBudgetVersionObserver;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityCandidateContract;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityProvider;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityPublishedRuntimeBindingRegistrar;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquidityReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\PortfolioLiquiditySourceVersionObserver;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthOwnerSourcePolicy;
-use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthReadinessProbe;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthProvider;
-use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthReadinessProbe;
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthReportBindingFactory;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthSourceReader;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\DrillDown\ProjectEvmControlDrillDownProvider;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlCandidateContract;
@@ -40,13 +47,15 @@ use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Providers\Pr
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Queries\ProjectEvmControlRowQuery;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Readiness\ProjectControlReadinessProbe;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\Services\ProjectEvmControlOptionsService;
-use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\BudgetPlanFactManagementPnlComponentSource;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\ProjectFinanceQueryService;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\ProjectMarginManagementPnlComponentSource;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastCandidateContract;
-use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastProvider;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastOptionsService;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastProvider;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastPublishedRuntimeBindingRegistrar;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastReportBindingFactory;
+use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginCandidateContract;
 use App\BusinessModules\Features\Budgeting\Services\BudgetCatalogService;
 use App\BusinessModules\Features\Budgeting\Services\BudgetImportFileReader;
 use App\BusinessModules\Features\Budgeting\Services\BudgetImportService;
@@ -82,6 +91,8 @@ use App\BusinessModules\Features\Budgeting\Services\ProjectMarginSourceSnapshotM
 use App\BusinessModules\Features\Budgeting\Services\ProjectMarginSourceSnapshotWriter;
 use App\BusinessModules\Features\Budgeting\Services\ProjectPortfolioDashboardPayloadBuilder;
 use App\BusinessModules\Features\Budgeting\Services\ProjectPortfolioDashboardService;
+use App\BusinessModules\Features\TimeTracking\Reporting\ProjectLaborCostManagementPnlComponentSource;
+use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessManagementPnlComponentSource;
 use Illuminate\Support\ServiceProvider;
 
 final class BudgetingServiceProvider extends ServiceProvider
@@ -97,8 +108,23 @@ final class BudgetingServiceProvider extends ServiceProvider
         $this->app->singleton(PlanFactReportSourceSnapshotAdapter::class);
         $this->app->singleton(BudgetPlanFactCandidateContract::class);
         $this->app->singleton(ManagementPnlCandidateContract::class);
+        $this->app->singleton(ManagementPnlBuiltinPublishedReport::class);
+        $this->app->scoped(ManagementPnlComponentSet::class);
+        $this->app->scoped(ManagementPnlProjectionService::class, static fn ($app): ManagementPnlProjectionService => new ManagementPnlProjectionService(
+            [
+                $app->make(ProjectMarginManagementPnlComponentSource::class),
+                $app->make(BudgetPlanFactManagementPnlComponentSource::class),
+                $app->make(ProjectLaborCostManagementPnlComponentSource::class),
+                $app->make(PayrollReadinessManagementPnlComponentSource::class),
+            ],
+            $app->make(ManagementPnlComponentSet::class),
+        ));
+        $this->app->scoped(ManagementPnlProvider::class);
+        $this->app->scoped(ManagementPnlQueryService::class);
         $this->app->scoped(ManagementPnlReadinessProbe::class);
         $this->app->scoped(ManagementPnlOptionsService::class);
+        $this->app->scoped(ManagementPnlReportBindingFactory::class);
+        $this->app->scoped(ManagementPnlPublishedRuntimeBindingRegistrar::class);
         $this->app->singleton(BudgetPlanFactReportBindingFactory::class);
         $this->app->singleton(BudgetPlanFactPublishedRuntimeBindingRegistrar::class);
         $this->app->singleton(ProjectMarginSourceSnapshotMaterializer::class);
@@ -172,6 +198,9 @@ final class BudgetingServiceProvider extends ServiceProvider
                     ->register($assembler);
                 $this->app
                     ->make(ProjectMarginPublishedRuntimeBindingRegistrar::class)
+                    ->register($assembler);
+                $this->app
+                    ->make(ManagementPnlPublishedRuntimeBindingRegistrar::class)
                     ->register($assembler);
                 $this->app
                     ->make(PortfolioLiquidityPublishedRuntimeBindingRegistrar::class)

--- a/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlBuiltinPublishedReport.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class ManagementPnlBuiltinPublishedReport
+{
+    public const MANIFEST_ORDINAL = 13;
+
+    public function __construct(private ManagementPnlCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            ManagementPnlCandidateContract::CODE,
+            'reports.catalog.management_pnl',
+            ReportCatalogGroup::FINANCE,
+            'finance',
+            'organization_article_period_scenario',
+            1,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(ManagementPnlCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return $this->contract->document('published');
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlProvider.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlProvider.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\Models\ManagementPnlPolicy;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\Readiness\ManagementPnlReadinessProbe;
 use DomainException;
 
 final readonly class ManagementPnlProvider implements ReportDataProvider
@@ -18,16 +19,17 @@ final readonly class ManagementPnlProvider implements ReportDataProvider
     public function __construct(
         private ManagementPnlProjectionService $projection,
         private ManagementPnlQueryService $query,
-    ) {
-    }
+        private ManagementPnlReadinessProbe $readiness,
+    ) {}
 
     public function materialize(ReportExecutionContext $context, ReportQuery $query, ReportProgress $progress): ReportSnapshotRef
     {
+        $this->readiness->assertRunnable($context, $query);
         $record = ManagementPnlPolicy::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('status', 'active')
             ->first();
-        if (!$record instanceof ManagementPnlPolicy) {
+        if (! $record instanceof ManagementPnlPolicy) {
             throw new DomainException('management_pnl_active_policy_missing');
         }
         $policy = new ManagementAccountingPolicy(

--- a/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class ManagementPnlPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private ManagementPnlReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(ManagementPnlCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+
+            throw $exception;
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlReportBindingFactory.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlReportBindingFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\Readiness\ManagementPnlReadinessProbe;
+
+final readonly class ManagementPnlReportBindingFactory
+{
+    public function __construct(
+        private ManagementPnlProvider $provider,
+        private ManagementPnlQueryService $query,
+        private ManagementPnlReadinessProbe $readiness,
+        private ManagementPnlCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->query,
+            $this->query,
+            $this->readiness,
+        );
+    }
+}

--- a/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/Readiness/ManagementPnlReadinessProbe.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/Readiness/ManagementPnlReadinessProbe.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\Readiness;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionReadinessProbe;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
@@ -20,7 +25,7 @@ use App\BusinessModules\Features\WorkforceManagement\Reporting\Models\PayrollRea
 use App\BusinessModules\Features\WorkforceManagement\Reporting\PayrollReadinessManagementPnlComponentSource;
 use DomainException;
 
-final readonly class ManagementPnlReadinessProbe
+final readonly class ManagementPnlReadinessProbe implements ReportDefinitionReadinessProbe
 {
     public function __construct(
         private ProjectMarginManagementPnlComponentSource $margin,
@@ -29,6 +34,26 @@ final readonly class ManagementPnlReadinessProbe
         private PayrollReadinessManagementPnlComponentSource $payroll,
         private ManagementPnlComponentSet $componentSet,
     ) {}
+
+    public function supports(ReportDefinition $definition): bool
+    {
+        return $definition->code === 'management_pnl'
+            && $definition->formulaVersion === 'management-pnl.v1';
+    }
+
+    public function assertRunnable(ReportExecutionContext $context, ReportQuery $query): void
+    {
+        $filters = $query->filters->values;
+        $periodFrom = (string) ($filters['period_from'] ?? '');
+        $periodTo = (string) ($filters['period_to'] ?? '');
+        $scopeHash = hash('sha256', CanonicalJson::encode($context->scope->canonicalIdentity()));
+        if ($this->factCount($context->scope, $query, $periodFrom, $periodTo, $scopeHash) === 0) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE, [
+                'report_code' => 'management_pnl',
+                'availability' => 'no_data',
+            ]);
+        }
+    }
 
     public function inspect(ReportScope $scope, ReportQuery $query): ManagementPnlReadinessSnapshot
     {
@@ -40,31 +65,7 @@ final readonly class ManagementPnlReadinessProbe
             : '';
         $scopeHash = hash('sha256', CanonicalJson::encode($scope->canonicalIdentity()));
 
-        $financeFacts = (int) ProjectFinanceSnapshot::query()
-            ->where('organization_id', $scope->organizationId)
-            ->whereIn('report_code', ['project_margin', 'budget_plan_fact'])
-            ->whereDate('period_from', $periodFrom)
-            ->whereDate('period_to', $periodTo)
-            ->where('scope_hash', $scopeHash)
-            ->where('generated_at', '<=', $query->asOf)
-            ->sum('row_count');
-        $laborFacts = ApprovedTimeEntryReportingFact::query()
-            ->where('organization_id', $scope->organizationId)
-            ->whereBetween('work_date', [$periodFrom, $periodTo])
-            ->where('approved_at', '<=', $query->asOf)
-            ->when($scope->projectIds !== [], static fn ($builder) => $builder->whereIn('project_id', $scope->projectIds))
-            ->count();
-        $payrollFacts = (int) PayrollReadinessSnapshot::query()
-            ->where('organization_id', $scope->organizationId)
-            ->whereDate('period_from', '>=', $periodFrom)
-            ->whereDate('period_to', '<=', $periodTo)
-            ->where('locked_at', '<=', $query->asOf)
-            ->when($scope->projectIds !== [], static fn ($builder) => $builder
-                ->where(static fn ($projects) => $projects
-                    ->whereNull('project_id')
-                    ->orWhereIn('project_id', $scope->projectIds)))
-            ->sum('row_count');
-        $factCount = $financeFacts + $laborFacts + $payrollFacts;
+        $factCount = $this->factCount($scope, $query, $periodFrom, $periodTo, $scopeHash);
         $hasPolicy = ManagementPnlPolicy::query()
             ->where('organization_id', $scope->organizationId)
             ->where('status', 'active')
@@ -130,6 +131,41 @@ final readonly class ManagementPnlReadinessProbe
             $this->ids($dimensionRows->pluck('responsibility_center_id')->all()),
             $this->ids($dimensionRows->pluck('budget_article_id')->all()),
         );
+    }
+
+    private function factCount(
+        ReportScope $scope,
+        ReportQuery $query,
+        string $periodFrom,
+        string $periodTo,
+        string $scopeHash,
+    ): int {
+        $financeFacts = (int) ProjectFinanceSnapshot::query()
+            ->where('organization_id', $scope->organizationId)
+            ->whereIn('report_code', ['project_margin', 'budget_plan_fact'])
+            ->whereDate('period_from', $periodFrom)
+            ->whereDate('period_to', $periodTo)
+            ->where('scope_hash', $scopeHash)
+            ->where('generated_at', '<=', $query->asOf)
+            ->sum('row_count');
+        $laborFacts = ApprovedTimeEntryReportingFact::query()
+            ->where('organization_id', $scope->organizationId)
+            ->whereBetween('work_date', [$periodFrom, $periodTo])
+            ->where('approved_at', '<=', $query->asOf)
+            ->when($scope->projectIds !== [], static fn ($builder) => $builder->whereIn('project_id', $scope->projectIds))
+            ->count();
+        $payrollFacts = (int) PayrollReadinessSnapshot::query()
+            ->where('organization_id', $scope->organizationId)
+            ->whereDate('period_from', '>=', $periodFrom)
+            ->whereDate('period_to', '<=', $periodTo)
+            ->where('locked_at', '<=', $query->asOf)
+            ->when($scope->projectIds !== [], static fn ($builder) => $builder
+                ->where(static fn ($projects) => $projects
+                    ->whereNull('project_id')
+                    ->orWhereIn('project_id', $scope->projectIds)))
+            ->sum('row_count');
+
+        return $financeFacts + $laborFacts + $payrollFacts;
     }
 
     /** @return list<int> */

--- a/tests/Unit/Reporting/WaveOne/ManagementPnlPublishedContractTest.php
+++ b/tests/Unit/Reporting/WaveOne/ManagementPnlPublishedContractTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\WaveOne;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlBuiltinPublishedReport;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlCandidateContract;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlProvider;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlQueryService;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\ManagementPnlReportBindingFactory;
+use App\BusinessModules\Features\Budgeting\Reporting\ManagementPnl\Readiness\ManagementPnlReadinessProbe;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ManagementPnlPublishedContractTest extends TestCase
+{
+    public function test_published_definition_preserves_verified_r13_contract(): void
+    {
+        $published = new ManagementPnlBuiltinPublishedReport(new ManagementPnlCandidateContract);
+        $definition = $published->definition()->payload();
+
+        self::assertSame('management_pnl', $definition->code);
+        self::assertSame('management-pnl.v1', $definition->formulaVersion);
+        self::assertSame('management-pnl-components.v1', $definition->sourceSchemaVersion);
+        self::assertSame('published', $definition->publicationReadiness->value);
+        self::assertSame(13, $published->metadata()->manifestOrdinal);
+        self::assertFalse($published->scheduling()->supportsSubscriptions);
+    }
+
+    public function test_authoritative_registries_and_run_route_include_r13(): void
+    {
+        $root = dirname(__DIR__, 4);
+        foreach ([
+            'BuiltinPublishedReportDefinitionRegistry.php',
+            'BuiltinReportCatalogMetadataRegistry.php',
+            'BuiltinReportSchedulingCapabilityRegistry.php',
+        ] as $file) {
+            $source = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/'.$file);
+            self::assertStringContainsString('ManagementPnlBuiltinPublishedReport', $source);
+        }
+        $routes = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/routes.php');
+        self::assertStringContainsString("Route::post('/management-pnl/runs'", $routes);
+        self::assertStringContainsString("->defaults('reportCode', 'management_pnl')", $routes);
+    }
+
+    public function test_runtime_binding_registers_existing_r13_runtime(): void
+    {
+        $contract = new ManagementPnlCandidateContract;
+        $definition = (new ManagementPnlBuiltinPublishedReport($contract))->definition();
+        $provider = (new ReflectionClass(ManagementPnlProvider::class))->newInstanceWithoutConstructor();
+        $query = (new ReflectionClass(ManagementPnlQueryService::class))->newInstanceWithoutConstructor();
+        $readiness = (new ReflectionClass(ManagementPnlReadinessProbe::class))->newInstanceWithoutConstructor();
+        $assembler = new ManagementPnlCapturingBindingAssembler;
+        $registrar = new ManagementPnlPublishedRuntimeBindingRegistrar(
+            new ManagementPnlPublishedRegistry($definition),
+            new ManagementPnlReportBindingFactory($provider, $query, $readiness, $contract),
+        );
+
+        $registrar->register($assembler);
+
+        $binding = $assembler->bindings['management_pnl'];
+        self::assertSame($provider, $binding->dataProvider);
+        self::assertSame($query, $binding->rowQuery);
+        self::assertSame($query, $binding->drillDownProvider);
+        self::assertSame($readiness, $binding->readinessProbe);
+    }
+
+    public function test_provider_checks_readiness_before_materialization(): void
+    {
+        $root = dirname(__DIR__, 4);
+        $provider = (string) file_get_contents($root.'/app/BusinessModules/Features/Budgeting/Reporting/ManagementPnl/ManagementPnlProvider.php');
+
+        $guard = strpos($provider, '$this->readiness->assertRunnable($context, $query);');
+        $policyLookup = strpos($provider, 'ManagementPnlPolicy::query()');
+        self::assertIsInt($guard);
+        self::assertIsInt($policyLookup);
+        self::assertLessThan($policyLookup, $guard);
+    }
+}
+
+final class ManagementPnlCapturingBindingAssembler implements ReportDefinitionBindingAssembler
+{
+    public array $bindings = [];
+
+    public function register(ReportDefinitionBinding $binding): void
+    {
+        $this->bindings[$binding->code] = $binding;
+    }
+
+    public function assemble(ReportDefinitionRegistry $registry): ReportDefinitionBindingMap
+    {
+        throw new LogicException('not_used');
+    }
+}
+
+final readonly class ManagementPnlPublishedRegistry implements ReportDefinitionRegistry
+{
+    public function __construct(private PublishedReportDefinition $definition) {}
+
+    public function published(string $code): PublishedReportDefinition
+    {
+        return $code === 'management_pnl'
+            ? $this->definition
+            : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+    }
+
+    public function publishedCodes(): array
+    {
+        return ['management_pnl'];
+    }
+
+    public function manifestSha256(): Sha256Hash
+    {
+        return new Sha256Hash(str_repeat('a', 64));
+    }
+}


### PR DESCRIPTION
## Что сделано
- R13 опубликован в едином реестре, каталоге и scheduling-контракте
- существующие provider, rows и drill-down подключены через runtime binding
- добавлен отдельный organization-scoped run route
- запуск без фактов прекращается до материализации snapshot
- DI собирает точный набор из четырёх канонических источников

## Проверки
- 19 изолированных тестов, 217 утверждений
- Pint для изменённых файлов
- PHPStan для изменённых PHP-файлов
- git diff --check