### PR TITLE
feat[reports]: добавлена готовность R14

### DIFF
--- a/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ChangeClaimReportOptionsController.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Controllers/ChangeClaimReportOptionsController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Controllers;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Http\Admin\Requests\ChangeClaimReportOptionsRequest;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimCandidateContract;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services\ChangeClaimOptionsService;
+use App\Http\Responses\AdminResponse;
+use Illuminate\Http\JsonResponse;
+
+final readonly class ChangeClaimReportOptionsController
+{
+    public function __construct(
+        private ReportHttpAuthorizationOrchestrator $authorization,
+        private ChangeClaimOptionsService $options,
+        private ChangeClaimCandidateContract $contract,
+    ) {}
+
+    public function __invoke(ChangeClaimReportOptionsRequest $request): JsonResponse
+    {
+        $context = $this->authorization->createRun($request, ChangeClaimCandidateContract::CODE)['context'];
+        $query = new ReportQuery($this->contract->definition(), $context->scope, new ReportFilterSet($request->reportFilters()), [], $request->asOf(), 'ru-RU');
+
+        return AdminResponse::success($this->options->options($context, $query));
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ChangeClaimReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ChangeClaimReportOptionsRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
+use DateTimeImmutable;
+
+final class ChangeClaimReportOptionsRequest extends ReportFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'period_from' => ['required', 'date_format:Y-m-d'],
+            'period_to' => ['required', 'date_format:Y-m-d', 'after_or_equal:period_from'],
+            'as_of' => ['required', 'string', static function (string $attribute, mixed $value, callable $fail): void {
+                if (ReportAsOfParser::parse($value) === null) {
+                    $fail(trans_message('reports.errors.report_request_invalid'));
+                }
+            }],
+            ...$this->forbiddenClientFieldsRules(),
+            'organization_id' => ['prohibited'],
+            'current_organization_id' => ['prohibited'],
+            'holding_organization_ids' => ['prohibited'],
+            'project_id' => ['prohibited'],
+            'project_ids' => ['prohibited'],
+            'scope' => ['prohibited'],
+            'actor_id' => ['prohibited'],
+        ];
+    }
+
+    protected function acceptedQueryFields(): array
+    {
+        return ['period_from', 'period_to', 'as_of'];
+    }
+
+    public function asOf(): DateTimeImmutable
+    {
+        return ReportAsOfParser::parse($this->validated('as_of'))
+            ?? throw ReportContractException::fromCode(ReportErrorCode::REPORT_REQUEST_INVALID, ['fields' => ['as_of']]);
+    }
+
+    public function reportFilters(): array
+    {
+        return ['period_from' => (string) $this->validated('period_from'), 'period_to' => (string) $this->validated('period_to')];
+    }
+}

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -7,6 +7,7 @@ use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\AcceptedProductionReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ContractSettlementExposureReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ChangeClaimReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\HoldingPerformanceReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\IntercompanyContractFlowReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\LookaheadReadinessReportOptionsController;
@@ -138,6 +139,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'management_pnl')
             ->middleware(['report.organization-scope', $resourceAccess])
             ->name('management-pnl.runs.store');
+        Route::get('/change-claim-contingency/options', ChangeClaimReportOptionsController::class)
+            ->defaults('reportCode', 'change_claim_contingency')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('change-claim-contingency.options');
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimCandidateContract.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimCandidateContract.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services\ChangeClaimContingencyFormula;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services\ChangeClaimSnapshotMaterializer;
+use InvalidArgumentException;
+use ReflectionClass;
+
+final readonly class ChangeClaimCandidateContract
+{
+    public const CODE = 'change_claim_contingency';
+
+    public const FORMULA_VERSION = 'change-claim-contingency.v1';
+
+    public const SOURCE_SCHEMA_VERSION = 'change-claim-history.v1';
+
+    public const FORMULA_HASH = '54cdf7e2799a088e466b26b95c507a9b5626e04272596aa775b83ab7979736e4';
+
+    public const SOURCE_HASH = 'ac833c12470847d747d75e28f5ca6f6f8d1916a1290049b2201ab1ce4f55ba5e';
+
+    public function definition(): ReportDefinition
+    {
+        $this->assertRuntimeMatches();
+
+        return (new ReportDefinitionFactory)->fromManifest($this->document());
+    }
+
+    public function filters(): array
+    {
+        return array_map(static fn (string $id): array => [
+            'id' => $id,
+            'required' => in_array($id, ['period_from', 'period_to'], true),
+        ], [
+            'period_from', 'period_to', 'project_ids', 'contract_ids', 'allocation_ids',
+            'change_request_ids', 'claim_ids', 'statuses', 'currencies', 'initiator_types',
+            'initiator_user_ids', 'owner_user_ids', 'reasons', 'source_types',
+        ]);
+    }
+
+    public function columns(): array
+    {
+        return array_map(static fn (string $id): array => ['id' => $id], [
+            'row_key', 'occurred_on', 'project_id', 'contract_id', 'allocation_id',
+            'change_request_id', 'change_version', 'status', 'currency',
+            'proposed_exposure', 'approved_exposure', 'linked_claim', 'opening_contingency',
+            'allocated_contingency', 'consumed_contingency', 'released_contingency',
+            'closing_contingency', 'quality_status', 'drill',
+        ]);
+    }
+
+    public function document(string $publication = 'blocked'): array
+    {
+        return [
+            'code' => self::CODE,
+            'title_key' => 'reports.catalog.change_claim_contingency',
+            'catalog_group' => 'projects',
+            'category' => 'control',
+            'grain' => 'change_version_allocation_currency',
+            'wave' => 3,
+            'source_module' => 'change-management',
+            'core_access_mode' => 'source_module_report',
+            'filters' => $this->filters(),
+            'columns' => $this->columns(),
+            'sorts' => [['id' => 'occurred_on', 'direction' => 'desc'], ['id' => 'project_id', 'direction' => 'asc'], ['id' => 'contract_id', 'direction' => 'asc'], ['id' => 'change_request_id', 'direction' => 'asc'], ['id' => 'currency', 'direction' => 'asc'], ['id' => 'closing_contingency', 'direction' => 'desc']],
+            'formats' => ['csv', 'xlsx'],
+            'versions' => ['contract' => '1.0.0', 'formula' => self::FORMULA_VERSION, 'source_schema' => self::SOURCE_SCHEMA_VERSION, 'renderer' => '1.0.0'],
+            'semantic_fingerprints' => ['formula' => self::FORMULA_HASH, 'source' => self::SOURCE_HASH],
+            'permissions' => ['view' => ['change-management.view'], 'export' => ['change-management.reports.export'], 'sensitive' => [], 'audit' => []],
+            'readiness' => ['source' => 'ready', 'formula' => 'ready', 'delivery' => 'verified', 'publication' => $publication],
+            'capabilities' => ['supports_subscriptions' => false, 'reproducible_scheduled_snapshot' => false],
+        ];
+    }
+
+    public function assertDefinition(ReportDefinition $definition): void
+    {
+        if ($definition->code !== self::CODE
+            || $definition->sourceModule !== 'change-management'
+            || $definition->coreAccessMode !== ReportCoreAccessMode::SOURCE_MODULE_REPORT
+            || $definition->formulaVersion !== self::FORMULA_VERSION
+            || $definition->sourceSchemaVersion !== self::SOURCE_SCHEMA_VERSION
+            || array_column($definition->filters, 'id') !== array_column($this->filters(), 'id')
+            || array_column($definition->columns, 'id') !== array_column($this->columns(), 'id')
+            || $definition->permissionPolicy->viewPermissions !== ['change-management.view']
+            || $definition->permissionPolicy->exportPermissions !== ['change-management.reports.export']) {
+            throw new InvalidArgumentException('change_claim_candidate_definition_invalid');
+        }
+    }
+
+    public function assertRuntimeMatches(): void
+    {
+        if (! hash_equals(self::FORMULA_HASH, $this->classHash(ChangeClaimContingencyFormula::class))
+            || ! hash_equals(self::SOURCE_HASH, $this->classHash(ChangeClaimSnapshotMaterializer::class))) {
+            throw new InvalidArgumentException('change_claim_candidate_contract_drift');
+        }
+    }
+
+    private function classHash(string $class): string
+    {
+        $file = (new ReflectionClass($class))->getFileName();
+        $hash = is_string($file) ? hash_file('sha256', $file) : false;
+
+        return is_string($hash) ? $hash : throw new InvalidArgumentException('change_claim_candidate_source_unreadable');
+    }
+}

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/DTO/ChangeClaimReadinessSnapshot.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/DTO/ChangeClaimReadinessSnapshot.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DTO;
+
+final readonly class ChangeClaimReadinessSnapshot
+{
+    public function __construct(
+        public int $factCount,
+        public bool $hasCheckpoint,
+        public bool $historyComplete,
+        public array $projectIds = [],
+        public array $contractIds = [],
+        public array $allocationIds = [],
+        public array $changeRequestIds = [],
+        public array $claimIds = [],
+        public array $statuses = [],
+        public array $currencies = [],
+        public array $initiatorTypes = [],
+        public array $initiatorUserIds = [],
+        public array $ownerUserIds = [],
+        public array $reasons = [],
+        public array $sourceTypes = [],
+    ) {}
+}

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Readiness/ChangeClaimReadinessProbe.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Readiness/ChangeClaimReadinessProbe.php
@@ -4,23 +4,129 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Readiness;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionReadinessProbe;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
-use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Models\ChangeClaimSnapshot;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DTO\ChangeClaimReadinessSnapshot;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Models\ChangeClaimHistoryCheckpoint;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Models\ChangeClaimLink;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Models\ChangeRequestVersion;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Models\ChangeWorkflowEvent;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Models\ContingencyLedgerEntry;
+use Illuminate\Database\Eloquent\Builder;
 
 final readonly class ChangeClaimReadinessProbe implements ReportDefinitionReadinessProbe
 {
     public function supports(ReportDefinition $definition): bool
     {
-        return $definition->code === 'change_claim_contingency';
+        return $definition->code === 'change_claim_contingency'
+            && $definition->formulaVersion === 'change-claim-contingency.v1';
     }
 
-    public function organizationReady(int $organizationId): bool
+    public function assertRunnable(ReportExecutionContext $context, ReportQuery $query): void
     {
-        return ChangeClaimSnapshot::query()
-            ->where('organization_id', $organizationId)
-            ->where('quality_status', 'complete')
-            ->where('stale_at', '>', now())
-            ->exists();
+        $snapshot = $this->inspect($context->scope, $query);
+        if ($snapshot->factCount === 0 || ! $snapshot->historyComplete) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE, [
+                'report_code' => 'change_claim_contingency',
+                'availability' => $snapshot->factCount === 0 ? 'no_data' : 'source_incomplete',
+            ]);
+        }
+    }
+
+    public function inspect(ReportScope $scope, ReportQuery $query): ChangeClaimReadinessSnapshot
+    {
+        $filters = $query->filters->values;
+        $versions = ChangeRequestVersion::query()
+            ->where('organization_id', $scope->organizationId)
+            ->where('effective_at', '<=', $query->asOf)
+            ->when($scope->projectIds !== [], static fn (Builder $builder) => $builder->whereIn('project_id', $scope->projectIds))
+            ->when(isset($filters['period_from']), static fn (Builder $builder) => $builder->whereDate('effective_at', '>=', (string) $filters['period_from']))
+            ->when(isset($filters['period_to']), static fn (Builder $builder) => $builder->whereDate('effective_at', '<=', (string) $filters['period_to']))
+            ->get();
+        $ledger = ContingencyLedgerEntry::query()
+            ->where('organization_id', $scope->organizationId)
+            ->where('effective_at', '<=', $query->asOf)
+            ->when($scope->projectIds !== [], static fn (Builder $builder) => $builder->whereIn('project_id', $scope->projectIds))
+            ->when(isset($filters['period_to']), static fn (Builder $builder) => $builder->whereDate('effective_on', '<=', (string) $filters['period_to']))
+            ->get();
+        $checkpoint = ChangeClaimHistoryCheckpoint::query()
+            ->where('organization_id', $scope->organizationId)
+            ->where('completed_at', '<=', $query->asOf)
+            ->orderByDesc('completed_at')
+            ->first();
+        $versionIds = $versions->pluck('id')->map(static fn ($id): int => (int) $id)->all();
+        $claimIds = $versionIds === [] ? [] : ChangeClaimLink::query()
+            ->where('organization_id', $scope->organizationId)
+            ->whereIn('change_request_version_id', $versionIds)
+            ->pluck('change_claim_id')->map(static fn ($id): int => (int) $id)->all();
+        $events = $versions->isEmpty() ? collect() : ChangeWorkflowEvent::query()
+            ->where('organization_id', $scope->organizationId)
+            ->whereIn('change_request_id', $versions->pluck('change_request_id'))
+            ->where('occurred_at', '<=', $query->asOf)
+            ->get();
+        $monetaryComplete = $versions->every(static fn ($version): bool => $version->contract_project_allocation_id !== null
+            && $version->currency !== null);
+        $approvalComplete = $events->where('event_type', 'approve')->every(static function ($event) use ($versions, $ledger): bool {
+            if (! $versions->contains(static fn ($version): bool => (int) $version->change_request_id === (int) $event->change_request_id
+                && (int) $version->version === (int) $event->version)) {
+                return true;
+            }
+
+            return $ledger->contains(static fn ($entry): bool => (string) $entry->source_type === 'change_request'
+                && (string) $entry->source_id === (string) $event->change_request_id
+                && (int) $entry->source_version === (int) $event->version
+                && (string) $entry->movement_type === 'consumption');
+        });
+        $latestByAllocation = $versions->whereNotNull('contract_project_allocation_id')
+            ->groupBy(static fn ($version): string => $version->contract_project_allocation_id.':'.$version->currency)
+            ->map(static fn ($group) => $group->max('effective_at'));
+        $ledgerComplete = $ledger->every(static function ($entry) use ($latestByAllocation): bool {
+            $latest = $latestByAllocation->get($entry->contract_project_allocation_id.':'.$entry->currency);
+
+            return $latest !== null && $entry->effective_at <= $latest;
+        });
+
+        return new ChangeClaimReadinessSnapshot(
+            $versions->count(),
+            $checkpoint !== null,
+            $checkpoint !== null
+                && (int) $checkpoint->unprojectable_legacy_count === 0
+                && $monetaryComplete
+                && $approvalComplete
+                && $ledgerComplete,
+            $this->ids([...$versions->pluck('project_id')->all(), ...$ledger->pluck('project_id')->all()]),
+            $this->ids($versions->pluck('contract_id')->all()),
+            $this->ids([...$versions->pluck('contract_project_allocation_id')->all(), ...$ledger->pluck('contract_project_allocation_id')->all()]),
+            $this->ids($versions->pluck('change_request_id')->all()),
+            $this->ids($claimIds),
+            $this->strings($versions->pluck('status')->all()),
+            $this->strings([...$versions->pluck('currency')->all(), ...$ledger->pluck('currency')->all()]),
+            $this->strings($versions->pluck('initiator_type')->all()),
+            $this->ids($versions->pluck('initiator_user_id')->all()),
+            $this->ids($versions->pluck('owner_user_id')->all()),
+            $this->strings($versions->pluck('reason')->all()),
+            $this->strings($ledger->pluck('source_type')->all()),
+        );
+    }
+
+    private function ids(array $values): array
+    {
+        $ids = array_values(array_unique(array_map('intval', array_filter($values))));
+        sort($ids, SORT_NUMERIC);
+
+        return $ids;
+    }
+
+    private function strings(array $values): array
+    {
+        $strings = array_values(array_unique(array_map('strval', array_filter($values, static fn ($value): bool => $value !== null && $value !== ''))));
+        sort($strings, SORT_STRING);
+
+        return $strings;
     }
 }

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Services/ChangeClaimOptionsService.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Services/ChangeClaimOptionsService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Features\ChangeManagement\Models\ChangeClaim;
+use App\BusinessModules\Features\ChangeManagement\Models\ChangeRequest;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DTO\ChangeClaimReadinessSnapshot;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Readiness\ChangeClaimReadinessProbe;
+use App\Models\Contract;
+use App\Models\Project;
+use App\Models\User;
+use InvalidArgumentException;
+
+final readonly class ChangeClaimOptionsService
+{
+    public function __construct(private ChangeClaimReadinessProbe $readiness) {}
+
+    public function options(ReportExecutionContext $context, ReportQuery $query): array
+    {
+        if ($context->scope->canonicalIdentity() !== $query->scope->canonicalIdentity()) {
+            throw new InvalidArgumentException('change_claim_options_scope_mismatch');
+        }
+        $snapshot = $this->readiness->inspect($context->scope, $query);
+
+        return [
+            'availability' => self::availability($snapshot),
+            'period' => ['from' => $query->filters->values['period_from'], 'to' => $query->filters->values['period_to']],
+            'projects' => $this->modelOptions(Project::class, $context->scope->organizationId, $snapshot->projectIds, 'name'),
+            'contracts' => $this->modelOptions(Contract::class, $context->scope->organizationId, $snapshot->contractIds, 'number'),
+            'allocations' => $this->numbered($snapshot->allocationIds, 'reports.change_claim_contingency.option_allocation'),
+            'changes' => $this->changeOptions($context->scope->organizationId, $snapshot->changeRequestIds),
+            'claims' => $this->claimOptions($context->scope->organizationId, $snapshot->claimIds),
+            'statuses' => $this->labels($snapshot->statuses, 'statuses'),
+            'currencies' => array_map(static fn (string $id): array => ['id' => $id, 'name' => $id], $snapshot->currencies),
+            'initiator_types' => $this->labels($snapshot->initiatorTypes, 'initiator_types'),
+            'initiators' => $this->userOptions($snapshot->initiatorUserIds),
+            'owners' => $this->userOptions($snapshot->ownerUserIds),
+            'reasons' => array_map(static fn (string $reason): array => ['id' => $reason, 'name' => $reason], $snapshot->reasons),
+            'source_types' => $this->labels($snapshot->sourceTypes, 'source_types'),
+        ];
+    }
+
+    public static function availability(ChangeClaimReadinessSnapshot $snapshot): array
+    {
+        $status = match (true) {
+            $snapshot->factCount === 0 => 'no_data',
+            $snapshot->hasCheckpoint && $snapshot->historyComplete => 'available',
+            default => 'source_incomplete',
+        };
+
+        return ['status' => $status, 'can_run' => $status === 'available'];
+    }
+
+    private function modelOptions(string $model, int $organizationId, array $ids, string $label): array
+    {
+        return $ids === [] ? [] : $model::query()->where('organization_id', $organizationId)->whereIn('id', $ids)
+            ->orderBy($label)->get(['id', $label])->map(static fn ($item): array => [
+                'id' => (int) $item->id,
+                'name' => (string) ($item->{$label} ?: $item->id),
+            ])->values()->all();
+    }
+
+    private function changeOptions(int $organizationId, array $ids): array
+    {
+        return $ids === [] ? [] : ChangeRequest::query()->where('organization_id', $organizationId)->whereIn('id', $ids)
+            ->orderBy('change_number')->get(['id', 'change_number', 'title'])->map(static fn ($item): array => [
+                'id' => (int) $item->id,
+                'name' => trim((string) $item->change_number.' — '.(string) $item->title, ' —'),
+            ])->values()->all();
+    }
+
+    private function claimOptions(int $organizationId, array $ids): array
+    {
+        return $ids === [] ? [] : ChangeClaim::query()->where('organization_id', $organizationId)->whereIn('id', $ids)
+            ->orderBy('claim_number')->get(['id', 'claim_number', 'title'])->map(static fn ($item): array => [
+                'id' => (int) $item->id,
+                'name' => trim((string) $item->claim_number.' — '.(string) $item->title, ' —'),
+            ])->values()->all();
+    }
+
+    private function userOptions(array $ids): array
+    {
+        return $ids === [] ? [] : User::query()->whereIn('id', $ids)->orderBy('name')->get(['id', 'name'])
+            ->map(static fn ($item): array => ['id' => (int) $item->id, 'name' => (string) $item->name])->values()->all();
+    }
+
+    private function numbered(array $ids, string $key): array
+    {
+        return array_map(static fn (int $id): array => ['id' => $id, 'name' => trans_message($key, ['id' => $id])], $ids);
+    }
+
+    private function labels(array $ids, string $group): array
+    {
+        return array_map(static function (string $id) use ($group): array {
+            $key = "reports.change_claim_contingency.{$group}.{$id}";
+            $label = trans_message($key);
+
+            return [
+                'id' => $id,
+                'name' => $label === $key
+                    ? trans_message('reports.change_claim_contingency.option_other')
+                    : $label,
+            ];
+        }, $ids);
+    }
+}

--- a/lang/ru/reports.php
+++ b/lang/ru/reports.php
@@ -164,6 +164,17 @@ return [
                 'due_date_missing' => 'Дата оплаты не указана',
             ],
         ],
+        'change_claim_contingency' => [
+            'option_allocation' => 'Распределение №:id',
+            'option_other' => 'Другое значение',
+            'statuses' => [
+                'draft' => 'Черновик', 'submitted' => 'Отправлено', 'under_review' => 'На рассмотрении',
+                'approved' => 'Утверждено', 'rejected' => 'Отклонено', 'implemented' => 'Исполнено',
+                'closed' => 'Закрыто', 'cancelled' => 'Отменено',
+            ],
+            'initiator_types' => ['internal' => 'Внутренний инициатор', 'customer' => 'Заказчик', 'contractor' => 'Подрядчик'],
+            'source_types' => ['change_request' => 'Изменение', 'manual_adjustment' => 'Корректировка резерва', 'opening_balance' => 'Начальный резерв'],
+        ],
     ],
     'errors' => [
         'report_not_found' => 'Отчёт не найден.',

--- a/tests/Unit/Reporting/Waves23/ChangeClaimOptionsServiceTest.php
+++ b/tests/Unit/Reporting/Waves23/ChangeClaimOptionsServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimCandidateContract;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DTO\ChangeClaimReadinessSnapshot;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services\ChangeClaimOptionsService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ChangeClaimOptionsServiceTest extends TestCase
+{
+    public function test_candidate_contract_matches_existing_runtime(): void
+    {
+        $contract = new ChangeClaimCandidateContract;
+        $definition = $contract->definition();
+
+        $contract->assertDefinition($definition);
+        self::assertSame('change_claim_contingency', $definition->code);
+        self::assertSame(['change-management.view'], $definition->permissionPolicy->viewPermissions);
+        self::assertSame(['change-management.reports.export'], $definition->permissionPolicy->exportPermissions);
+    }
+
+    #[DataProvider('availabilityCases')]
+    public function test_availability_is_fail_closed(ChangeClaimReadinessSnapshot $snapshot, string $status): void
+    {
+        self::assertSame($status, ChangeClaimOptionsService::availability($snapshot)['status']);
+        self::assertSame($status === 'available', ChangeClaimOptionsService::availability($snapshot)['can_run']);
+    }
+
+    public static function availabilityCases(): array
+    {
+        return [
+            'no facts' => [new ChangeClaimReadinessSnapshot(0, false, false), 'no_data'],
+            'checkpoint missing' => [new ChangeClaimReadinessSnapshot(3, false, false), 'source_incomplete'],
+            'history gaps' => [new ChangeClaimReadinessSnapshot(3, true, false), 'source_incomplete'],
+            'ready' => [new ChangeClaimReadinessSnapshot(3, true, true), 'available'],
+        ];
+    }
+
+    public function test_options_route_is_organization_scoped_and_rejects_client_context(): void
+    {
+        $root = dirname(__DIR__, 4);
+        $routes = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/routes.php');
+        $request = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/Http/Admin/Requests/ChangeClaimReportOptionsRequest.php');
+
+        self::assertStringContainsString("Route::get('/change-claim-contingency/options'", $routes);
+        self::assertStringContainsString("->middleware(['report.organization-scope', \$resourceAccess])", $routes);
+        foreach (['organization_id', 'current_organization_id', 'holding_organization_ids', 'project_id', 'project_ids', 'scope', 'actor_id'] as $field) {
+            self::assertStringContainsString("'{$field}' => ['prohibited']", $request);
+        }
+    }
+
+    public function test_readiness_requires_checkpoint_and_complete_monetary_history(): void
+    {
+        $probe = (string) file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Readiness/ChangeClaimReadinessProbe.php',
+        );
+
+        self::assertStringContainsString('unprojectable_legacy_count', $probe);
+        self::assertStringContainsString('$monetaryComplete', $probe);
+        self::assertStringContainsString('$approvalComplete', $probe);
+        self::assertStringContainsString('$ledgerComplete', $probe);
+        self::assertStringContainsString("'availability' => \$snapshot->factCount === 0 ? 'no_data' : 'source_incomplete'", $probe);
+    }
+}


### PR DESCRIPTION
Добавлены candidate-контракт и tenant-scoped options R14. Run разрешается только при полном checkpoint истории, денежных реквизитах, approval-consumption и покрытии ledger; при отсутствии версий возвращается no_data. Клиентский контекст запрещён. Проверено: 7 PHPUnit / 25 assertions, Pint, php -l, diff check; PHPStan ограничен известной storage_configuration_invalid.