### PR TITLE
feat[reports]: опубликован отчет R14

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinPublishedReportDefinitionRegistry.php
@@ -21,6 +21,7 @@ use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioH
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimBuiltinPublishedReport;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
@@ -71,6 +72,7 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
         ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
         ?ManagementPnlBuiltinPublishedReport $managementPnl = null,
+        ?ChangeClaimBuiltinPublishedReport $changeClaim = null,
     ) {
         $byCode = [];
         $definitions = [$projectMargin->definition(), $budgetPlanFact->definition(), $portfolioLiquidity->definition(), $projectPortfolioHealth->definition(), $projectEvmControl->definition(), $wipCompletionForecast->definition(), $contractSettlementExposure->definition(), $baselineScheduleVariance->definition(), $acceptedProduction->definition(), $projectLaborCost->definition(), $payrollReadiness->definition(), $workforceCapacity->definition(), $procurementCycle->definition(), $supplierAward->definition(), $supplyReliability->definition(), $inventoryRisk->definition(), $attendanceExecution->definition(), $qualityDefectFlow->definition(), $safetyIncidentActions->definition(), $workforceAdmission->definition(), $handoverReadiness->definition(), $contractorScorecard->definition(), $customerSla->definition(), $holdingPerformance->definition(), $intercompanyContractFlow->definition()];
@@ -79,6 +81,9 @@ final readonly class BuiltinPublishedReportDefinitionRegistry implements ReportD
         }
         if ($managementPnl !== null) {
             $definitions[] = $managementPnl->definition();
+        }
+        if ($changeClaim !== null) {
+            $definitions[] = $changeClaim->definition();
         }
         foreach ($definitions as $definition) {
             $byCode[$definition->code] = $definition;

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportCatalogMetadataRegistry.php
@@ -19,6 +19,7 @@ use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioH
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimBuiltinPublishedReport;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
@@ -66,6 +67,7 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         private IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
         private ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
         private ?ManagementPnlBuiltinPublishedReport $managementPnl = null,
+        private ?ChangeClaimBuiltinPublishedReport $changeClaim = null,
     ) {}
 
     public function published(string $code): ReportCatalogMetadata
@@ -77,6 +79,10 @@ final readonly class BuiltinReportCatalogMetadataRegistry implements ReportCatal
         if ($this->managementPnl !== null
             && $code === $this->managementPnl->metadata()->code) {
             return $this->managementPnl->metadata();
+        }
+        if ($this->changeClaim !== null
+            && $code === $this->changeClaim->metadata()->code) {
+            return $this->changeClaim->metadata();
         }
 
         return match ($code) {

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/BuiltinReportSchedulingCapabilityRegistry.php
@@ -19,6 +19,7 @@ use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioH
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\ProjectEvmControlBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectFinance\WipCompletionForecastBuiltinPublishedReport;
 use App\BusinessModules\Features\Budgeting\Reporting\ProjectMarginBuiltinPublishedReport;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimBuiltinPublishedReport;
 use App\BusinessModules\Features\ContractManagement\Reporting\ContractSettlementExposureBuiltinPublishedReport;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\HandoverReadinessBuiltinPublishedReport;
 use App\BusinessModules\Features\Procurement\Reporting\Award\SupplierAwardBuiltinPublishedReport;
@@ -66,6 +67,7 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         private IntercompanyContractFlowBuiltinPublishedReport $intercompanyContractFlow,
         private ?LookaheadReadinessBuiltinPublishedReport $lookaheadReadiness = null,
         private ?ManagementPnlBuiltinPublishedReport $managementPnl = null,
+        private ?ChangeClaimBuiltinPublishedReport $changeClaim = null,
     ) {}
 
     public function published(string $code): ReportSchedulingCapability
@@ -77,6 +79,10 @@ final readonly class BuiltinReportSchedulingCapabilityRegistry implements Report
         if ($this->managementPnl !== null
             && $code === $this->managementPnl->scheduling()->code) {
             return $this->managementPnl->scheduling();
+        }
+        if ($this->changeClaim !== null
+            && $code === $this->changeClaim->scheduling()->code) {
+            return $this->changeClaim->scheduling();
         }
 
         return match ($code) {

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -6,8 +6,8 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportingPermissionMat
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\AcceptedProductionReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\BudgetPlanFactReportOptionsController;
-use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ContractSettlementExposureReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ChangeClaimReportOptionsController;
+use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\ContractSettlementExposureReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\HoldingPerformanceReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\IntercompanyContractFlowReportOptionsController;
 use App\BusinessModules\Core\Reporting\Http\Admin\Controllers\LookaheadReadinessReportOptionsController;
@@ -143,6 +143,10 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'change_claim_contingency')
             ->middleware(['report.organization-scope', $resourceAccess])
             ->name('change-claim-contingency.options');
+        Route::post('/change-claim-contingency/runs', [ReportRunController::class, 'store'])
+            ->defaults('reportCode', 'change_claim_contingency')
+            ->middleware(['report.organization-scope', $resourceAccess])
+            ->name('change-claim-contingency.runs.store');
         Route::post('/{reportCode}/runs', [ReportRunController::class, 'store'])
             ->middleware($resourceAccess)
             ->name('runs.store');

--- a/app/BusinessModules/Features/ChangeManagement/ChangeManagementServiceProvider.php
+++ b/app/BusinessModules/Features/ChangeManagement/ChangeManagementServiceProvider.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\ChangeManagement;
 
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
 use App\BusinessModules\Features\ChangeManagement\Http\Middleware\EnsureChangeManagementActive;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimBuiltinPublishedReport;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimCandidateContract;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimReportBindingFactory;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DrillDown\ChangeClaimDrillDownProvider;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Providers\ChangeClaimContingencyReportProvider;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Queries\ChangeClaimRowQuery;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Readiness\ChangeClaimReadinessProbe;
 use App\BusinessModules\Features\ChangeManagement\Services\ChangeManagementService;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
@@ -15,13 +24,27 @@ final class ChangeManagementServiceProvider extends ServiceProvider
     {
         $this->app->singleton(ChangeManagementModule::class);
         $this->app->scoped(ChangeManagementService::class);
+        $this->app->singleton(ChangeClaimCandidateContract::class);
+        $this->app->singleton(ChangeClaimBuiltinPublishedReport::class);
+        $this->app->scoped(ChangeClaimContingencyReportProvider::class);
+        $this->app->scoped(ChangeClaimRowQuery::class);
+        $this->app->scoped(ChangeClaimDrillDownProvider::class);
+        $this->app->scoped(ChangeClaimReadinessProbe::class);
+        $this->app->scoped(ChangeClaimReportBindingFactory::class);
+        $this->app->scoped(ChangeClaimPublishedRuntimeBindingRegistrar::class);
     }
 
     public function boot(Router $router): void
     {
+        $this->app->afterResolving(
+            ReportDefinitionBindingAssembler::class,
+            fn (ReportDefinitionBindingAssembler $assembler) => $this->app
+                ->make(ChangeClaimPublishedRuntimeBindingRegistrar::class)
+                ->register($assembler),
+        );
         $router->aliasMiddleware('change-management.active', EnsureChangeManagementActive::class);
 
-        $this->loadMigrationsFrom(__DIR__ . '/migrations');
-        $this->loadRoutesFrom(__DIR__ . '/routes.php');
+        $this->loadMigrationsFrom(__DIR__.'/migrations');
+        $this->loadRoutesFrom(__DIR__.'/routes.php');
     }
 }

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimBuiltinPublishedReport.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCatalogMetadata;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSchedulingCapability;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCatalogGroup;
+use App\BusinessModules\Core\Reporting\Infrastructure\Catalog\ReportDefinitionFactory;
+
+final readonly class ChangeClaimBuiltinPublishedReport
+{
+    public const MANIFEST_ORDINAL = 14;
+
+    public function __construct(private ChangeClaimCandidateContract $contract) {}
+
+    public function definition(): PublishedReportDefinition
+    {
+        $this->contract->assertRuntimeMatches();
+        $definition = (new ReportDefinitionFactory)->fromManifest($this->document());
+        $this->contract->assertDefinition($definition);
+
+        return new PublishedReportDefinition($definition);
+    }
+
+    public function metadata(): ReportCatalogMetadata
+    {
+        return new ReportCatalogMetadata(
+            ChangeClaimCandidateContract::CODE,
+            'reports.catalog.change_claim_contingency',
+            ReportCatalogGroup::PROJECTS,
+            'control',
+            'change_version_allocation_currency',
+            3,
+            self::MANIFEST_ORDINAL,
+        );
+    }
+
+    public function scheduling(): ReportSchedulingCapability
+    {
+        return new ReportSchedulingCapability(ChangeClaimCandidateContract::CODE, false, false);
+    }
+
+    public function document(): array
+    {
+        return $this->contract->document('published');
+    }
+}

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimPublishedRuntimeBindingRegistrar.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimPublishedRuntimeBindingRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+
+final readonly class ChangeClaimPublishedRuntimeBindingRegistrar
+{
+    public function __construct(
+        private ReportDefinitionRegistry $definitions,
+        private ChangeClaimReportBindingFactory $bindings,
+    ) {}
+
+    public function register(ReportDefinitionBindingAssembler $assembler): void
+    {
+        try {
+            $definition = $this->definitions->published(ChangeClaimCandidateContract::CODE);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode === ReportErrorCode::REPORT_NOT_FOUND) {
+                return;
+            }
+
+            throw $exception;
+        }
+
+        $assembler->register($this->bindings->create($definition->payload()));
+    }
+}

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimReportBindingFactory.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/ChangeClaimReportBindingFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DrillDown\ChangeClaimDrillDownProvider;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Providers\ChangeClaimContingencyReportProvider;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Queries\ChangeClaimRowQuery;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Readiness\ChangeClaimReadinessProbe;
+
+final readonly class ChangeClaimReportBindingFactory
+{
+    public function __construct(
+        private ChangeClaimContingencyReportProvider $provider,
+        private ChangeClaimRowQuery $query,
+        private ChangeClaimDrillDownProvider $drillDown,
+        private ChangeClaimReadinessProbe $readiness,
+        private ChangeClaimCandidateContract $contract,
+    ) {}
+
+    public function create(ReportDefinition $definition): ReportDefinitionBinding
+    {
+        $this->contract->assertRuntimeMatches();
+        $this->contract->assertDefinition($definition);
+
+        return new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->provider,
+            $this->query,
+            $this->drillDown,
+            $this->readiness,
+        );
+    }
+}

--- a/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Providers/ChangeClaimContingencyReportProvider.php
+++ b/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Providers/ChangeClaimContingencyReportProvider.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Queries\ChangeClaimRowQuery;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Readiness\ChangeClaimReadinessProbe;
 use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Services\ChangeClaimSnapshotMaterializer;
 
 final readonly class ChangeClaimContingencyReportProvider implements ReportDataProvider
@@ -18,11 +19,12 @@ final readonly class ChangeClaimContingencyReportProvider implements ReportDataP
     public function __construct(
         private ChangeClaimSnapshotMaterializer $materializer,
         private ChangeClaimRowQuery $query,
-    ) {
-    }
+        private ChangeClaimReadinessProbe $readiness,
+    ) {}
 
     public function materialize(ReportExecutionContext $context, ReportQuery $query, ReportProgress $progress): ReportSnapshotRef
     {
+        $this->readiness->assertRunnable($context, $query);
         $snapshot = $this->materializer->materialize($context->scope, $query);
         $progress->advance(100);
 

--- a/tests/Unit/Reporting/Waves23/ChangeClaimPublishedContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ChangeClaimPublishedContractTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionBindingAssembler;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
+use App\BusinessModules\Core\Reporting\Domain\DTO\PublishedReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimBuiltinPublishedReport;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimCandidateContract;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimPublishedRuntimeBindingRegistrar;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\ChangeClaimReportBindingFactory;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\DrillDown\ChangeClaimDrillDownProvider;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Providers\ChangeClaimContingencyReportProvider;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Queries\ChangeClaimRowQuery;
+use App\BusinessModules\Features\ChangeManagement\Reporting\ChangeClaim\Readiness\ChangeClaimReadinessProbe;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ChangeClaimPublishedContractTest extends TestCase
+{
+    public function test_published_definition_preserves_verified_r14_contract(): void
+    {
+        $published = new ChangeClaimBuiltinPublishedReport(new ChangeClaimCandidateContract);
+        $definition = $published->definition()->payload();
+
+        self::assertSame('change_claim_contingency', $definition->code);
+        self::assertSame('change-claim-contingency.v1', $definition->formulaVersion);
+        self::assertSame('change-claim-history.v1', $definition->sourceSchemaVersion);
+        self::assertSame('published', $definition->publicationReadiness->value);
+        self::assertSame(14, $published->metadata()->manifestOrdinal);
+        self::assertFalse($published->scheduling()->supportsSubscriptions);
+    }
+
+    public function test_authoritative_registries_and_run_route_include_r14(): void
+    {
+        $root = dirname(__DIR__, 4);
+        foreach ([
+            'BuiltinPublishedReportDefinitionRegistry.php',
+            'BuiltinReportCatalogMetadataRegistry.php',
+            'BuiltinReportSchedulingCapabilityRegistry.php',
+        ] as $file) {
+            $source = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/Infrastructure/Catalog/'.$file);
+            self::assertStringContainsString('ChangeClaimBuiltinPublishedReport', $source);
+        }
+        $routes = (string) file_get_contents($root.'/app/BusinessModules/Core/Reporting/routes.php');
+        self::assertStringContainsString("Route::post('/change-claim-contingency/runs'", $routes);
+        self::assertStringContainsString("->defaults('reportCode', 'change_claim_contingency')", $routes);
+    }
+
+    public function test_runtime_binding_registers_existing_r14_runtime(): void
+    {
+        $contract = new ChangeClaimCandidateContract;
+        $definition = (new ChangeClaimBuiltinPublishedReport($contract))->definition();
+        $provider = (new ReflectionClass(ChangeClaimContingencyReportProvider::class))->newInstanceWithoutConstructor();
+        $query = (new ReflectionClass(ChangeClaimRowQuery::class))->newInstanceWithoutConstructor();
+        $drillDown = (new ReflectionClass(ChangeClaimDrillDownProvider::class))->newInstanceWithoutConstructor();
+        $readiness = (new ReflectionClass(ChangeClaimReadinessProbe::class))->newInstanceWithoutConstructor();
+        $assembler = new ChangeClaimCapturingBindingAssembler;
+        $registrar = new ChangeClaimPublishedRuntimeBindingRegistrar(
+            new ChangeClaimPublishedRegistry($definition),
+            new ChangeClaimReportBindingFactory($provider, $query, $drillDown, $readiness, $contract),
+        );
+
+        $registrar->register($assembler);
+
+        $binding = $assembler->bindings['change_claim_contingency'];
+        self::assertSame($provider, $binding->dataProvider);
+        self::assertSame($query, $binding->rowQuery);
+        self::assertSame($drillDown, $binding->drillDownProvider);
+        self::assertSame($readiness, $binding->readinessProbe);
+    }
+
+    public function test_provider_checks_readiness_before_materialization(): void
+    {
+        $root = dirname(__DIR__, 4);
+        $provider = (string) file_get_contents($root.'/app/BusinessModules/Features/ChangeManagement/Reporting/ChangeClaim/Providers/ChangeClaimContingencyReportProvider.php');
+
+        $guard = strpos($provider, '$this->readiness->assertRunnable($context, $query);');
+        $materialization = strpos($provider, '$this->materializer->materialize($context->scope, $query);');
+        self::assertIsInt($guard);
+        self::assertIsInt($materialization);
+        self::assertLessThan($materialization, $guard);
+    }
+}
+
+final class ChangeClaimCapturingBindingAssembler implements ReportDefinitionBindingAssembler
+{
+    public array $bindings = [];
+
+    public function register(ReportDefinitionBinding $binding): void
+    {
+        $this->bindings[$binding->code] = $binding;
+    }
+
+    public function assemble(ReportDefinitionRegistry $registry): ReportDefinitionBindingMap
+    {
+        throw new LogicException('not_used');
+    }
+}
+
+final readonly class ChangeClaimPublishedRegistry implements ReportDefinitionRegistry
+{
+    public function __construct(private PublishedReportDefinition $definition) {}
+
+    public function published(string $code): PublishedReportDefinition
+    {
+        return $code === 'change_claim_contingency'
+            ? $this->definition
+            : throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
+    }
+
+    public function publishedCodes(): array
+    {
+        return ['change_claim_contingency'];
+    }
+
+    public function manifestSha256(): Sha256Hash
+    {
+        return new Sha256Hash(str_repeat('a', 64));
+    }
+}


### PR DESCRIPTION
## Что сделано
- опубликован канонический контракт R14 в серверном каталоге
- зарегистрированы runtime binding, row query, drill-down и readiness probe
- добавлен отдельный organization-scoped маршрут запуска
- запуск блокируется до материализации при отсутствии данных или неполной истории

## Проверки
- 20 целевых PHPUnit-тестов, 59 assertions
- Pint для измененных файлов
- php -l для всего модуля R14
- git diff --check