### PR TITLE
fix[reports]: разрешен ключ идемпотентности в CORS

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -20,6 +20,7 @@ return [
         'Accept',
         'Authorization',
         'Content-Type',
+        'Idempotency-Key',
         'If-None-Match',
         'Origin',
         'X-CSRF-Token',

--- a/tests/Unit/Http/CorsConfigTest.php
+++ b/tests/Unit/Http/CorsConfigTest.php
@@ -34,4 +34,11 @@ class CorsConfigTest extends TestCase
         self::assertContains('If-None-Match', $config['allowed_headers']);
         self::assertContains('ETag', $config['exposed_headers']);
     }
+
+    public function test_idempotent_mutation_header_is_cors_accessible(): void
+    {
+        $config = require dirname(__DIR__, 3).'/config/cors.php';
+
+        self::assertContains('Idempotency-Key', $config['allowed_headers']);
+    }
 }


### PR DESCRIPTION
## Исправление
- разрешён заголовок Idempotency-Key для CORS preflight
- добавлен регрессионный тест конфигурации

## Причина
Preflight OPTIONS запросов формирования и экспорта отчётов возвращал 403 до выполнения POST.

## Проверки
- RED: тест падал на отсутствии Idempotency-Key
- GREEN: 2 теста, 3 assertions
- PHP syntax
- Pint
- git diff --check