### PR TITLE
fix[reports]: зарегистрирован resolver источников отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Access/DefinitionBoundReportSourceAccessResolver.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Access/DefinitionBoundReportSourceAccessResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Infrastructure\Access;
+
+use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceAccessResolver;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceRef;
+
+final readonly class DefinitionBoundReportSourceAccessResolver implements ReportSourceAccessResolver
+{
+    public function assertAccessible(
+        ReportExecutionContext $context,
+        ReportDefinition $definition,
+        ReportSourceRef $source,
+    ): void {
+        if (! hash_equals($definition->sourceSchemaVersion, $source->schemaVersion)) {
+            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
+        }
+    }
+}

--- a/app/BusinessModules/Core/Reporting/ReportingExecutionServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingExecutionServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Core\Reporting;
 
 use App\BusinessModules\Core\Reporting\Application\Access\ReportHttpAuthorizationOrchestrator;
+use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceAccessResolver;
 use App\BusinessModules\Core\Reporting\Application\Actions\Handlers\CancelReportExportHandler;
 use App\BusinessModules\Core\Reporting\Application\Actions\Handlers\CancelReportRunHandler;
 use App\BusinessModules\Core\Reporting\Application\Actions\Handlers\CreateReportDownloadLinkHandler;
@@ -71,6 +72,7 @@ use App\BusinessModules\Core\Reporting\Application\Exports\ReportExportLimits;
 use App\BusinessModules\Core\Reporting\Application\Exports\ReportPdfDocumentBuilder;
 use App\BusinessModules\Core\Reporting\Application\Exports\ReportPdfDocumentRenderer;
 use App\BusinessModules\Core\Reporting\Application\Exports\ReportPdfRenderBudget;
+use App\BusinessModules\Core\Reporting\Infrastructure\Access\DefinitionBoundReportSourceAccessResolver;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\LaravelCurrentReportAbacEvaluator;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\LaravelReportHttpAuthorizationTargetResolver;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\LaravelReportModuleEntitlement;
@@ -154,6 +156,7 @@ final class ReportingExecutionServiceProvider extends ServiceProvider
     private function validateArchitectureBindings(): void
     {
         foreach ([
+            ReportSourceAccessResolver::class => DefinitionBoundReportSourceAccessResolver::class,
             ReportAuthorizationSubjectReader::class => EloquentReportAuthorizationSubjectReader::class,
             ReportHttpAuthorizationTargetResolver::class => LaravelReportHttpAuthorizationTargetResolver::class,
             ReportModuleEntitlement::class => LaravelReportModuleEntitlement::class,
@@ -222,6 +225,10 @@ final class ReportingExecutionServiceProvider extends ServiceProvider
 
     private function registerInfrastructure(): void
     {
+        $this->app->singleton(
+            ReportSourceAccessResolver::class,
+            DefinitionBoundReportSourceAccessResolver::class,
+        );
         $this->app->singleton(ReportExecutionClock::class, SystemReportExecutionClock::class);
         $this->app->singleton(ReportExecutionAlertWindow::class);
         $this->app->singleton(ReportExecutionTelemetry::class, function (Container $app): LaravelReportExecutionTelemetry {

--- a/tests/Architecture/Reporting/ReportingRuntimeContainerResolutionTest.php
+++ b/tests/Architecture/Reporting/ReportingRuntimeContainerResolutionTest.php
@@ -8,15 +8,21 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceAccessReso
 use App\BusinessModules\Core\Reporting\Application\Contracts\CreateReportRunAction;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportExecutionClock;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportRunStore;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunCoordinator;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSavedViewReferenceResolver;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceRef;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\ReportingCatalogServiceProvider;
 use App\BusinessModules\Core\Reporting\ReportingContractsServiceProvider;
 use App\BusinessModules\Core\Reporting\ReportingExecutionServiceProvider;
 use App\Domain\Authorization\Services\AuthorizationService;
 use Illuminate\Foundation\Application;
 use PHPUnit\Framework\TestCase;
+use Tests\Support\Reporting\ReportDefinitionBuilder;
+use Tests\Support\Reporting\ReportExecutionContextBuilder;
 
 final class ReportingRuntimeContainerResolutionTest extends TestCase
 {
@@ -30,11 +36,46 @@ final class ReportingRuntimeContainerResolutionTest extends TestCase
         $app->instance(AuthorizationService::class, $this->createStub(AuthorizationService::class));
         $app->instance(ReportDefinitionRegistry::class, $this->createStub(ReportDefinitionRegistry::class));
         $app->instance(ReportSavedViewReferenceResolver::class, $this->createStub(ReportSavedViewReferenceResolver::class));
-        $app->instance(ReportSourceAccessResolver::class, $this->createStub(ReportSourceAccessResolver::class));
         $app->instance(ReportRunStore::class, $this->createStub(ReportRunStore::class));
         $app->instance(ReportExecutionClock::class, $this->createStub(ReportExecutionClock::class));
 
+        self::assertInstanceOf(ReportSourceAccessResolver::class, $app->make(ReportSourceAccessResolver::class));
         self::assertInstanceOf(ReportRunCoordinator::class, $app->make(ReportRunCoordinator::class));
         self::assertInstanceOf(CreateReportRunAction::class, $app->make(CreateReportRunAction::class));
+    }
+
+    public function test_registered_source_resolver_accepts_only_definition_bound_schema(): void
+    {
+        $app = new Application(dirname(__DIR__, 3));
+        (new ReportingExecutionServiceProvider($app))->register();
+        $resolver = $app->make(ReportSourceAccessResolver::class);
+        $context = (new ReportExecutionContextBuilder)->build();
+        $definition = (new ReportDefinitionBuilder)->sourceSchemaVersion('v1_0_0')->payload();
+
+        $resolver->assertAccessible(
+            $context,
+            $definition,
+            $this->source($definition->sourceSchemaVersion),
+        );
+
+        try {
+            $resolver->assertAccessible($context, $definition, $this->source('v2_0_0'));
+            self::fail('A source from another schema was accepted.');
+        } catch (ReportContractException $exception) {
+            self::assertSame(ReportErrorCode::REPORT_SCOPE_FORBIDDEN, $exception->errorCode);
+        }
+    }
+
+    private function source(string $schemaVersion): ReportSourceRef
+    {
+        return new ReportSourceRef(
+            'report_source',
+            'immutable_snapshot',
+            'snapshot_1',
+            $schemaVersion,
+            'watermark_1',
+            0,
+            new Sha256Hash(str_repeat('a', 64)),
+        );
     }
 }


### PR DESCRIPTION
## Что исправлено
- зарегистрирован production binding для ReportSourceAccessResolver
- источник привязан к версии схемы определения отчёта
- добавлен регрессионный тест реального разрешения цепочки запуска через Laravel container

## Проверки
- PHPUnit: 72 теста, 501 проверка
- PHP syntax: 3 файла
- Pint: 3 файла
- git diff --check

Larastan не стартовал из-за несвязанного обязательного storage-конфига в общем bootstrap: storage_configuration_invalid.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced DefinitionBoundReportSourceAccessResolver to enforce schema version matching between report definitions and sources.</li>
<li>Registered the new ReportSourceAccessResolver in the ReportingExecutionServiceProvider.</li>
<li>Added architecture tests to verify the container resolution and the access enforcement logic of the new resolver.</li>
</ul></div>