### PR TITLE
fix[admin]: исправлен полный доступ к проектам в отчётах

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Execution/LaravelCurrentReportScopeAuthorizer.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Execution/LaravelCurrentReportScopeAuthorizer.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportVisibility;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\LaravelReportScopedResourceAuthorizerRegistry;
+use App\Enums\UserProjectAccessMode;
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\User;
@@ -405,7 +406,9 @@ final readonly class LaravelCurrentReportScopeAuthorizer implements CurrentRepor
                             ->where('project_organization.is_active', true);
                     });
             });
-        if (($membership->project_access_mode ?? 'assigned') !== 'all') {
+        if (($membership->project_access_mode ?? UserProjectAccessMode::ASSIGNED_PROJECTS->value)
+            !== UserProjectAccessMode::ALL_PROJECTS->value
+        ) {
             $query->whereHas('users', static function ($users) use ($actorId): void {
                 $users->where('users.id', $actorId)->where('project_user.is_active', true);
             });

--- a/tests/Support/Reporting/current_report_project_access_mode_harness.php
+++ b/tests/Support/Reporting/current_report_project_access_mode_harness.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__, 3);
+$source = file_get_contents(
+    $root.'/app/BusinessModules/Core/Reporting/Infrastructure/Execution/LaravelCurrentReportScopeAuthorizer.php',
+);
+
+assert(is_string($source));
+assert(str_contains($source, 'use App\\Enums\\UserProjectAccessMode;'));
+assert(str_contains($source, 'UserProjectAccessMode::ALL_PROJECTS->value'));
+assert(! str_contains($source, "project_access_mode ?? 'assigned'"));
+assert(! str_contains($source, "!== 'all'"));
+
+echo "current report project access mode contract: OK\n";


### PR DESCRIPTION
## Причина
Общий authorizer отчётов сравнивал действующие значения project_access_mode со старыми строками all/assigned. Режим all_projects ошибочно требовал отдельную запись project_user и возвращал REPORT_SCOPE_FORBIDDEN.

## Исправление
- используется единый UserProjectAccessMode
- all_projects сохраняет полный tenant-scoped project scope
- assigned_projects по-прежнему ограничен активными project_user
- добавлен RED→GREEN contract harness

## Проверки
- assertions-enabled harness: OK
- php -l: 2/2
- git diff --check: OK