### PR TITLE
fix[backend]: нормализован список прав пользователя

### DIFF
--- a/app/Domain/Authorization/Services/AuthorizationService.php
+++ b/app/Domain/Authorization/Services/AuthorizationService.php
@@ -166,7 +166,7 @@ class AuthorizationService
             $permissions = array_merge($permissions, $rolePermissions);
         }
         
-        return array_unique($permissions);
+        return array_values(array_unique($permissions));
     }
 
     /**

--- a/tests/Unit/Authorization/AuthorizationPermissionListContractTest.php
+++ b/tests/Unit/Authorization/AuthorizationPermissionListContractTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Authorization;
+
+use App\Domain\Authorization\Models\AuthorizationContext;
+use App\Domain\Authorization\Models\UserRoleAssignment;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Domain\Authorization\Services\PermissionResolver;
+use App\Domain\Authorization\Services\RoleScanner;
+use App\Models\User;
+use App\Services\Logging\LoggingService;
+use Illuminate\Support\Collection;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+final class AuthorizationPermissionListContractTest extends TestCase
+{
+    public function test_permissions_remain_a_list_when_roles_have_duplicate_permissions(): void
+    {
+        $first = new UserRoleAssignment(['role_slug' => 'first', 'role_type' => 'system']);
+        $second = new UserRoleAssignment(['role_slug' => 'second', 'role_type' => 'system']);
+        $service = new class(collect([$first, $second])) extends AuthorizationService
+        {
+            public function __construct(private readonly Collection $assignments)
+            {
+                $permissions = Mockery::mock(PermissionResolver::class);
+                $permissions->shouldReceive('extractOrganizationId')->twice()->andReturn(null);
+                parent::__construct(
+                    Mockery::mock(RoleScanner::class),
+                    $permissions,
+                    Mockery::mock(LoggingService::class),
+                );
+            }
+
+            public function getUserRoles(User $user, ?AuthorizationContext $context = null): Collection
+            {
+                return $this->assignments;
+            }
+
+            protected function getRolePermissions(string $roleSlug, string $roleType, ?int $organizationId = null): array
+            {
+                return $roleSlug === 'first'
+                    ? ['workforce.view', 'reports.view']
+                    : ['workforce.view', 'workforce.reports.export'];
+            }
+        };
+
+        $permissions = $service->getUserPermissions(new User());
+
+        self::assertTrue(array_is_list($permissions));
+        self::assertSame(
+            ['workforce.view', 'reports.view', 'workforce.reports.export'],
+            $permissions,
+        );
+    }
+}


### PR DESCRIPTION
## Что исправлено
- контракт getUserPermissions() всегда возвращает последовательный список
- устранён ложный REPORT_SCOPE_FORBIDDEN при повторяющихся правах из нескольких секций/ролей
- добавлен регрессионный unit-тест на дубли прав

## Проверки
- php -d auto_prepend_file=app/Domain/Authorization/Services/AuthorizationService.php vendor/bin/phpunit tests/Unit/Authorization/AuthorizationPermissionListContractTest.php
- php -l для изменённых PHP-файлов
- git diff --check

PHPStan локально не завершён из-за несвязанного eager-bootstrap S3-конфигурации в переиспользуемом vendor worktree; исполняемый контракт покрыт целевым тестом.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated AuthorizationService to ensure the returned permissions array is a list by re-indexing after removing duplicates.</li>
<li>Added a new unit test to verify that user permissions remain a list even when multiple roles contain duplicate permissions.</li>
</ul></div>