### PR TITLE
fix[backend]: разрешены терминальные wildcard-права отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportActor.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportActor.php
@@ -32,7 +32,9 @@ final readonly class ReportActor
         $normalized = [];
 
         foreach ($permissionSlugs as $permissionSlug) {
-            if (!is_string($permissionSlug) || preg_match('/^[a-z0-9][a-z0-9._-]+$/', $permissionSlug) !== 1 || isset($normalized[$permissionSlug])) {
+            if (!is_string($permissionSlug)
+                || preg_match('/^[a-z0-9][a-z0-9_-]*(?:\.[a-z0-9_-]+)*(?:\.\*)?$/D', $permissionSlug) !== 1
+                || isset($normalized[$permissionSlug])) {
                 throw new \InvalidArgumentException('report_actor_permissions_invalid');
             }
 

--- a/tests/Unit/Reporting/Contracts/ReportActorPermissionSlugTest.php
+++ b/tests/Unit/Reporting/Contracts/ReportActorPermissionSlugTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Contracts;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportActor;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ReportActorPermissionSlugTest extends TestCase
+{
+    public function test_terminal_wildcard_permission_is_valid(): void
+    {
+        $actor = new ReportActor(39, 'active', ['admin.*', 'workforce.view']);
+
+        self::assertSame(['admin.*', 'workforce.view'], $actor->permissionSlugs);
+    }
+
+    #[DataProvider('invalidWildcardPermissions')]
+    public function test_wildcard_is_rejected_outside_terminal_segment(string $permission): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('report_actor_permissions_invalid');
+
+        new ReportActor(39, 'active', [$permission]);
+    }
+
+    public static function invalidWildcardPermissions(): array
+    {
+        return [
+            'leading wildcard' => ['*.view'],
+            'embedded wildcard' => ['admin.*.view'],
+            'partial wildcard' => ['admin.v*'],
+            'empty segment' => ['admin..*'],
+        ];
+    }
+}


### PR DESCRIPTION
Исправлено: ReportActor принимает штатные права вида admin.*, wildcard разрешён только отдельным последним сегментом. Добавлены проверки допустимого и опасных вариантов wildcard. Проверено: целевой PHPUnit — 5 тестов, 9 assertions; PHP syntax; git diff --check.