### PR TITLE
fix[backend]: восстановлен runtime фоновых отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/ReportingContractsServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingContractsServiceProvider.php
@@ -9,10 +9,13 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportActorLoader;
 use App\BusinessModules\Core\Reporting\Application\Access\ReportExecutionContextFactory;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCatalog;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorResponseFactory;
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSnapshotSealStore;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStore;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStreamingStore;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\EloquentReportActorLoader;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReportSourceSnapshotStore;
+use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReportSnapshotSealStore;
+use App\BusinessModules\Core\Reporting\Infrastructure\Security\CanonicalReportSnapshotSealer;
 use Illuminate\Support\ServiceProvider;
 
 final class ReportingContractsServiceProvider extends ServiceProvider
@@ -20,6 +23,11 @@ final class ReportingContractsServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(ReportSourceSnapshotStore::class, EloquentReportSourceSnapshotStore::class);
+        $this->app->singleton(CanonicalReportSnapshotSealer::class, static fn (): CanonicalReportSnapshotSealer => new CanonicalReportSnapshotSealer(
+            (string) config('reporting_execution.active_seal.private_key'),
+            (string) config('reporting_execution.active_seal.key_id'),
+        ));
+        $this->app->singleton(ReportSnapshotSealStore::class, EloquentReportSnapshotSealStore::class);
         $this->app->singleton(
             ReportSourceSnapshotStreamingStore::class,
             static fn ($app): ReportSourceSnapshotStreamingStore => $app->make(ReportSourceSnapshotStore::class),

--- a/config/reporting_execution.php
+++ b/config/reporting_execution.php
@@ -11,6 +11,10 @@ $trustedSealKeys = json_decode(
 );
 
 return [
+    'active_seal' => [
+        'key_id' => env('REPORT_SNAPSHOT_SIGNING_KEY_ID', ''),
+        'private_key' => env('REPORT_SNAPSHOT_SIGNING_PRIVATE_KEY', ''),
+    ],
     'runs' => [
         'ttl_seconds' => (int) env('REPORT_RUN_TTL_SECONDS', 86400),
         'poll_after_ms' => (int) env('REPORT_RUN_POLL_AFTER_MS', 1250),

--- a/database/migrations/2026_08_08_000001_expand_immutable_audit_reporting_domain.php
+++ b/database/migrations/2026_08_08_000001_expand_immutable_audit_reporting_domain.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql' || ! Schema::hasTable('immutable_audit_events')) {
+            return;
+        }
+
+        DB::unprepared(<<<'SQL'
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'immutable_audit_events'::regclass
+          AND conname = 'immutable_audit_events_domain_check_v3'
+    ) THEN
+        ALTER TABLE immutable_audit_events
+            ADD CONSTRAINT immutable_audit_events_domain_check_v3
+            CHECK (domain IN (
+                'payments', 'budgeting', 'mdm', 'rbac', 'one_c_exchange', 'warehouse', 'crm',
+                'period_close', 'procurement', 'sod', 'contracts', 'legal_archive', 'reporting'
+            )) NOT VALID;
+    END IF;
+END
+$$;
+SQL);
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE immutable_audit_events DROP CONSTRAINT IF EXISTS immutable_audit_events_domain_check_v3');
+    }
+};

--- a/database/migrations/2026_08_08_000002_validate_immutable_audit_reporting_domain.php
+++ b/database/migrations/2026_08_08_000002_validate_immutable_audit_reporting_domain.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql' || ! Schema::hasTable('immutable_audit_events')) {
+            return;
+        }
+
+        DB::unprepared(<<<'SQL'
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'immutable_audit_events'::regclass
+          AND conname = 'immutable_audit_events_domain_check_v3'
+    ) THEN
+        ALTER TABLE immutable_audit_events
+            VALIDATE CONSTRAINT immutable_audit_events_domain_check_v3;
+        ALTER TABLE immutable_audit_events
+            DROP CONSTRAINT IF EXISTS immutable_audit_events_domain_check;
+        ALTER TABLE immutable_audit_events
+            RENAME CONSTRAINT immutable_audit_events_domain_check_v3
+            TO immutable_audit_events_domain_check;
+    END IF;
+END
+$$;
+SQL);
+    }
+
+    public function down(): void
+    {
+        throw new RuntimeException('immutable_audit_reporting_domain_rollout_is_forward_only');
+    }
+};

--- a/tests/Architecture/Reporting/ReportingImmutableAuditDomainMigrationTest.php
+++ b/tests/Architecture/Reporting/ReportingImmutableAuditDomainMigrationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\TestCase;
+
+final class ReportingImmutableAuditDomainMigrationTest extends TestCase
+{
+    public function test_reporting_domain_is_added_with_expand_and_validate_migrations(): void
+    {
+        $root = dirname(__DIR__, 3).'/database/migrations/';
+        $expand = (string) file_get_contents(
+            $root.'2026_08_08_000001_expand_immutable_audit_reporting_domain.php',
+        );
+        $validate = (string) file_get_contents(
+            $root.'2026_08_08_000002_validate_immutable_audit_reporting_domain.php',
+        );
+
+        self::assertStringContainsString("'reporting'", $expand);
+        self::assertStringContainsString('NOT VALID', $expand);
+        self::assertStringContainsString('immutable_audit_events_domain_check_v3', $expand);
+        self::assertStringContainsString('VALIDATE CONSTRAINT immutable_audit_events_domain_check_v3', $validate);
+        self::assertStringContainsString('DROP CONSTRAINT IF EXISTS immutable_audit_events_domain_check', $validate);
+        self::assertStringContainsString('RENAME CONSTRAINT immutable_audit_events_domain_check_v3', $validate);
+    }
+}

--- a/tests/Architecture/Reporting/ReportingSnapshotSealContainerTest.php
+++ b/tests/Architecture/Reporting/ReportingSnapshotSealContainerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSnapshotSealStore;
+use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReportSnapshotSealStore;
+use App\BusinessModules\Core\Reporting\ReportingContractsServiceProvider;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Foundation\Application;
+use PHPUnit\Framework\TestCase;
+
+final class ReportingSnapshotSealContainerTest extends TestCase
+{
+    public function test_registered_contracts_resolve_the_persistent_snapshot_seal_store(): void
+    {
+        require_once dirname(__DIR__, 3).'/app/BusinessModules/Core/Reporting/ReportingContractsServiceProvider.php';
+
+        $app = new Application(dirname(__DIR__, 3));
+        $app->instance('config', new ConfigRepository([
+            'reporting_execution' => [
+                'active_seal' => [
+                    'private_key' => rtrim(strtr(base64_encode(
+                        sodium_crypto_sign_secretkey(sodium_crypto_sign_keypair()),
+                    ), '+/', '-_'), '='),
+                    'key_id' => 'test-key-v1',
+                ],
+            ],
+        ]));
+        (new ReportingContractsServiceProvider($app))->register();
+
+        self::assertInstanceOf(
+            EloquentReportSnapshotSealStore::class,
+            $app->make(ReportSnapshotSealStore::class),
+        );
+    }
+}


### PR DESCRIPTION
Исправлена production-цепочка фоновой генерации отчётов. Зарегистрированы канонический sealer и PostgreSQL ReportSnapshotSealStore. Домен reporting добавляется в immutable-аудит двухфазными expand/validate миграциями без отключения контроля. Добавлены container-resolution и schema-rollout regression-тесты. Проверки: 4 теста, 11 assertions; PHP syntax для 6 файлов; git diff --check.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented report snapshot sealing functionality with a new service provider registration and configuration.</li>
<li>Added a new database migration to expand the 'immutable_audit_events' domain check constraint to include 'reporting'.</li>
<li>Added a second migration to validate the new 'immutable_audit_events_domain_check_v3' constraint.</li>
<li>Introduced new infrastructure classes for report snapshot sealing and persistence.</li>
<li>Added architecture tests to verify the new migration and snapshot sealing container.</li>
</ul></div>