### PR TITLE
fix: завершена миграция drill-down контракта

### DIFF
--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/DrillDown/ContractorScorecardDrillDownProvider.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/DrillDown/ContractorScorecardDrillDownProvider.php
@@ -10,12 +10,11 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceObjectAuth
 use App\BusinessModules\Core\Reporting\Application\Rows\StableDrillDownPage;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use InvalidArgumentException;
-use JsonException;
 
 final readonly class ContractorScorecardDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
@@ -32,7 +31,7 @@ final readonly class ContractorScorecardDrillDownProvider implements ReportDrill
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
         if (
             $snapshot->kind !== 'contractor_scorecard'
@@ -40,7 +39,7 @@ final readonly class ContractorScorecardDrillDownProvider implements ReportDrill
         ) {
             throw new InvalidArgumentException('contractor_scorecard_drill_down_invalid');
         }
-        $rowKey = $this->rowKey($request->token, $snapshot);
+        $rowKey = $input->cell->rowKey;
         $row = ContractorScorecardRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
@@ -65,31 +64,11 @@ final readonly class ContractorScorecardDrillDownProvider implements ReportDrill
         }
         $page = StableDrillDownPage::fromRows(
             $evidence,
-            $request->cursor,
-            $request->limit,
+            $input->cursor,
+            $input->limit,
         );
 
         return new ReportDrillDownResult($page->rows, $page->nextCursor, []);
     }
 
-    private function rowKey(string $token, ReportSnapshotRef $snapshot): string
-    {
-        try {
-            $encoded = explode('.', $token, 2)[0] ?? '';
-            $json = base64_decode(strtr($encoded, '-_', '+/').str_repeat('=', (4 - strlen($encoded) % 4) % 4), true);
-            $payload = is_string($json) ? json_decode($json, true, 32, JSON_THROW_ON_ERROR) : null;
-        } catch (JsonException) {
-            $payload = null;
-        }
-        if (
-            ! is_array($payload)
-            || ($payload['snapshot_id'] ?? null) !== $snapshot->id
-            || ($payload['source_hash'] ?? null) !== $snapshot->sourceHash->value
-            || ! is_string($payload['row_key'] ?? null)
-        ) {
-            throw new InvalidArgumentException('contractor_scorecard_drill_down_token_invalid');
-        }
-
-        return $payload['row_key'];
-    }
 }

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/DrillDown/InventoryRiskDrillDownProvider.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/DrillDown/InventoryRiskDrillDownProvider.php
@@ -6,7 +6,7 @@ namespace App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Dr
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -15,7 +15,6 @@ use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Models\I
 use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Models\InventoryRiskRow;
 use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Models\WarehouseInventoryEvent;
 use App\Support\Reporting\EloquentOwnerDrillDown;
-use App\Support\Reporting\OwnerReportTokenPayload;
 use App\Support\Reporting\ReportSourceAccessPolicy;
 use DomainException;
 use Illuminate\Database\Eloquent\Builder;
@@ -30,25 +29,24 @@ final readonly class InventoryRiskDrillDownProvider implements ReportDrillDownPr
 
     public function __construct(
         private EloquentOwnerDrillDown $drillDown,
-        private OwnerReportTokenPayload $tokens,
         private ReportSourceAccessPolicy $sourceAccess,
     ) {}
 
-    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownRequest $request): ReportDrillDownResult
+    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownInput $input): ReportDrillDownResult
     {
-        $row = $this->authorizedRow($context, $snapshot, $request);
+        $row = $this->authorizedRow($context, $snapshot, $input);
         $eventIds = $row->getAttribute('inventory_event_ids');
         if (! is_array($eventIds)) {
             throw new DomainException('Report drill-down pinned source identities are invalid.');
         }
         if ($eventIds === []) {
-            return $this->planningEvidence($context, $snapshot, $request, $row);
+            return $this->planningEvidence($context, $snapshot, $input, $row);
         }
 
         return $this->drillDown->resolve(
             $context,
             $snapshot,
-            $request,
+            $input,
             InventoryRiskRow::class,
             WarehouseInventoryEvent::class,
             'material_id',
@@ -90,7 +88,7 @@ final readonly class InventoryRiskDrillDownProvider implements ReportDrillDownPr
     private function authorizedRow(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): InventoryRiskRow {
         if ($context->scope->canonicalIdentity() !== $snapshot->scope->canonicalIdentity()) {
             throw new DomainException('Report scope does not match snapshot scope.');
@@ -102,7 +100,7 @@ final readonly class InventoryRiskDrillDownProvider implements ReportDrillDownPr
         $row = InventoryRiskRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
-            ->where('row_key', $this->tokens->drillDownRowKey($request->token, $snapshot))
+            ->where('row_key', $input->cell->rowKey)
             ->firstOrFail();
         $warehouseId = $row->getAttribute('warehouse_id');
         $projectId = $row->getAttribute('project_id');
@@ -124,15 +122,15 @@ final readonly class InventoryRiskDrillDownProvider implements ReportDrillDownPr
     private function planningEvidence(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
         InventoryRiskRow $row,
     ): ReportDrillDownResult {
         $asOf = $snapshot->dimensions['as_of'] ?? null;
         if (! is_string($asOf) || trim($asOf) === '') {
             throw new DomainException('Report drill-down cutoff is unavailable.');
         }
-        $offset = $request->cursor === null ? 0 : (int) $request->cursor;
-        if ($request->cursor !== null && preg_match('/^[1-9][0-9]*$/D', $request->cursor) !== 1) {
+        $offset = $input->cursor === null ? 0 : (int) $input->cursor;
+        if ($input->cursor !== null && preg_match('/^[1-9][0-9]*$/D', $input->cursor) !== 1) {
             throw new DomainException('Report drill-down cursor is invalid.');
         }
 
@@ -168,7 +166,7 @@ final readonly class InventoryRiskDrillDownProvider implements ReportDrillDownPr
             }
         }
 
-        $page = $records->slice($offset, $request->limit)->values();
+        $page = $records->slice($offset, $input->limit)->values();
         $nextOffset = $offset + $page->count();
 
         return new ReportDrillDownResult(

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/DrillDown/ProjectEvmControlDrillDownProvider.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectControl/DrillDown/ProjectEvmControlDrillDownProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Budgeting\Reporting\ProjectControl\DrillDown;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -34,12 +34,12 @@ final readonly class ProjectEvmControlDrillDownProvider implements ReportDrillDo
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
         $row = $this->reader->findRow(
             $context,
             $snapshot,
-            $this->reader->rowKeyFromToken($request->token),
+            $input->cell->rowKey,
         );
         if ($row === null) {
             return new ReportDrillDownResult([], null, []);

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/DrillDown/HandoverReadinessDrillDownProvider.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/DrillDown/HandoverReadinessDrillDownProvider.php
@@ -8,13 +8,12 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceObjectAuth
 use App\BusinessModules\Core\Reporting\Application\Rows\StableDrillDownPage;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Models\HandoverReadinessRow;
 use InvalidArgumentException;
-use JsonException;
 
 final readonly class HandoverReadinessDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
@@ -28,7 +27,7 @@ final readonly class HandoverReadinessDrillDownProvider implements ReportDrillDo
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
         if (
             $snapshot->kind !== 'handover_readiness'
@@ -36,7 +35,7 @@ final readonly class HandoverReadinessDrillDownProvider implements ReportDrillDo
         ) {
             throw new InvalidArgumentException('handover_readiness_drill_down_invalid');
         }
-        $rowKey = $this->rowKey($request->token, $snapshot);
+        $rowKey = $input->cell->rowKey;
         $row = HandoverReadinessRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
@@ -69,31 +68,11 @@ final readonly class HandoverReadinessDrillDownProvider implements ReportDrillDo
         }
         $page = StableDrillDownPage::fromRows(
             $evidence,
-            $request->cursor,
-            $request->limit,
+            $input->cursor,
+            $input->limit,
         );
 
         return new ReportDrillDownResult($page->rows, $page->nextCursor, []);
     }
 
-    private function rowKey(string $token, ReportSnapshotRef $snapshot): string
-    {
-        try {
-            $encoded = explode('.', $token, 2)[0] ?? '';
-            $json = base64_decode(strtr($encoded, '-_', '+/').str_repeat('=', (4 - strlen($encoded) % 4) % 4), true);
-            $payload = is_string($json) ? json_decode($json, true, 32, JSON_THROW_ON_ERROR) : null;
-        } catch (JsonException) {
-            $payload = null;
-        }
-        if (
-            ! is_array($payload)
-            || ($payload['snapshot_id'] ?? null) !== $snapshot->id
-            || ($payload['source_hash'] ?? null) !== $snapshot->sourceHash->value
-            || ! is_string($payload['row_key'] ?? null)
-        ) {
-            throw new InvalidArgumentException('handover_readiness_drill_down_token_invalid');
-        }
-
-        return $payload['row_key'];
-    }
 }

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/Queries/SupplierAwardRowQuery.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/Queries/SupplierAwardRowQuery.php
@@ -8,7 +8,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCursor;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportPage;
@@ -75,12 +75,12 @@ final readonly class SupplierAwardRowQuery implements ReportDrillDownProvider, R
         );
     }
 
-    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownRequest $request): ReportDrillDownResult
+    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownInput $input): ReportDrillDownResult
     {
         return $this->drillDown->resolve(
             $context,
             $snapshot,
-            $request,
+            $input,
             SupplierAwardRow::class,
             SupplierAwardDecisionVersion::class,
             'decision_id',

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Queries/ProcurementCycleRowQuery.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Queries/ProcurementCycleRowQuery.php
@@ -8,7 +8,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCursor;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportPage;
@@ -74,12 +74,12 @@ final readonly class ProcurementCycleRowQuery implements ReportDrillDownProvider
         );
     }
 
-    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownRequest $request): ReportDrillDownResult
+    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownInput $input): ReportDrillDownResult
     {
         return $this->drillDown->resolve(
             $context,
             $snapshot,
-            $request,
+            $input,
             ProcurementCycleRow::class,
             ProcurementProcessEvent::class,
             'purchase_request_line_id',

--- a/app/BusinessModules/Features/Procurement/Reporting/Supply/DrillDown/SupplyReliabilityDrillDownProvider.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Supply/DrillDown/SupplyReliabilityDrillDownProvider.php
@@ -6,7 +6,7 @@ namespace App\BusinessModules\Features\Procurement\Reporting\Supply\DrillDown;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -23,12 +23,12 @@ final readonly class SupplyReliabilityDrillDownProvider implements ReportDrillDo
 
     public function __construct(private EloquentOwnerDrillDown $drillDown) {}
 
-    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownRequest $request): ReportDrillDownResult
+    public function drillDown(ReportExecutionContext $context, ReportSnapshotRef $snapshot, ReportDrillDownInput $input): ReportDrillDownResult
     {
         return $this->drillDown->resolve(
             $context,
             $snapshot,
-            $request,
+            $input,
             SupplyReliabilityRow::class,
             SupplyLifecycleEvent::class,
             'purchase_order_item_id',

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/DrillDown/QualityDefectFlowDrillDownProvider.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/DrillDown/QualityDefectFlowDrillDownProvider.php
@@ -8,7 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractExceptio
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResourceLink;
@@ -27,13 +27,12 @@ final readonly class QualityDefectFlowDrillDownProvider implements ReportDrillDo
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
-        $cell = $this->cell($request->token, $snapshot);
         $row = QualityDefectFlowRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
-            ->where('row_key', $cell['row_key'])
+            ->where('row_key', $input->cell->rowKey)
             ->first();
         if (! $row instanceof QualityDefectFlowRow) {
             throw ReportContractException::fromCode(ReportErrorCode::REPORT_NOT_FOUND);
@@ -85,19 +84,4 @@ final readonly class QualityDefectFlowDrillDownProvider implements ReportDrillDo
         );
     }
 
-    private function cell(string $token, ReportSnapshotRef $snapshot): array
-    {
-        $encoded = explode('.', $token, 2)[0] ?? '';
-        $decoded = base64_decode(strtr($encoded, '-_', '+/').str_repeat('=', (4 - strlen($encoded) % 4) % 4), true);
-        $payload = is_string($decoded) ? json_decode($decoded, true) : null;
-        if (! is_array($payload)
-            || ($payload['snapshot_id'] ?? null) !== $snapshot->id
-            || ($payload['source_hash'] ?? null) !== $snapshot->sourceHash->value
-            || ! is_string($payload['row_key'] ?? null)
-            || ! is_string($payload['column_id'] ?? null)) {
-            throw ReportContractException::fromCode(ReportErrorCode::REPORT_CURSOR_INVALID);
-        }
-
-        return ['row_key' => $payload['row_key'], 'column_id' => $payload['column_id']];
-    }
 }

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/DrillDown/WorkforceAdmissionDrillDownProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/DrillDown/WorkforceAdmissionDrillDownProvider.php
@@ -8,7 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractExceptio
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResourceLink;
@@ -27,9 +27,9 @@ final readonly class WorkforceAdmissionDrillDownProvider implements ReportDrillD
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
-        $rowKey = $this->rowKey($request->token, $snapshot);
+        $rowKey = $input->cell->rowKey;
         $row = SafetyAdmissionRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
@@ -106,18 +106,4 @@ final readonly class WorkforceAdmissionDrillDownProvider implements ReportDrillD
         );
     }
 
-    private function rowKey(string $token, ReportSnapshotRef $snapshot): string
-    {
-        $encoded = explode('.', $token, 2)[0] ?? '';
-        $decoded = base64_decode(strtr($encoded, '-_', '+/').str_repeat('=', (4 - strlen($encoded) % 4) % 4), true);
-        $payload = is_string($decoded) ? json_decode($decoded, true) : null;
-        if (! is_array($payload)
-            || ($payload['snapshot_id'] ?? null) !== $snapshot->id
-            || ($payload['source_hash'] ?? null) !== $snapshot->sourceHash->value
-            || ! is_string($payload['row_key'] ?? null)) {
-            throw ReportContractException::fromCode(ReportErrorCode::REPORT_CURSOR_INVALID);
-        }
-
-        return $payload['row_key'];
-    }
 }

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/DrillDown/SafetyIncidentDrillDownProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/DrillDown/SafetyIncidentDrillDownProvider.php
@@ -8,7 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractExceptio
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResourceLink;
@@ -27,9 +27,9 @@ final readonly class SafetyIncidentDrillDownProvider implements ReportDrillDownP
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
-        $rowKey = $this->rowKey($request->token, $snapshot);
+        $rowKey = $input->cell->rowKey;
         $row = SafetyIncidentRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
@@ -80,18 +80,4 @@ final readonly class SafetyIncidentDrillDownProvider implements ReportDrillDownP
         );
     }
 
-    private function rowKey(string $token, ReportSnapshotRef $snapshot): string
-    {
-        $encoded = explode('.', $token, 2)[0] ?? '';
-        $decoded = base64_decode(strtr($encoded, '-_', '+/').str_repeat('=', (4 - strlen($encoded) % 4) % 4), true);
-        $payload = is_string($decoded) ? json_decode($decoded, true) : null;
-        if (! is_array($payload)
-            || ($payload['snapshot_id'] ?? null) !== $snapshot->id
-            || ($payload['source_hash'] ?? null) !== $snapshot->sourceHash->value
-            || ! is_string($payload['row_key'] ?? null)) {
-            throw ReportContractException::fromCode(ReportErrorCode::REPORT_CURSOR_INVALID);
-        }
-
-        return $payload['row_key'];
-    }
 }

--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceQueryService.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceQueryService.php
@@ -8,7 +8,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCursor;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportPage;
@@ -72,12 +72,12 @@ final readonly class BaselineScheduleVarianceQueryService implements ReportRowQu
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
         $row = $this->reader->findRow(
             $context,
             $snapshot,
-            $this->reader->rowKeyFromToken($request->token),
+            $input->cell->rowKey,
         );
         if ($row === null) {
             return new ReportDrillDownResult([], null, []);

--- a/app/Services/Customer/Reporting/Sla/DrillDown/CustomerSlaDrillDownProvider.php
+++ b/app/Services/Customer/Reporting/Sla/DrillDown/CustomerSlaDrillDownProvider.php
@@ -9,13 +9,12 @@ use App\BusinessModules\Core\Reporting\Application\Access\ReportSourceObjectAuth
 use App\BusinessModules\Core\Reporting\Application\Rows\StableDrillDownPage;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownTokenColumns;
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\Services\Customer\Reporting\Sla\Models\CustomerSlaRow;
 use InvalidArgumentException;
-use JsonException;
 
 final readonly class CustomerSlaDrillDownProvider implements ReportDrillDownProvider, ReportDrillDownTokenColumns
 {
@@ -32,7 +31,7 @@ final readonly class CustomerSlaDrillDownProvider implements ReportDrillDownProv
     public function drillDown(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
     ): ReportDrillDownResult {
         if (
             $snapshot->kind !== 'customer_sla'
@@ -40,7 +39,7 @@ final readonly class CustomerSlaDrillDownProvider implements ReportDrillDownProv
         ) {
             throw new InvalidArgumentException('customer_sla_drill_down_invalid');
         }
-        $rowKey = $this->rowKey($request->token, $snapshot);
+        $rowKey = $input->cell->rowKey;
         $row = CustomerSlaRow::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('snapshot_id', $snapshot->id)
@@ -60,31 +59,11 @@ final readonly class CustomerSlaDrillDownProvider implements ReportDrillDownProv
         );
         $page = StableDrillDownPage::fromRows(
             $events,
-            $request->cursor,
-            $request->limit,
+            $input->cursor,
+            $input->limit,
         );
 
         return new ReportDrillDownResult($page->rows, $page->nextCursor, []);
     }
 
-    private function rowKey(string $token, ReportSnapshotRef $snapshot): string
-    {
-        try {
-            $encoded = explode('.', $token, 2)[0] ?? '';
-            $json = base64_decode(strtr($encoded, '-_', '+/').str_repeat('=', (4 - strlen($encoded) % 4) % 4), true);
-            $payload = is_string($json) ? json_decode($json, true, 32, JSON_THROW_ON_ERROR) : null;
-        } catch (JsonException) {
-            $payload = null;
-        }
-        if (
-            ! is_array($payload)
-            || ($payload['snapshot_id'] ?? null) !== $snapshot->id
-            || ($payload['source_hash'] ?? null) !== $snapshot->sourceHash->value
-            || ! is_string($payload['row_key'] ?? null)
-        ) {
-            throw new InvalidArgumentException('customer_sla_drill_down_token_invalid');
-        }
-
-        return $payload['row_key'];
-    }
 }

--- a/app/Support/Reporting/EloquentOwnerDrillDown.php
+++ b/app/Support/Reporting/EloquentOwnerDrillDown.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Support\Reporting;
 
-use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownRequest;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownResult;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -16,14 +16,13 @@ use Illuminate\Database\Eloquent\Model;
 final readonly class EloquentOwnerDrillDown
 {
     public function __construct(
-        private OwnerReportTokenPayload $tokens,
         private ReportSourceAccessPolicy $sourceAccess,
     ) {}
 
     public function resolve(
         ReportExecutionContext $context,
         ReportSnapshotRef $snapshot,
-        ReportDrillDownRequest $request,
+        ReportDrillDownInput $input,
         string $rowModel,
         string $sourceModel,
         string $rowRelationColumn,
@@ -50,7 +49,7 @@ final readonly class EloquentOwnerDrillDown
             throw new DomainException('Report drill-down is unavailable for the current access scope.');
         }
 
-        $rowKey = $this->tokens->drillDownRowKey($request->token, $snapshot);
+        $rowKey = $input->cell->rowKey;
         /** @var Model $row */
         $row = (new $rowModel)->newQuery()
             ->where('organization_id', $context->scope->organizationId)
@@ -126,16 +125,16 @@ final readonly class EloquentOwnerDrillDown
                 ->where($sourceOccurredAtColumn, '<', $dayEnd->setTimezone(new DateTimeZone('UTC')));
         }
 
-        if ($request->cursor !== null) {
-            if (preg_match('/^[1-9][0-9]*$/D', $request->cursor) !== 1) {
+        if ($input->cursor !== null) {
+            if (preg_match('/^[1-9][0-9]*$/D', $input->cursor) !== 1) {
                 throw new DomainException('Report drill-down cursor is invalid.');
             }
-            $query->where('id', '>', (int) $request->cursor);
+            $query->where('id', '>', (int) $input->cursor);
         }
 
-        $records = $query->limit($request->limit + 1)->get();
-        $hasMore = $records->count() > $request->limit;
-        $page = $records->take($request->limit);
+        $records = $query->limit($input->limit + 1)->get();
+        $hasMore = $records->count() > $input->limit;
+        $page = $records->take($input->limit);
         $rows = $page->map(function (Model $record) use ($publicColumns): array {
             $serialized = $record->toArray();
             $values = ['row_key' => 'source_'.(string) $record->getKey()];

--- a/tests/Architecture/Reporting/PublishedDrillDownProviderSignatureTest.php
+++ b/tests/Architecture/Reporting/PublishedDrillDownProviderSignatureTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+final class PublishedDrillDownProviderSignatureTest extends TestCase
+{
+    public function test_every_published_drill_down_provider_accepts_validated_input(): void
+    {
+        $root = dirname(__DIR__, 3).'/app';
+        $legacyProviders = [];
+
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root)) as $file) {
+            if (! $file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $source = file_get_contents($file->getPathname());
+            self::assertIsString($source);
+            if (! str_contains($source, 'ReportDrillDownProvider')) {
+                continue;
+            }
+
+            if (str_contains($source, 'ReportDrillDownRequest $request')) {
+                $legacyProviders[] = str_replace('\\', '/', $file->getPathname());
+            }
+        }
+
+        self::assertSame([], $legacyProviders);
+    }
+}


### PR DESCRIPTION
## Что исправлено
- все опубликованные drill-down провайдеры переведены на валидированный ReportDrillDownInput
- удалён повторный разбор подписанного токена из провайдеров
- добавлен архитектурный регрессионный тест совместимости интерфейса

## Проверки
- 12 целевых PHPUnit тестов: успешно
- php -l для 13 изменённых runtime-файлов: успешно
- git diff --check: успешно
- PHPStan не стартует из-за существующей eager-проверки storage_configuration_invalid в локальном bootstrap

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored reporting drill-down providers to use 'ReportDrillDownInput' instead of 'ReportDrillDownRequest'.</li>
<li>Simplified drill-down logic by removing manual token decoding and validation in favor of direct 'rowKey' access from the input.</li>
<li>Removed redundant 'OwnerReportTokenPayload' dependency from multiple drill-down providers.</li>
<li>Updated architecture tests to reflect the new drill-down provider signature.</li>
</ul></div>