### PR TITLE
fix: исправлена каноническая идентичность workforce-снимков

### DIFF
--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionCandidateContract.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class AttendanceExecutionCandidateContract
 
     public const FORMULA_HASH = 'e6a3ad9e002e7c77ad662ded9ee460b8175783aeae31e41b7176a68a5fadab02';
 
-    public const SOURCE_HASH = '2e03ae7b74e26289677f62ee7835b1f0cd8b774c0e38231338f5594904594295';
+    public const SOURCE_HASH = 'e7eb0cc2f4b7f6b428ac8bcba254f9398fe413b9793f64aed34a64509ee32bd8';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionProvider.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
 
+use App\BusinessModules\Core\Reporting\Application\Execution\ReportSnapshotIdentityBuilder;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
@@ -17,6 +18,7 @@ final readonly class AttendanceExecutionProvider implements ReportDataProvider
     public function __construct(
         private WorkforceReportProjectionService $projection,
         private WorkforceReportQueryService $queryService,
+        private ReportSnapshotIdentityBuilder $identities,
     ) {
     }
 
@@ -29,10 +31,28 @@ final readonly class AttendanceExecutionProvider implements ReportDataProvider
             throw new InvalidArgumentException('attendance_execution_definition_invalid');
         }
         $progress->advance(10);
-        $snapshot = $this->projection->materializeAttendance($context->scope, $query);
+        $provisional = $this->projection->materializeAttendance($context->scope, $query);
+        $canonical = $this->identities->build(
+            $query,
+            $provisional,
+            $this->result($context, $provisional),
+        );
         $progress->advance(100);
 
-        return $snapshot;
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
+        );
     }
 
     public function result(ReportExecutionContext $context, ReportSnapshotRef $snapshot): ReportResult

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabaseWorkforceReportAdapter.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabaseWorkforceReportAdapter.php
@@ -1139,7 +1139,7 @@ final readonly class DatabaseWorkforceReportAdapter implements WorkforceReportDa
         $record = $this->connection->table('workforce_report_snapshots')
             ->where('organization_id', $context->scope->organizationId)
             ->where('id', $snapshot->id)
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->first();
         if ($record === null) {
             throw new DomainException('REPORT_FILTER_VALUE_NOT_FOUND');

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityCandidateContract.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class WorkforceCapacityCandidateContract
 
     public const FORMULA_HASH = 'ec5f0c7c6f0c55c5cb97ae69587c3ca695da41746bcd51b11b1f477e961a18b3';
 
-    public const SOURCE_HASH = '2e03ae7b74e26289677f62ee7835b1f0cd8b774c0e38231338f5594904594295';
+    public const SOURCE_HASH = 'e7eb0cc2f4b7f6b428ac8bcba254f9398fe413b9793f64aed34a64509ee32bd8';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityProvider.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\WorkforceManagement\Reporting;
 
+use App\BusinessModules\Core\Reporting\Application\Execution\ReportSnapshotIdentityBuilder;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
@@ -17,6 +18,7 @@ final readonly class WorkforceCapacityProvider implements ReportDataProvider
     public function __construct(
         private WorkforceReportProjectionService $projection,
         private WorkforceReportQueryService $queryService,
+        private ReportSnapshotIdentityBuilder $identities,
     ) {
     }
 
@@ -29,10 +31,28 @@ final readonly class WorkforceCapacityProvider implements ReportDataProvider
             throw new InvalidArgumentException('workforce_capacity_definition_invalid');
         }
         $progress->advance(10);
-        $snapshot = $this->projection->materializeCapacity($context->scope, $query);
+        $provisional = $this->projection->materializeCapacity($context->scope, $query);
+        $canonical = $this->identities->build(
+            $query,
+            $provisional,
+            $this->result($context, $provisional),
+        );
         $progress->advance(100);
 
-        return $snapshot;
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
+        );
     }
 
     public function result(ReportExecutionContext $context, ReportSnapshotRef $snapshot): ReportResult

--- a/tests/Architecture/Reporting/WorkforceProviderCanonicalHashContractTest.php
+++ b/tests/Architecture/Reporting/WorkforceProviderCanonicalHashContractTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class WorkforceProviderCanonicalHashContractTest extends TestCase
+{
+    #[DataProvider('providerFiles')]
+    public function test_provider_finalizes_the_materialized_snapshot_with_canonical_identity(string $file): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 3).'/'.$file);
+        self::assertIsString($source);
+
+        foreach ([
+            'ReportSnapshotIdentityBuilder',
+            '$this->identities->build(',
+            '$this->result($context, $provisional)',
+            'materializedSourceHash: $provisional->materializedSourceHash',
+        ] as $required) {
+            self::assertStringContainsString($required, $source, $file);
+        }
+    }
+
+    public static function providerFiles(): array
+    {
+        return [
+            'attendance execution' => [
+                'app/BusinessModules/Features/WorkforceManagement/Reporting/AttendanceExecutionProvider.php',
+            ],
+            'workforce capacity' => [
+                'app/BusinessModules/Features/WorkforceManagement/Reporting/WorkforceCapacityProvider.php',
+            ],
+        ];
+    }
+
+    public function test_persisted_snapshot_lookup_uses_materialized_source_identity(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 3)
+            .'/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabaseWorkforceReportAdapter.php');
+        self::assertIsString($source);
+
+        self::assertStringContainsString(
+            "->where('source_hash', \$snapshot->materializedSourceHash->value)",
+            $source,
+        );
+    }
+}


### PR DESCRIPTION
## Причина
Workforce-проекция возвращала materialized source hash как canonical report hash. Runtime корректно отклонял snapshot с REPORT_SNAPSHOT_NOT_READY.

## Исправление
- R09/R10 финализируют snapshot через ReportSnapshotIdentityBuilder
- persisted snapshot lookup использует materializedSourceHash
- обновлены sealed source fingerprints
- добавлен архитектурный регрессионный тест

## Проверки
- 79 целевых PHPUnit тестов: успешно
- PHP syntax для изменённых runtime-файлов: успешно
- PHPStan не стартует из-за существующей eager-проверки storage_configuration_invalid
- общий catalog-тест имеет независимый baseline-дефект: 28 ordinal, 26 уникальных