### PR TITLE
fix: выровнены номера канонического каталога

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/BudgetPlanFactBuiltinPublishedReport.php
@@ -16,7 +16,7 @@ final readonly class BudgetPlanFactBuiltinPublishedReport
 
     public const RENDERER_VERSION = '1.0.0';
 
-    public const MANIFEST_ORDINAL = 12;
+    public const MANIFEST_ORDINAL = 10;
 
     public function __construct(private BudgetPlanFactCandidateContract $contract) {}
 

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectFinance/WipCompletionForecastBuiltinPublishedReport.php
@@ -14,7 +14,7 @@ final readonly class WipCompletionForecastBuiltinPublishedReport
 {
     public const CONTRACT_VERSION = '1.0.0';
     public const RENDERER_VERSION = '1.0.0';
-    public const MANIFEST_ORDINAL = 13;
+    public const MANIFEST_ORDINAL = 11;
 
     public function __construct(private WipCompletionForecastCandidateContract $contract) {}
 

--- a/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/ProjectMarginBuiltinPublishedReport.php
@@ -16,7 +16,7 @@ final readonly class ProjectMarginBuiltinPublishedReport
 
     public const RENDERER_VERSION = '1.0.0';
 
-    public const MANIFEST_ORDINAL = 11;
+    public const MANIFEST_ORDINAL = 9;
 
     public function __construct(private ProjectMarginCandidateContract $contract) {}
 

--- a/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureBuiltinPublishedReport.php
+++ b/app/BusinessModules/Features/ContractManagement/Reporting/ContractSettlementExposureBuiltinPublishedReport.php
@@ -14,7 +14,7 @@ final readonly class ContractSettlementExposureBuiltinPublishedReport
 {
     public const CONTRACT_VERSION = '3.0.0';
     public const RENDERER_VERSION = '1.0.0';
-    public const MANIFEST_ORDINAL = 14;
+    public const MANIFEST_ORDINAL = 12;
 
     public function __construct(private ContractSettlementExposureCandidateContract $contract) {}
 


### PR DESCRIPTION
## Исправлено
Опубликованные R09-R12 используют канонические номера 9-12 вместо дубликатов 11-14. R13 и R14 сохраняют номера 13 и 14.

## Проверки
- BuiltinPublishedReportDefinitionRegistryTest: 6 тестов, 162 assertions — успешно
- php -l изменённых файлов — успешно
- git diff --check — успешно