### PR TITLE
fix[reports]: восстановлено чтение готовых запусков

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Persistence/EloquentReportAuthorizationSubjectReader.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Persistence/EloquentReportAuthorizationSubjectReader.php
@@ -110,7 +110,7 @@ final class EloquentReportAuthorizationSubjectReader implements ReportAuthorizat
         }
         $seal = ! in_array(true, $present, true) ? null : new ReportSnapshotSeal($this->string($record->snapshot_seal_key_id), $this->string($record->snapshot_seal_algorithm), new Sha256Hash($this->string($record->snapshot_sealed_payload_hash)), $this->string($record->snapshot_seal_signature), $this->instant($record->snapshot_sealed_at));
 
-        return new ReportSnapshotRef($this->string($record->snapshot_kind), $this->string($record->snapshot_id), $scope, new Sha256Hash($this->string($record->definition_hash)), $this->string($record->formula_version), new Sha256Hash($this->string($record->source_hash)), $this->instant($record->snapshot_generated_at), $record->snapshot_stale_at === null ? null : $this->instant($record->snapshot_stale_at), $this->array($record->snapshot_watermarks), $classification, $seal);
+        return new ReportSnapshotRef($this->string($record->snapshot_kind), $this->string($record->snapshot_id), $scope, new Sha256Hash($this->string($record->definition_hash)), $this->string($record->formula_version), new Sha256Hash($this->string($record->source_hash)), $this->instant($record->snapshot_generated_at), $record->snapshot_stale_at === null ? null : $this->instant($record->snapshot_stale_at), $this->arrayValue($record->snapshot_watermarks), $classification, $seal);
     }
 
     private function scope(ReportExportRecord $record): ReportScope
@@ -205,6 +205,15 @@ final class EloquentReportAuthorizationSubjectReader implements ReportAuthorizat
     private function array(mixed $value): array
     {
         if (! is_array($value) || ! array_is_list($value)) {
+            throw new \InvalidArgumentException('report_persistence_array_invalid');
+        }
+
+        return $value;
+    }
+
+    private function arrayValue(mixed $value): array
+    {
+        if (! is_array($value)) {
             throw new \InvalidArgumentException('report_persistence_array_invalid');
         }
 

--- a/tests/Feature/Reporting/Persistence/EloquentReportAuthorizationSubjectReaderTest.php
+++ b/tests/Feature/Reporting/Persistence/EloquentReportAuthorizationSubjectReaderTest.php
@@ -5,14 +5,45 @@ declare(strict_types=1);
 namespace Tests\Feature\Reporting\Persistence;
 
 use App\BusinessModules\Core\Reporting\Application\Contracts\Access\ReportAuthorizationSubjectReader;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReportAuthorizationSubjectReader;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\Models\ReportExportRecord;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\Models\ReportRunRecord;
+use DateTimeZone;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
 final class EloquentReportAuthorizationSubjectReaderTest extends TestCase
 {
+    public function test_ready_snapshot_reader_accepts_associative_watermarks(): void
+    {
+        $record = $this->runRecord([
+            'snapshot_kind' => 'materialized',
+            'snapshot_id' => 'snapshot-1',
+            'definition_hash' => str_repeat('a', 64),
+            'formula_version' => 'formula-v1',
+            'source_hash' => str_repeat('b', 64),
+            'snapshot_generated_at' => '2026-08-08 00:00:00+00',
+            'snapshot_stale_at' => null,
+            'snapshot_watermarks' => json_encode(['attendance_source' => 'max_id_0'], JSON_THROW_ON_ERROR),
+            'snapshot_classification' => 'operational',
+            'snapshot_seal_key_id' => null,
+            'snapshot_seal_algorithm' => null,
+            'snapshot_sealed_payload_hash' => null,
+            'snapshot_seal_signature' => null,
+            'snapshot_sealed_at' => null,
+        ]);
+        $reader = new EloquentReportAuthorizationSubjectReader(new \App\BusinessModules\Core\Reporting\Infrastructure\Persistence\ReportRunHydrator);
+
+        $snapshot = $this->method('snapshot')->invoke(
+            $reader,
+            $record,
+            new ReportScope(38, [38], [52], [], new DateTimeZone('UTC')),
+        );
+
+        self::assertSame(['attendance_source' => 'max_id_0'], $snapshot->watermarks);
+    }
+
     public function test_reader_is_the_closed_persistence_adapter_for_authorization_subjects(): void
     {
         self::assertTrue(is_subclass_of(EloquentReportAuthorizationSubjectReader::class, ReportAuthorizationSubjectReader::class));


### PR DESCRIPTION
## Что исправлено
- authorization read-path принимает каноническую карту watermarks готового снимка
- добавлен регрессионный тест для ассоциативных watermarks

## Проверки
- php -l изменённых PHP-файлов
- git diff --check
- целевой PHPUnit будет выполнен в CI (локальный vendor отсутствует)

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new private method `arrayValue` to `EloquentReportAuthorizationSubjectReader` to enforce array validation for snapshot watermarks.</li>
<li>Updated the `snapshot` method in `EloquentReportAuthorizationSubjectReader` to use `arrayValue` instead of the generic `array` method for processing `snapshot_watermarks`.</li>
<li>Added a new feature test `test_ready_snapshot_reader_accepts_associative_watermarks` to verify that the reader correctly handles associative arrays for watermarks.</li>
</ul></div>