### PR TITLE
fix[reports]: задания публикуются сразу после commit

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/CreateReportRunHandler.php
+++ b/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/CreateReportRunHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Core\Reporting\Application\Actions\Handlers;
 
 use App\BusinessModules\Core\Reporting\Application\Contracts\CreateReportRunAction;
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportDispatchIntentPromptPublisher;
 use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunCoordinator;
 use App\BusinessModules\Core\Reporting\Application\Input\CreateReportRunData;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -13,12 +14,17 @@ use App\BusinessModules\Core\Reporting\Domain\ValueObjects\IdempotencyKey;
 
 final readonly class CreateReportRunHandler implements CreateReportRunAction
 {
-    public function __construct(private ReportRunCoordinator $coordinator)
-    {
+    public function __construct(
+        private ReportRunCoordinator $coordinator,
+        private ReportDispatchIntentPromptPublisher $promptPublisher,
+    ) {
     }
 
     public function handle(ReportExecutionContext $context, CreateReportRunData $data, IdempotencyKey $key): ReportRun
     {
-        return $this->coordinator->create($context, $data, $key);
+        $run = $this->coordinator->create($context, $data, $key);
+        $this->promptPublisher->publishPending();
+
+        return $run;
     }
 }

--- a/app/BusinessModules/Core/Reporting/Application/Contracts/Execution/ReportDispatchIntentPromptPublisher.php
+++ b/app/BusinessModules/Core/Reporting/Application/Contracts/Execution/ReportDispatchIntentPromptPublisher.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Application\Contracts\Execution;
+
+interface ReportDispatchIntentPromptPublisher
+{
+    public function publishPending(): void;
+}

--- a/app/BusinessModules/Core/Reporting/Application/Dispatch/BestEffortReportDispatchIntentPromptPublisher.php
+++ b/app/BusinessModules/Core/Reporting/Application/Dispatch/BestEffortReportDispatchIntentPromptPublisher.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Application\Dispatch;
+
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportDispatchIntentPromptPublisher;
+use DateTimeImmutable;
+use DateTimeZone;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+final readonly class BestEffortReportDispatchIntentPromptPublisher implements ReportDispatchIntentPromptPublisher
+{
+    public function __construct(
+        private ReportDispatchIntentPublisher $publisher,
+        private LoggerInterface $logger,
+        private int $batchSize,
+    ) {
+    }
+
+    public function publishPending(): void
+    {
+        try {
+            $this->publisher->publishBatch(
+                $this->batchSize,
+                new DateTimeImmutable('now', new DateTimeZone('UTC')),
+            );
+        } catch (Throwable $exception) {
+            $this->logger->warning('Immediate report dispatch intent publication failed; scheduled reconciliation remains active.', [
+                'exception_class' => $exception::class,
+            ]);
+        }
+    }
+}

--- a/app/BusinessModules/Core/Reporting/ReportingExecutionServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingExecutionServiceProvider.php
@@ -35,6 +35,7 @@ use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportAud
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportAuditIntentStore;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportCompletedArtifactRecoveryStore;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportDispatchIntentStore;
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportDispatchIntentPromptPublisher;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportExecutionClock;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportExecutionTelemetry;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportExportAsyncContextSeedReader;
@@ -57,6 +58,7 @@ use App\BusinessModules\Core\Reporting\Application\Contracts\GetReportRowsAction
 use App\BusinessModules\Core\Reporting\Application\Contracts\GetReportRunAction;
 use App\BusinessModules\Core\Reporting\Application\Contracts\RetryReportExportAction;
 use App\BusinessModules\Core\Reporting\Application\Contracts\RetryReportRunAction;
+use App\BusinessModules\Core\Reporting\Application\Dispatch\BestEffortReportDispatchIntentPromptPublisher;
 use App\BusinessModules\Core\Reporting\Application\Dispatch\ReportDispatchBackoffPolicy;
 use App\BusinessModules\Core\Reporting\Application\Dispatch\ReportDispatchIntentPublisher;
 use App\BusinessModules\Core\Reporting\Application\Dispatch\ReportDispatchIntentReconciler;
@@ -410,6 +412,13 @@ final class ReportingExecutionServiceProvider extends ServiceProvider
                 $app->make(ReportDispatchBackoffPolicy::class),
                 $app->make(ReportExecutionTelemetry::class),
                 $app->make(ReportExecutionRuntimeConfiguration::class),
+            );
+        });
+        $this->app->singleton(ReportDispatchIntentPromptPublisher::class, function (Container $app): ReportDispatchIntentPromptPublisher {
+            return new BestEffortReportDispatchIntentPromptPublisher(
+                $app->make(ReportDispatchIntentPublisher::class),
+                $app->make(\Psr\Log\LoggerInterface::class),
+                $this->configArray('dispatch')['batch_size'],
             );
         });
         $this->app->singleton(ReportDispatchIntentReconciler::class);

--- a/tests/Unit/Reporting/Actions/ReportRunHandlersTest.php
+++ b/tests/Unit/Reporting/Actions/ReportRunHandlersTest.php
@@ -16,6 +16,7 @@ use App\BusinessModules\Core\Reporting\Application\Actions\Handlers\RetryReportR
 use App\BusinessModules\Core\Reporting\Application\Contracts\CancelReportRunAction;
 use App\BusinessModules\Core\Reporting\Application\Contracts\CreateReportRunAction;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportExecutionClock;
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportDispatchIntentPromptPublisher;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportRunStore;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSnapshotSealVerifier;
 use App\BusinessModules\Core\Reporting\Application\Contracts\GetReportRunAction;
@@ -126,7 +127,11 @@ final class ReportRunHandlersTest extends TestCase
             ]],
         ] as $handler => [$interface, $method, $parameters]) {
             self::assertSame([$interface], array_values(class_implements($handler)));
-            $this->assertConstructor($handler, [['coordinator', ReportRunCoordinator::class]]);
+            $constructor = [['coordinator', ReportRunCoordinator::class]];
+            if ($handler === CreateReportRunHandler::class) {
+                $constructor[] = ['promptPublisher', ReportDispatchIntentPromptPublisher::class];
+            }
+            $this->assertConstructor($handler, $constructor);
             $this->assertMethod($handler, $method, $parameters, ReportRun::class);
         }
 
@@ -267,12 +272,14 @@ final class ReportRunHandlersTest extends TestCase
         $key = new IdempotencyKey('run-key-1');
         $data = new CreateReportRunData('report', new ReportFilterSet([]), [], new DateTimeImmutable('2026-07-29T07:00:00Z'), 'ru-RU', $savedViews->reference->id);
 
-        $run = (new CreateReportRunHandler($coordinator))->handle($context, $data, $key);
+        $publisher = new RecordingReportDispatchIntentPromptPublisher;
+        $run = (new CreateReportRunHandler($coordinator, $publisher))->handle($context, $data, $key);
 
         self::assertSame($store->run, $run);
         self::assertSame($key, $store->lastKey);
         self::assertSame($savedViews->reference, $store->lastSavedView);
         self::assertSame('report', $store->lastQuery?->definition->code);
+        self::assertSame(1, $publisher->calls);
     }
 
     public function test_create_reuses_same_explicit_key_and_conflicts_when_canonical_body_changes(): void
@@ -283,13 +290,13 @@ final class ReportRunHandlersTest extends TestCase
         $changed = new CreateReportRunData('report', new ReportFilterSet([]), ['period' => 'previous'], new DateTimeImmutable('2026-07-29T07:00:00Z'), 'ru-RU', null);
 
         self::assertSame(
-            (new CreateReportRunHandler($coordinator))->handle($context, $first, $key),
-            (new CreateReportRunHandler($coordinator))->handle($context, $first, $key),
+            (new CreateReportRunHandler($coordinator, new RecordingReportDispatchIntentPromptPublisher))->handle($context, $first, $key),
+            (new CreateReportRunHandler($coordinator, new RecordingReportDispatchIntentPromptPublisher))->handle($context, $first, $key),
         );
         self::assertSame(2, $store->createCalls);
 
         try {
-            (new CreateReportRunHandler($coordinator))->handle($context, $changed, $key);
+            (new CreateReportRunHandler($coordinator, new RecordingReportDispatchIntentPromptPublisher))->handle($context, $changed, $key);
             self::fail('Changed canonical body reused the key.');
         } catch (ReportContractException $exception) {
             self::assertSame(\App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode::REPORT_IDEMPOTENCY_CONFLICT, $exception->errorCode);
@@ -303,7 +310,7 @@ final class ReportRunHandlersTest extends TestCase
         $data = new CreateReportRunData('report', new ReportFilterSet([]), [], new DateTimeImmutable('2026-07-29T07:00:00Z'), 'ru-RU', $savedViews->reference->id);
 
         try {
-            (new CreateReportRunHandler($coordinator))->handle($context, $data, new IdempotencyKey('run-key-1'));
+            (new CreateReportRunHandler($coordinator, new RecordingReportDispatchIntentPromptPublisher))->handle($context, $data, new IdempotencyKey('run-key-1'));
             self::fail('Invalid saved view was accepted.');
         } catch (InvalidArgumentException) {
             self::assertSame(0, $store->createCalls);
@@ -502,7 +509,7 @@ final class ReportRunHandlersTest extends TestCase
             null,
         );
         $attempts = [
-            'create' => static fn () => (new CreateReportRunHandler($coordinator))->handle(
+            'create' => static fn () => (new CreateReportRunHandler($coordinator, new RecordingReportDispatchIntentPromptPublisher))->handle(
                 $context,
                 new CreateReportRunData('report', new ReportFilterSet([]), [], new DateTimeImmutable('2026-07-29T07:00:00Z'), 'ru-RU', null),
                 new IdempotencyKey('denied-create'),
@@ -763,6 +770,16 @@ final class ReportRunHandlersTest extends TestCase
         }
 
         return true;
+    }
+}
+
+final class RecordingReportDispatchIntentPromptPublisher implements ReportDispatchIntentPromptPublisher
+{
+    public int $calls = 0;
+
+    public function publishPending(): void
+    {
+        $this->calls++;
     }
 }
 


### PR DESCRIPTION
## Что исправлено
- сохранённый transactional outbox intent публикуется сразу после успешного создания запуска
- выделенная очередь reports и асинхронный worker сохраняются
- штатный минутный reconciler остаётся fallback при сбое транспорта

## Проверки
- php -l изменённых PHP-файлов
- git diff --check
- регрессионный unit-контракт немедленной публикации
- локальный PHPUnit недоступен: vendor отсутствует; проверка выполняется CI