### PR TITLE
fix[reports]: защищена пагинация детализации

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/GetReportDrillDownHandler.php
+++ b/app/BusinessModules/Core/Reporting/Application/Actions/Handlers/GetReportDrillDownHandler.php
@@ -6,6 +6,7 @@ namespace App\BusinessModules\Core\Reporting\Application\Actions\Handlers;
 
 use App\BusinessModules\Core\Reporting\Application\Access\ReportExecutionContextFactory;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\CurrentReportScopeAuthorizer;
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportExecutionClock;
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportRunStore;
 use App\BusinessModules\Core\Reporting\Application\Contracts\GetReportDrillDownAction;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
@@ -35,6 +36,7 @@ final readonly class GetReportDrillDownHandler implements GetReportDrillDownActi
         private CurrentReportScopeAuthorizer $authorizer,
         private ReportExecutionContextFactory $contexts,
         private SignedReportCursorCodec $tokens,
+        private ReportExecutionClock $clock,
     ) {}
 
     public function handle(
@@ -61,13 +63,44 @@ final readonly class GetReportDrillDownHandler implements GetReportDrillDownActi
                 ['fields' => ['token']],
             );
         }
-        $authorization = $this->authorizeDrillDown($context, $query, $snapshot);
+        $authorization = $this->authorizeDrillDown($context, $query, $snapshot, $cell->columnId);
         $providerContext = $this->contexts->fromCurrentAuthorization($authorization);
+        $providerCursor = $request->cursor === null
+            ? null
+            : $this->tokens->decodeDrillDownPage(
+                $request->cursor,
+                $query->scope->organizationId,
+                $run->reportCode,
+                $run->id,
+                $snapshot,
+                $run->queryHash,
+                $cell->rowKey,
+            );
 
-        return $binding->drillDownProvider->drillDown(
+        $result = $binding->drillDownProvider->drillDown(
             $providerContext,
             $snapshot,
-            new ReportDrillDownInput($cell, $request->cursor, $request->limit),
+            new ReportDrillDownInput($cell, $providerCursor, $request->limit),
+        );
+        if ($result->nextCursor === null) {
+            return $result;
+        }
+
+        $nextCursor = $this->tokens->encodeDrillDownPage(
+            $query->scope->organizationId,
+            $run->reportCode,
+            $run->id,
+            $snapshot,
+            $run->queryHash,
+            $cell->rowKey,
+            $result->nextCursor,
+            $this->clock->now()->modify('+5 minutes'),
+        );
+
+        return new ReportDrillDownResult(
+            $result->rows,
+            $nextCursor,
+            $result->resourceLinks,
         );
     }
 
@@ -124,13 +157,14 @@ final readonly class GetReportDrillDownHandler implements GetReportDrillDownActi
         ReportExecutionContext $context,
         ReportQuery $query,
         ReportSnapshotRef $snapshot,
+        string $columnId,
     ): CurrentReportAuthorization {
         $authorization = $this->authorize($context, $query, $snapshot, ReportOperation::VIEW);
         $classification = $query->definition->outputClassification;
-        if ($classification->requiresSensitiveForRows()) {
+        if ($classification->requiresSensitiveForColumns([$columnId])) {
             $authorization = $this->authorize($context, $query, $snapshot, ReportOperation::VIEW_SENSITIVE);
         }
-        if ($classification->requiresAuditForRows()) {
+        if ($classification->requiresAuditForColumns([$columnId]) || $classification->provenanceAudit) {
             $authorization = $this->authorize($context, $query, $snapshot, ReportOperation::VIEW_AUDIT);
         }
 

--- a/tests/Unit/Reporting/Actions/ReportReadHandlersTest.php
+++ b/tests/Unit/Reporting/Actions/ReportReadHandlersTest.php
@@ -210,14 +210,14 @@ final class ReportReadHandlersTest extends TestCase
         );
         $operations = [];
 
-        $this->expectReportError(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
-
         try {
-            $this->rowsHandler($fixture, $this->authorizer($operations, false))->handle(
-                $this->context,
-                self::RUN_ID,
-                new ReportRowsWindow(null, 50, $sort),
-            );
+            $this->expectReportError(ReportErrorCode::REPORT_SCOPE_FORBIDDEN, function () use ($fixture, &$operations, $sort): void {
+                $this->rowsHandler($fixture, $this->authorizer($operations, false))->handle(
+                    $this->context,
+                    self::RUN_ID,
+                    new ReportRowsWindow(null, 50, $sort),
+                );
+            });
         } finally {
             self::assertSame([ReportOperation::VIEW, ReportOperation::VIEW_SENSITIVE], $operations);
             self::assertCount(0, $fixture['rowQuery']->pageCalls());
@@ -268,14 +268,14 @@ final class ReportReadHandlersTest extends TestCase
         );
         $operations = [];
 
-        $this->expectReportError(ReportErrorCode::REPORT_SCOPE_FORBIDDEN);
-
         try {
-            $this->rowsHandler($fixture, $this->authorizer($operations, auditAllowed: false))->handle(
-                $this->context,
-                self::RUN_ID,
-                new ReportRowsWindow(null, 50, $sort),
-            );
+            $this->expectReportError(ReportErrorCode::REPORT_SCOPE_FORBIDDEN, function () use ($fixture, &$operations, $sort): void {
+                $this->rowsHandler($fixture, $this->authorizer($operations, auditAllowed: false))->handle(
+                    $this->context,
+                    self::RUN_ID,
+                    new ReportRowsWindow(null, 50, $sort),
+                );
+            });
         } finally {
             self::assertSame([ReportOperation::VIEW, ReportOperation::VIEW_AUDIT], $operations);
             self::assertCount(0, $fixture['rowQuery']->pageCalls());
@@ -351,8 +351,8 @@ final class ReportReadHandlersTest extends TestCase
         );
         $operations = [];
         $request = new ReportDrillDownRequest(
-            $this->cellToken($fixture, 'row-1', 'name'),
-            'details-page-2',
+            $this->cellToken($fixture, 'row-1', 'audit_event'),
+            null,
             25,
         );
 
@@ -370,8 +370,8 @@ final class ReportReadHandlersTest extends TestCase
         self::assertSame($fixture['run']->resultMetadata->snapshot, $fixture['drillDown']->calls()[0][1]);
         $input = $fixture['drillDown']->calls()[0][2];
         self::assertSame('row-1', $input->cell->rowKey);
-        self::assertSame('name', $input->cell->columnId);
-        self::assertSame('details-page-2', $input->cursor);
+        self::assertSame('audit_event', $input->cell->columnId);
+        self::assertNull($input->cursor);
         self::assertSame(25, $input->limit);
         self::assertObjectNotHasProperty('token', $input);
     }
@@ -655,8 +655,7 @@ final class ReportReadHandlersTest extends TestCase
         array &$operations,
         bool $sensitiveAllowed = true,
         bool $auditAllowed = true,
-    ): CurrentReportScopeAuthorizer&MockObject
-    {
+    ): CurrentReportScopeAuthorizer&MockObject {
         $authorizer = $this->createMock(CurrentReportScopeAuthorizer::class);
         $authorizer->method('authorizeExact')->willReturnCallback(
             function (int $actorId, $scope, CurrentReportAuthorizationTarget $target) use (&$operations, $sensitiveAllowed, $auditAllowed): CurrentReportAuthorization {
@@ -713,6 +712,7 @@ final class ReportReadHandlersTest extends TestCase
             $authorizer,
             new ReportExecutionContextFactory,
             $this->codec(),
+            $this->clock,
         );
     }
 


### PR DESCRIPTION
## Что изменено

- cursor детализации подписывается сервером и привязывается к организации, запуску, snapshot, query и родительской строке;
- provider cursor декодируется только после проверки серверной подписи;
- sensitive/audit-доступ детализации проверяется по выбранной колонке и признаку provenance;
- восстановлены два сломанных denial-теста чтения.

## Причина

GetReportDrillDownHandler пропускал provider cursor наружу без подписи и принимал его обратно как доверенный. После уточнения семантики классификации handler также продолжал применять проверки всей таблицы вместо выбранной колонки.

## Проверки

- RED: 2 подтверждённых unit failure;
- GREEN: 51 тест, 300 assertions для read handlers, cursor codec и builtin registry;
- повторный целевой набор после форматирования: 16 тестов, 70 assertions;
- php -l изменённых файлов;
- Pint изменённых файлов;
- git diff --check.

Larastan не дошёл до анализа из-за общего bootstrap storage_configuration_invalid без production S3-конфигурации. PostgreSQL-only feature-тесты локально не запускались: окружение содержит только SQLite, миграции и DB-команды не выполнялись.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated GetReportDrillDownHandler to support cursor-based pagination for drill-down results, including token encoding with a 5-minute expiration.</li>
<li>Refined authorization logic in GetReportDrillDownHandler to evaluate sensitive and audit requirements based on specific column IDs rather than row-level checks.</li>
<li>Updated unit tests in ReportReadHandlersTest to reflect the new authorization logic and pagination handling, ensuring proper error expectation wrapping.</li>
</ul></div>