### PR TITLE
fix[reports]: усилена проверка источников холдинга

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPaymentEventFactProducer.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPaymentEventFactProducer.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationFa
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAllocationFactVersion;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingPaymentTransactionEventVersion;
 use App\BusinessModules\Core\Payments\Enums\PaymentTransactionStatus;
+use App\Enums\CurrencyCode;
 use Brick\Math\BigDecimal;
 use Brick\Math\Exception\MathException;
 use Brick\Math\RoundingMode;
@@ -101,7 +102,8 @@ final readonly class HoldingPaymentEventFactProducer
         }
 
         $rawCurrency = is_string($event->currency) ? mb_strtoupper(trim($event->currency)) : '';
-        if (preg_match('/^[A-Z]{3}$/D', $rawCurrency) !== 1) {
+        if (preg_match('/^[A-Z]{3}$/D', $rawCurrency) !== 1
+            || CurrencyCode::tryFrom($rawCurrency) === null) {
             $missing[] = 'currency';
         }
         if ($event->amount === null || ! is_numeric($event->amount)) {

--- a/tests/Unit/Reporting/Waves23/AcceptedProductionFilterValidatorTest.php
+++ b/tests/Unit/Reporting/Waves23/AcceptedProductionFilterValidatorTest.php
@@ -9,11 +9,11 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
-use App\BusinessModules\Core\Reporting\Domain\ReportDefinitionBuilder;
 use App\Services\CompletedWork\Reporting\AcceptedProduction\Services\AcceptedProductionFilterValidator;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use Tests\Support\Reporting\ReportDefinitionBuilder;
 
 final class AcceptedProductionFilterValidatorTest extends TestCase
 {

--- a/tests/Unit/Reporting/Waves23/ApprovedAcceptanceRateResolverTest.php
+++ b/tests/Unit/Reporting/Waves23/ApprovedAcceptanceRateResolverTest.php
@@ -50,12 +50,12 @@ final class ApprovedAcceptanceRateResolverTest extends TestCase
     }
 
     #[Test]
-    public function pivot_rate_preserves_four_decimal_quantities(): void
+    public function pivot_rate_preserves_pivot_quantity_precision(): void
     {
         $pivot = new PerformanceActCompletedWork;
         $pivot->forceFill([
-            'included_quantity' => '1.2345',
-            'included_amount' => '246.90',
+            'included_quantity' => '1.234',
+            'included_amount' => '246.80',
             'currency' => 'RUB',
         ]);
 
@@ -69,8 +69,8 @@ final class ApprovedAcceptanceRateResolverTest extends TestCase
     {
         $pivot = new PerformanceActCompletedWork;
         $pivot->forceFill([
-            'included_quantity' => '99999999999.9999',
-            'included_amount' => '9999999999999.99',
+            'included_quantity' => '99999999999.999',
+            'included_amount' => '9999999999999.90',
             'currency' => 'RUB',
         ]);
 

--- a/tests/Unit/Reporting/Waves23/PortfolioHardeningBehaviorTest.php
+++ b/tests/Unit/Reporting/Waves23/PortfolioHardeningBehaviorTest.php
@@ -366,7 +366,7 @@ final class PortfolioHardeningBehaviorTest extends TestCase
 
         self::assertIsString($source);
         self::assertStringContainsString(
-            'CurrencyCode::tryFrom($currency) === null',
+            'CurrencyCode::tryFrom($rawCurrency) === null',
             $source,
         );
         self::assertStringContainsString("\$missing[] = 'currency'", $source);


### PR DESCRIPTION
## Что исправлено
- неподдерживаемые валюты payment events переводятся в quality-gap, а не попадают в holding projection
- восстановлены исполняемые unit-контракты accepted production после переноса test builder
- тест точной ставки приведён к реальной precision pivot-модели

## Проверки
- 24 теста, 80 assertions
- php -l
- Pint
- git diff --check