### PR TITLE
fix[reports]: обновлен fingerprint источника холдинга

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/HoldingPerformanceCandidateContract.php
@@ -10,25 +10,25 @@ use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingAllocationFa
 use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingContractDimensionSnapshot;
 use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingPerformanceMetricRow;
 use App\BusinessModules\Core\MultiOrganization\Reporting\DTO\HoldingPerformanceProjectionCoverage;
-use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAllocationFactVersion;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Listeners\ProjectHoldingAllocationFacts;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAcceptedWorkEventVersion;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingAllocationFactVersion;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingPaymentEventCoverageCheckpoint;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Models\HoldingPaymentTransactionEventVersion;
-use App\BusinessModules\Core\MultiOrganization\Reporting\Listeners\ProjectHoldingAllocationFacts;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\AcceptedWorkHoldingFactProducer;
-use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationCheckpointSourceAssembler;
-use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationFactProjector;
-use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceFormula;
-use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPaymentEventFactProducer;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAcceptedWorkLifecycleRecorder;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationCheckpointSourceAssembler;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationContextResolver;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingAllocationFactProjector;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingContractDimensionResolver;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingHierarchyResolver;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPaymentEventFactProducer;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceFormula;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceImmutableEventSource;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceImmutableProjectionSynchronizer;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceProjectionCoverageInspector;
-use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingReportingSourceCoverage;
 use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingPerformanceSnapshotMaterializer;
+use App\BusinessModules\Core\MultiOrganization\Reporting\Services\HoldingReportingSourceCoverage;
 use App\BusinessModules\Core\Payments\Enums\PaymentTransactionStatus;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
@@ -41,10 +41,14 @@ use ReflectionClass;
 final readonly class HoldingPerformanceCandidateContract
 {
     public const CODE = 'holding_performance';
+
     public const FORMULA_VERSION = 'holding_performance.v1';
+
     public const SOURCE_SCHEMA_VERSION = 'holding_allocation_facts.v2';
+
     public const FORMULA_HASH = '59c4e2d23349656ae8948679fcea4dc59da5be20792b865afb17da2b9a667f20';
-    public const SOURCE_HASH = '95144d292c56689d11ea6cf18c72d3abb2982a99e9a5981763bf94a61234b4ac';
+
+    public const SOURCE_HASH = '78e2b098800ef98c47f81deedecc07cdba54f9e120219a4ef103ed42a7f6454f';
 
     public function filters(): array
     {
@@ -99,35 +103,35 @@ final readonly class HoldingPerformanceCandidateContract
     {
         if (self::SOURCE_SCHEMA_VERSION !== HoldingAllocationFactVersion::SOURCE_SCHEMA_VERSION
             || ! hash_equals(self::FORMULA_HASH, self::classesHash([
-            HoldingPerformanceFormula::class,
-            HoldingAllocationFact::class,
-            HoldingPerformanceMetricRow::class,
-            CurrencyCode::class,
-        ])) || ! hash_equals(self::SOURCE_HASH, self::classesHash([
-            HoldingAllocationCheckpointSourceAssembler::class,
-            HoldingAllocationCheckpointSource::class,
-            HoldingAllocationCheckpointBatch::class,
-            HoldingAllocationFactProjector::class,
-            HoldingAllocationFactVersion::class,
-            HoldingHierarchyResolver::class,
-            HoldingContractDimensionSnapshot::class,
-            HoldingContractDimensionResolver::class,
-            HoldingAllocationContextResolver::class,
-            HoldingReportingSourceCoverage::class,
-            HoldingAcceptedWorkEventVersion::class,
-            HoldingPaymentEventCoverageCheckpoint::class,
-            HoldingPaymentTransactionEventVersion::class,
-            AcceptedWorkHoldingFactProducer::class,
-            HoldingAcceptedWorkLifecycleRecorder::class,
-            HoldingPaymentEventFactProducer::class,
-            ProjectHoldingAllocationFacts::class,
-            PaymentTransactionStatus::class,
-            HoldingPerformanceImmutableEventSource::class,
-            HoldingPerformanceImmutableProjectionSynchronizer::class,
-            HoldingPerformanceProjectionCoverageInspector::class,
-            HoldingPerformanceProjectionCoverage::class,
-            HoldingPerformanceSnapshotMaterializer::class,
-        ]))) {
+                HoldingPerformanceFormula::class,
+                HoldingAllocationFact::class,
+                HoldingPerformanceMetricRow::class,
+                CurrencyCode::class,
+            ])) || ! hash_equals(self::SOURCE_HASH, self::classesHash([
+                HoldingAllocationCheckpointSourceAssembler::class,
+                HoldingAllocationCheckpointSource::class,
+                HoldingAllocationCheckpointBatch::class,
+                HoldingAllocationFactProjector::class,
+                HoldingAllocationFactVersion::class,
+                HoldingHierarchyResolver::class,
+                HoldingContractDimensionSnapshot::class,
+                HoldingContractDimensionResolver::class,
+                HoldingAllocationContextResolver::class,
+                HoldingReportingSourceCoverage::class,
+                HoldingAcceptedWorkEventVersion::class,
+                HoldingPaymentEventCoverageCheckpoint::class,
+                HoldingPaymentTransactionEventVersion::class,
+                AcceptedWorkHoldingFactProducer::class,
+                HoldingAcceptedWorkLifecycleRecorder::class,
+                HoldingPaymentEventFactProducer::class,
+                ProjectHoldingAllocationFacts::class,
+                PaymentTransactionStatus::class,
+                HoldingPerformanceImmutableEventSource::class,
+                HoldingPerformanceImmutableProjectionSynchronizer::class,
+                HoldingPerformanceProjectionCoverageInspector::class,
+                HoldingPerformanceProjectionCoverage::class,
+                HoldingPerformanceSnapshotMaterializer::class,
+            ]))) {
             throw new InvalidArgumentException('holding_performance_candidate_contract_drift');
         }
     }


### PR DESCRIPTION
## Исправление
Обновлён закреплённый SOURCE_HASH после fail-closed проверки валют payment events. Без этого holding_performance корректно блокировался как contract drift.

## Проверки
- 11 тестов, 254 assertions
- builtin registry contract
- php -l
- Pint
- git diff --check