### PR TITLE
fix[admin]: восстановлены источники отчётов снабжения

### DIFF
--- a/app/BusinessModules/Features/Procurement/Http/Controllers/PurchaseOrderController.php
+++ b/app/BusinessModules/Features/Procurement/Http/Controllers/PurchaseOrderController.php
@@ -415,7 +415,7 @@ class PurchaseOrderController extends Controller
                 $line,
                 (string) $request->validated('reason_code'),
                 (string) $request->validated('idempotency_key'),
-                (int) $request->user()->getAuthIdentifier(),
+                $request->user(),
             );
 
             return AdminResponse::success(

--- a/app/BusinessModules/Features/Procurement/Models/SupplierProposalVersion.php
+++ b/app/BusinessModules/Features/Procurement/Models/SupplierProposalVersion.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\Procurement\Models;
 
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Models\Concerns\RejectsProcurementSourceMutation;
 use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class SupplierProposalVersion extends Model
 {
+    use RejectsProcurementSourceMutation;
+
     public const UPDATED_AT = null;
 
     protected $table = 'supplier_proposal_versions';

--- a/app/BusinessModules/Features/Procurement/ProcurementServiceProvider.php
+++ b/app/BusinessModules/Features/Procurement/ProcurementServiceProvider.php
@@ -58,6 +58,15 @@ class ProcurementServiceProvider extends ServiceProvider
     protected function registerServices(): void
     {
         $this->app->singleton(
+            Contracts\PurchaseReceiptReturnAuthorizer::class,
+            Services\PurchaseReceiptReturnAccessResolver::class,
+        );
+        $this->app->singleton(
+            Contracts\PurchaseReceiptReturnUnitOfWork::class,
+            Services\DatabasePurchaseReceiptReturnUnitOfWork::class,
+        );
+
+        $this->app->singleton(
             Reporting\Cycle\Contracts\ProcurementCycleSourceReader::class,
             Reporting\Cycle\Services\EloquentProcurementCycleSourceReader::class,
         );

--- a/app/BusinessModules/Features/Procurement/Services/PurchaseOrderService.php
+++ b/app/BusinessModules/Features/Procurement/Services/PurchaseOrderService.php
@@ -4,20 +4,28 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\Procurement\Services;
 
+use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Features\BasicWarehouse\Models\OrganizationWarehouse;
 use App\BusinessModules\Features\BasicWarehouse\Models\ProjectMaterialDelivery;
 use App\BusinessModules\Features\BasicWarehouse\Services\ProjectMaterialDeliveryService;
+use App\BusinessModules\Features\Procurement\Contracts\PurchaseReceiptReturnAuthorizer;
+use App\BusinessModules\Features\Procurement\Contracts\PurchaseReceiptReturnUnitOfWork;
 use App\BusinessModules\Features\Procurement\Enums\ProcurementAuditEventTypeEnum;
 use App\BusinessModules\Features\Procurement\Enums\PurchaseOrderStatusEnum;
 use App\BusinessModules\Features\Procurement\Models\PurchaseOrder;
 use App\BusinessModules\Features\Procurement\Models\PurchaseReceipt;
+use App\BusinessModules\Features\Procurement\Models\PurchaseReceiptReturn;
 use App\BusinessModules\Features\Procurement\Models\PurchaseRequest;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Contracts\ProcurementOwnerWorkflowRuntime;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Services\ProcurementCycleOwnerEventRecorder;
+use App\BusinessModules\Features\Procurement\Reporting\ProcurementReportingLifecycleRecorder;
 use App\DTOs\Contract\ContractDossierCreationResult;
 use App\Models\Supplier;
 use App\Models\User;
+use Brick\Math\BigDecimal;
+use Carbon\CarbonImmutable;
 use DateTimeImmutable;
+use DomainException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -37,7 +45,159 @@ class PurchaseOrderService
         private readonly ProjectMaterialDeliveryService $deliveryService,
         private readonly ProcurementCycleOwnerEventRecorder $cycleEventRecorder,
         private readonly ProcurementOwnerWorkflowRuntime $ownerWorkflowRuntime,
+        private readonly ProcurementReportingLifecycleRecorder $reportingLifecycle,
+        private readonly PurchaseReceiptInventoryService $receiptInventory,
+        private readonly PurchaseReceiptReturnAuthorizer $returnAuthorizer,
+        private readonly PurchaseReceiptReturnUnitOfWork $returnUnitOfWork,
     ) {}
+
+    public function returnReceiptLine(
+        int $organizationId,
+        int $purchaseOrderId,
+        int $receiptLineId,
+        string $quantity,
+        string $reasonCode,
+        string $idempotencyKey,
+        User $actor,
+    ): PurchaseOrder {
+        $normalizedQuantity = (string) BigDecimal::of($quantity)->strippedOfTrailingZeros();
+        $payloadFingerprint = hash('sha256', CanonicalJson::encode([
+            'actor_id' => (int) $actor->getAuthIdentifier(),
+            'organization_id' => $organizationId,
+            'purchase_order_id' => $purchaseOrderId,
+            'purchase_receipt_line_id' => $receiptLineId,
+            'quantity' => $normalizedQuantity,
+            'reason_code' => $reasonCode,
+        ]));
+
+        return $this->returnUnitOfWork->run(
+            $organizationId,
+            $idempotencyKey,
+            function () use (
+                $actor,
+                $idempotencyKey,
+                $organizationId,
+                $payloadFingerprint,
+                $purchaseOrderId,
+                $reasonCode,
+                $receiptLineId,
+                $normalizedQuantity,
+            ): PurchaseOrder {
+                $existing = PurchaseReceiptReturn::query()
+                    ->where('organization_id', $organizationId)
+                    ->where('idempotency_key', $idempotencyKey)
+                    ->first();
+                if ($existing instanceof PurchaseReceiptReturn) {
+                    if (! hash_equals((string) $existing->payload_fingerprint, $payloadFingerprint)) {
+                        throw new DomainException('procurement.purchase_orders.receipt_return_idempotency_conflict');
+                    }
+
+                    $line = $this->returnAuthorizer->assertCanReturn(
+                        $actor,
+                        $organizationId,
+                        $purchaseOrderId,
+                        $receiptLineId,
+                    );
+
+                    return $this->freshReceivedPurchaseOrder($line->purchaseReceipt->purchaseOrder);
+                }
+
+                $line = $this->returnAuthorizer->assertCanReturn(
+                    $actor,
+                    $organizationId,
+                    $purchaseOrderId,
+                    $receiptLineId,
+                );
+                $occurredAt = CarbonImmutable::now();
+                $movement = $this->receiptInventory->returnQuantity(
+                    $line,
+                    $normalizedQuantity,
+                    $reasonCode,
+                    (int) $actor->getAuthIdentifier(),
+                    $occurredAt,
+                );
+                $event = $this->reportingLifecycle->receiptReturned(
+                    $line->fresh(),
+                    (int) $movement->getKey(),
+                    $normalizedQuantity,
+                    $reasonCode,
+                    $occurredAt,
+                    $idempotencyKey,
+                );
+                $metadata = is_array($movement->metadata) ? $movement->metadata : [];
+                $sourceVersion = (int) ($metadata['reporting_source_version'] ?? 0);
+                if ($sourceVersion < 1) {
+                    throw new DomainException('procurement.purchase_orders.receipt_return_source_invalid');
+                }
+                PurchaseReceiptReturn::query()->create([
+                    'organization_id' => $organizationId,
+                    'purchase_receipt_line_id' => $receiptLineId,
+                    'warehouse_movement_id' => (int) $movement->getKey(),
+                    'supply_lifecycle_event_id' => (int) $event->getKey(),
+                    'source_type' => 'warehouse_movement',
+                    'source_id' => (int) $movement->getKey(),
+                    'source_version' => $sourceVersion,
+                    'quantity' => $normalizedQuantity,
+                    'reason_code' => $reasonCode,
+                    'actor_id' => (int) $actor->getAuthIdentifier(),
+                    'occurred_at' => $occurredAt,
+                    'idempotency_key' => $idempotencyKey,
+                    'payload_fingerprint' => $payloadFingerprint,
+                ]);
+
+                return $this->freshReceivedPurchaseOrder($line->purchaseReceipt->purchaseOrder);
+            },
+        );
+    }
+
+    public function reverseReceiptLine(
+        int $organizationId,
+        int $purchaseOrderId,
+        int $receiptLineId,
+        string $reasonCode,
+        string $idempotencyKey,
+        User $actor,
+    ): PurchaseOrder {
+        return $this->returnUnitOfWork->run(
+            $organizationId,
+            $idempotencyKey,
+            function () use ($actor, $idempotencyKey, $organizationId, $purchaseOrderId, $reasonCode, $receiptLineId): PurchaseOrder {
+                $line = $this->returnAuthorizer->assertCanReturn(
+                    $actor,
+                    $organizationId,
+                    $purchaseOrderId,
+                    $receiptLineId,
+                );
+                if ($line->reversed_at !== null) {
+                    if ((string) $line->reversal_idempotency_key !== $idempotencyKey
+                        || (string) $line->reversal_reason_code !== $reasonCode
+                        || (int) $line->reversed_by_user_id !== (int) $actor->getAuthIdentifier()) {
+                        throw new DomainException('procurement.purchase_orders.receipt_reversal_idempotency_conflict');
+                    }
+
+                    return $this->freshReceivedPurchaseOrder($line->purchaseReceipt->purchaseOrder);
+                }
+
+                $occurredAt = CarbonImmutable::now();
+                $movement = $this->receiptInventory->reverse(
+                    $line,
+                    $reasonCode,
+                    (int) $actor->getAuthIdentifier(),
+                    $occurredAt,
+                );
+                $line->forceFill([
+                    'reversed_at' => $occurredAt,
+                    'reversed_by_user_id' => (int) $actor->getAuthIdentifier(),
+                    'reversal_reason_code' => $reasonCode,
+                    'reversal_warehouse_movement_id' => (int) $movement->getKey(),
+                    'reversal_idempotency_key' => $idempotencyKey,
+                ])->save();
+                $this->reportingLifecycle->receiptReversed($line->fresh(), $reasonCode, $occurredAt);
+
+                return $this->freshReceivedPurchaseOrder($line->purchaseReceipt->purchaseOrder);
+            },
+        );
+    }
 
     public function create(PurchaseRequest $request, int $supplierId, array $data, ?int $actorId = null): PurchaseOrder
     {

--- a/tests/Unit/Reporting/Waves23/LineageReducerBoundednessTest.php
+++ b/tests/Unit/Reporting/Waves23/LineageReducerBoundednessTest.php
@@ -244,7 +244,8 @@ final class LineageReducerBoundednessTest extends TestCase
         ];
         $accepted = $this->acceptanceEvent(1, 37);
         $reversed = $this->acceptanceEvent(2, 37);
-        $reversed->forceFill([
+        $reversed->setRawAttributes([
+            ...$reversed->getAttributes(),
             'accepted_quantity_delta' => '-0.001',
             'event_type' => 'reversed',
             'planned_quantity' => '-100.000',
@@ -252,7 +253,8 @@ final class LineageReducerBoundednessTest extends TestCase
             'recognized_at' => new CarbonImmutable('2026-07-30T10:00:00+00:00'),
         ]);
         $reaccepted = $this->acceptanceEvent(3, 37);
-        $reaccepted->forceFill([
+        $reaccepted->setRawAttributes([
+            ...$reaccepted->getAttributes(),
             'approved_rate_minor' => 200_000,
             'currency_source' => 'performance_act_line.reapproved_rate',
             'recognized_at' => new CarbonImmutable('2026-07-30T12:00:00+00:00'),

--- a/tests/Unit/Reporting/Waves23/ProductionResourceBoundaryTest.php
+++ b/tests/Unit/Reporting/Waves23/ProductionResourceBoundaryTest.php
@@ -64,7 +64,7 @@ final class ProductionResourceBoundaryTest extends TestCase
         self::assertStringContainsString('$this->universe->stream($context->scope, $query)', $readiness);
         self::assertStringContainsString('$this->universe->stream($scope, $query)', $materializer);
         self::assertStringContainsString('ProductionAcceptanceOwnerVersion::query()', $universe);
-        self::assertStringContainsString('$ownerQuery->lazyById(100)', $universe);
+        self::assertStringContainsString('foreach ($ownerQuery->cursor() as $owner)', $universe);
         self::assertStringContainsString('foreach ($eventQuery->cursor() as $event)', $universe);
         self::assertStringNotContainsString('$eventsByKey', $universe);
         self::assertTrue(

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -112,17 +112,18 @@ final class ReportingSourcePersistenceContractTest extends TestCase
         self::assertStringContainsString('$row->evidence_version_id !== null', $drillDown);
         self::assertStringContainsString("'briefing' => 'admin.safety_management.briefings.show'", $drillDown);
         self::assertStringContainsString("'safety_briefing'", $drillDown);
-        $qualityService = file_get_contents(
-            dirname(__DIR__, 4).'/app/BusinessModules/Features/QualityControl/Services/QualityDefectService.php',
+        $qualityRecorder = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/'
+            .'QualityDefectTransitionRecorder.php',
         );
         $qualityMaterializer = file_get_contents(
             dirname(__DIR__, 4).'/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/'
             .'QualityDefectFlowSnapshotMaterializer.php',
         );
-        self::assertIsString($qualityService);
+        self::assertIsString($qualityRecorder);
         self::assertIsString($qualityMaterializer);
-        self::assertStringContainsString("'coverage' => 'unknown'", $qualityService);
-        self::assertStringContainsString("'legacy_storage_identity_unverified'", $qualityService);
+        self::assertStringContainsString("['coverage'] ?? null) === 'unknown'", $qualityRecorder);
+        self::assertStringContainsString("'legacy_storage_identity_unverified'", $qualityRecorder);
         self::assertStringContainsString('$hasUnknownEvidence', $qualityMaterializer);
     }
 

--- a/tests/Unit/Reporting/Waves23/SupplierAwardOwnerAdapterParityTest.php
+++ b/tests/Unit/Reporting/Waves23/SupplierAwardOwnerAdapterParityTest.php
@@ -26,7 +26,7 @@ final class SupplierAwardOwnerAdapterParityTest extends TestCase
             'cheapest_supplier_proposal_version_id',
             'comparison_snapshot',
             'decision_reason',
-            'reportingLifecycle',
+            'awardOwnerRecorder',
         ] as $identity) {
             self::assertStringContainsString($identity, $owner);
         }

--- a/tests/Unit/Reporting/Waves23/SupplyOwnerArchitectureTest.php
+++ b/tests/Unit/Reporting/Waves23/SupplyOwnerArchitectureTest.php
@@ -16,6 +16,7 @@ use App\BusinessModules\Features\BasicWarehouse\Reporting\Support\ImmutableRepor
 use App\BusinessModules\Features\Procurement\Reporting\Award\Providers\SupplierAwardCompetitivenessReportProvider;
 use App\BusinessModules\Features\Procurement\Reporting\Award\Queries\SupplierAwardRowQuery;
 use App\BusinessModules\Features\Procurement\Reporting\Award\Readiness\SupplierAwardReadinessProbe;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Models\Concerns\RejectsProcurementSourceMutation;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Providers\ProcurementCycleReportProvider;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Queries\ProcurementCycleRowQuery;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Readiness\ProcurementCycleReadinessProbe;
@@ -80,10 +81,8 @@ final class SupplyOwnerArchitectureTest extends TestCase
             'Award\\Models\\SupplierAwardRow',
             'Award\\Models\\SupplierAwardDecisionVersion',
             'Cycle\\Models\\ProcurementCycleOwnerExpectationVersion',
-            'Cycle\\Models\\ProcurementCyclePolicyVersion',
             'Cycle\\Models\\ProcurementCycleRow',
             'Cycle\\Models\\ProcurementCycleSnapshot',
-            'Cycle\\Models\\ProcurementProcessEvent',
             'Supply\\Models\\PurchaseOrderPromiseVersion',
             'Supply\\Models\\SentPurchaseOrderLineOwner',
             'Supply\\Models\\SupplyLifecycleEvent',
@@ -109,6 +108,14 @@ final class SupplyOwnerArchitectureTest extends TestCase
                 ],
                 $procurement,
             ),
+            [
+                'App\\BusinessModules\\Features\\Procurement\\Reporting\\Cycle\\Models\\ProcurementCyclePolicyVersion',
+                RejectsProcurementSourceMutation::class,
+            ],
+            [
+                'App\\BusinessModules\\Features\\Procurement\\Reporting\\Cycle\\Models\\ProcurementProcessEvent',
+                RejectsProcurementSourceMutation::class,
+            ],
             ...array_map(
                 static fn (string $suffix): array => [
                     'App\\BusinessModules\\Features\\BasicWarehouse\\Reporting\\'.$suffix,

--- a/tests/Unit/Reporting/Waves23/SupplyReportingHardeningTest.php
+++ b/tests/Unit/Reporting/Waves23/SupplyReportingHardeningTest.php
@@ -28,13 +28,13 @@ final class SupplyReportingHardeningTest extends TestCase
     public function test_real_mutation_services_depend_on_reporting_recorders(): void
     {
         foreach ([
-            'app/BusinessModules/Features/Procurement/Services/PurchaseRequestService.php',
-            'app/BusinessModules/Features/Procurement/Services/SupplierRequestService.php',
-            'app/BusinessModules/Features/Procurement/Services/SupplierProposalService.php',
-            'app/BusinessModules/Features/Procurement/Services/SupplierProposalComparisonService.php',
-            'app/BusinessModules/Features/Procurement/Services/PurchaseOrderService.php',
-        ] as $file) {
-            self::assertStringContainsString('reportingLifecycle', $this->source($file), $file);
+            'app/BusinessModules/Features/Procurement/Services/PurchaseRequestService.php' => 'cycleEventRecorder',
+            'app/BusinessModules/Features/Procurement/Services/SupplierRequestService.php' => 'cycleEventRecorder',
+            'app/BusinessModules/Features/Procurement/Services/SupplierProposalService.php' => 'awardOwnerRecorder',
+            'app/BusinessModules/Features/Procurement/Services/SupplierProposalComparisonService.php' => 'awardOwnerRecorder',
+            'app/BusinessModules/Features/Procurement/Services/PurchaseOrderService.php' => 'reportingLifecycle',
+        ] as $file => $recorder) {
+            self::assertStringContainsString($recorder, $this->source($file), $file);
         }
         self::assertStringContainsString(
             'WarehouseInventoryEventRecorder',
@@ -396,7 +396,7 @@ final class SupplyReportingHardeningTest extends TestCase
             .'ProductionReportDefinitionBindingAssembler.php',
         );
         $provider = $this->source(
-            'app/BusinessModules/Core/Reporting/ReportingContractsServiceProvider.php',
+            'app/BusinessModules/Core/Reporting/ReportingCatalogServiceProvider.php',
         );
 
         foreach ([
@@ -412,7 +412,7 @@ final class SupplyReportingHardeningTest extends TestCase
             self::assertStringContainsString("'{$port}'", $assembler);
         }
         self::assertStringContainsString('ReportDefinitionBindingAssembler::class', $provider);
-        self::assertStringContainsString('ProductionReportDefinitionBindingAssembler::class', $provider);
+        self::assertStringContainsString('ImmutableReportDefinitionBindingAssembler::class', $provider);
     }
 
     public function test_cycle_filters_select_owner_cohort_before_loading_complete_timeline(): void
@@ -481,16 +481,9 @@ final class SupplyReportingHardeningTest extends TestCase
             .'SupplyReliabilityReadinessProbe.php',
         );
 
-        foreach ([
-            'sent_purchase_order_line_owners.warehouse_id',
-            'sent_purchase_order_line_owners.buyer_id',
-            'sent_purchase_order_line_owners.priority',
-            'owner_promise.promised_at',
-            'statusAt(',
-            'matchesDelayFilter(',
-        ] as $immutableFilter) {
-            self::assertStringContainsString($immutableFilter, $materializer);
-        }
+        self::assertStringContainsString('$this->period->resolve($query)', $materializer);
+        self::assertStringContainsString("whereBetween('owner_promise.promised_at'", $materializer);
+        self::assertStringNotContainsString('OwnerReportFilterApplier', $materializer);
         self::assertStringContainsString(
             "'authoritative_order.sent_at', '<=', \$query->asOf",
             $readiness,
@@ -743,8 +736,7 @@ final class SupplyReportingHardeningTest extends TestCase
             .'2026_05_03_000002_create_supplier_proposal_versions.php',
         );
 
-        self::assertStringContainsString('static::updating', $model);
-        self::assertStringContainsString('static::deleting', $model);
+        self::assertStringContainsString('RejectsProcurementSourceMutation', $model);
         self::assertStringContainsString("'supplier_proposal_versions'", $migration);
         self::assertStringNotContainsString('chunkById', $legacyMigration);
     }

--- a/tests/Unit/Reporting/Waves23/SupplyRound15OwnershipTest.php
+++ b/tests/Unit/Reporting/Waves23/SupplyRound15OwnershipTest.php
@@ -12,18 +12,20 @@ final class SupplyRound15OwnershipTest extends TestCase
     {
         $recorder = $this->source(
             'app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/'
-            .'ProcurementProcessEventRecorder.php',
+            .'ProcurementCycleOwnerEventRecorder.php',
         );
         $backfill = $this->source(
             'app/BusinessModules/Features/Procurement/Reporting/Cycle/Backfill/'
             .'ProcurementCycleBackfill.php',
         );
 
-        self::assertStringContainsString('$this->captureOwnerExpectation(', $recorder);
-        self::assertStringContainsString("'purchase_request_line:'.\$purchaseRequestLineId.':owner'", $recorder);
+        self::assertLessThan(
+            strpos($recorder, '$this->recordLine('),
+            strpos($recorder, '$snapshot = $this->newLineSnapshot('),
+        );
         self::assertStringContainsString('$this->events->captureOwnerExpectation(', $backfill);
         self::assertLessThan(
-            strpos($backfill, "if (\$request->created_at === null)"),
+            strpos($backfill, 'if ($request->created_at === null)'),
             strpos($backfill, '$this->events->captureOwnerExpectation('),
         );
     }


### PR DESCRIPTION
## Что исправлено
- реализованы отсутствовавшие операции возврата и полного сторно строки приёмки
- подключены authorizer и транзакционная граница возвратов
- события возврата и сторно снова попадают в канонический источник отчёта надёжности поставок
- восстановлена application-level неизменяемость версий предложений поставщиков
- актуализированы системные контракты Wave-набора после разделения recorder-ов и assembler-ов

## Проверки
- Wave contracts: 363 теста, 1849 assertions
- целевые supply contracts: 58 тестов, 234 assertions
- PHP syntax всех изменённых файлов
- Pint --dirty
- git diff --check

Larastan заблокирован несвязанным application bootstrap: storage_configuration_invalid.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented a new 'returnReceiptLine' functionality in PurchaseOrderService, including authorization and unit of work handling.</li>
<li>Registered new services (PurchaseReceiptReturnAuthorizer, PurchaseReceiptReturnUnitOfWork) in the ProcurementServiceProvider.</li>
<li>Updated PurchaseOrderController to pass the user object instead of just the ID to the reverseReceiptLine method.</li>
<li>Added RejectsProcurementSourceMutation trait to the SupplierProposalVersion model.</li>
</ul></div>