### PR TITLE
fix[admin]: ограничен запуск отчётов выбранным проектом

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Access/ReportHttpAuthorizationOrchestrator.php
+++ b/app/BusinessModules/Core/Reporting/Application/Access/ReportHttpAuthorizationOrchestrator.php
@@ -13,6 +13,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthorization;
 use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthorizationTarget;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\AuthorizeReportDefinitionAccess;
 use Closure;
@@ -38,6 +39,14 @@ final readonly class ReportHttpAuthorizationOrchestrator
         return $this->transaction(function () use ($request, $reportCode): array {
             $facts = $this->contexts->httpFacts($request);
             $target = $this->targets->createRun($reportCode);
+            $projectId = $request->attributes->get('report_project_scope_id');
+            if (is_int($projectId) && $projectId > 0) {
+                return $this->projectAuthorization(
+                    $facts,
+                    $projectId,
+                    $target,
+                );
+            }
 
             return $this->organizationAuthorization($facts, $target);
         });
@@ -225,6 +234,34 @@ final readonly class ReportHttpAuthorizationOrchestrator
             $facts['actor_id'],
             $facts['organization_id'],
             new DateTimeZone('UTC'),
+            $target,
+        );
+        $this->assertAuthorizationMatches($facts['actor_id'], $authorization, $target);
+
+        return [
+            'context' => $this->contexts->fromCurrentAuthorization($authorization),
+            'authorization' => $authorization,
+        ];
+    }
+
+    /**
+     * @param  array{actor_id:int,organization_id:int}  $facts
+     * @return array{context:ReportExecutionContext,authorization:CurrentReportAuthorization}
+     */
+    private function projectAuthorization(
+        array $facts,
+        int $projectId,
+        CurrentReportAuthorizationTarget $target,
+    ): array {
+        $authorization = $this->authorizer->authorizeExact(
+            $facts['actor_id'],
+            new ReportScope(
+                $facts['organization_id'],
+                [$facts['organization_id']],
+                [$projectId],
+                [],
+                new DateTimeZone('UTC'),
+            ),
             $target,
         );
         $this->assertAuthorizationMatches($facts['actor_id'], $authorization, $target);

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -79,7 +79,8 @@ final readonly class AuthorizeReportDefinitionAccess
     private function target(Request $request, string $routeName): CurrentReportAuthorizationTarget
     {
         return match ($routeName) {
-            'admin.reports.runs.store' => $this->genericCreateRun($request),
+            'admin.reports.runs.store',
+            'admin.reports.project-runs.store' => $this->genericCreateRun($request),
             'admin.reports.project-budget-plan-fact.runs.store',
             'admin.reports.project-budget-plan-fact.options',
             'admin.reports.project-margin.runs.store',

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/BindProjectReportScope.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/BindProjectReportScope.php
@@ -29,15 +29,17 @@ final class BindProjectReportScope
             return $this->invalidRequest();
         }
 
-        $filters = $request->input('filters');
-        if ($request->isMethod('GET') || ! is_array($filters)) {
-            return $next($request);
-        }
-
         $project = $request->attributes->get('project');
         $organization = $request->attributes->get('current_organization');
         if ($project === null || $organization === null) {
             return $this->invalidRequest();
+        }
+
+        $request->attributes->set('report_project_scope_id', (int) $project->id);
+
+        $filters = $request->input('filters');
+        if ($request->isMethod('GET') || ! is_array($filters)) {
+            return $next($request);
         }
 
         $request->merge([

--- a/app/BusinessModules/Core/Reporting/routes.php
+++ b/app/BusinessModules/Core/Reporting/routes.php
@@ -214,6 +214,9 @@ Route::prefix('api/v1/admin/reports')
             ->defaults('reportCode', 'payroll_readiness')
             ->middleware(['project.context', 'report.project-scope', $resourceAccess])
             ->name('payroll-readiness.options');
+        Route::post('/projects/{project}/{reportCode}/runs', [ReportRunController::class, 'store'])
+            ->middleware(['project.context', 'report.project-scope', $resourceAccess])
+            ->name('project-runs.store');
         Route::get('/runs/{runId}', [ReportRunController::class, 'show'])
             ->middleware($resourceAccess)
             ->name('runs.show');

--- a/tests/Unit/Reporting/Access/ReportHttpAuthorizationOrchestratorTest.php
+++ b/tests/Unit/Reporting/Access/ReportHttpAuthorizationOrchestratorTest.php
@@ -123,6 +123,32 @@ final class ReportHttpAuthorizationOrchestratorTest extends TestCase
         self::assertSame([], $result['context']->scope->resources);
     }
 
+    public function test_create_run_uses_the_trusted_project_scope_instead_of_the_whole_organization(): void
+    {
+        $definition = $this->definition();
+        $resolver = new RecordingAuthorizationTargetResolver(
+            new CurrentReportAuthorizationTarget($definition, ReportOperation::RUN, null),
+        );
+        $authorizer = new RecordingCurrentReportScopeAuthorizer;
+        $orchestrator = $this->orchestrator(
+            $resolver,
+            new RecordingAuthorizationSubjectReader,
+            $authorizer,
+        );
+        $request = $this->request();
+        $request->attributes->set('report_project_scope_id', 73);
+
+        $result = $orchestrator->createRun($request, 'report');
+
+        self::assertSame([], $authorizer->organizationCalls);
+        self::assertCount(1, $authorizer->exactCalls);
+        self::assertSame(17, $authorizer->exactCalls[0]['actorId']);
+        self::assertSame(41, $authorizer->exactCalls[0]['scope']->organizationId);
+        self::assertSame([41], $authorizer->exactCalls[0]['scope']->holdingOrganizationIds);
+        self::assertSame([73], $authorizer->exactCalls[0]['scope']->projectIds);
+        self::assertSame([73], $result['context']->scope->projectIds);
+    }
+
     public function test_persisted_subject_from_another_middleware_organization_fails_before_authorization(): void
     {
         $scope = new ReportScope(42, [42], [], [], new DateTimeZone('UTC'));

--- a/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
+++ b/tests/Unit/Reporting/Http/ReportInterfaceMiddlewareContractTest.php
@@ -165,6 +165,7 @@ final class ReportInterfaceMiddlewareContractTest extends TestCase
             static function (CreateReportRunRequest $request): Response {
                 self::assertSame('17', $request->input('filters.project_id'));
                 self::assertSame('23', $request->input('filters.organization_id'));
+                self::assertSame(17, $request->attributes->get('report_project_scope_id'));
 
                 return new Response(status: 204);
             },


### PR DESCRIPTION
Исправляет REPORT_SCOPE_FORBIDDEN для проектных канонических отчётов: сервер авторизует доверенный project-scope вместо всей организации. Добавлен общий project-scoped маршрут и регрессионные тесты.\n\nПроверки: PHPUnit 54 теста / 211 assertions; PHP syntax; diff check. PHPStan локально заблокирован обязательной storage-конфигурацией окружения.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced project-scoped report authorization in ReportHttpAuthorizationOrchestrator.</li>
<li>Updated AuthorizeReportDefinitionAccess middleware to support project-specific report run routes.</li>
<li>Modified BindProjectReportScope middleware to inject the project ID into the request attributes.</li>
<li>Added new routes and updated existing ones to support project-scoped reporting.</li>
<li>Added unit tests to verify the new project-scoped authorization logic.</li>
</ul></div>