### PR TITLE
fix[admin]: устранена повторная авторизация отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Access/ReportAccessService.php
+++ b/app/BusinessModules/Core/Reporting/Application/Access/ReportAccessService.php
@@ -29,15 +29,16 @@ final readonly class ReportAccessService
         ?ReportSourceRef $source,
         ?string $exportFormat = null,
     ): ReportVisibility {
-        $actor = $this->reloadActor($context);
-        $permissions = array_fill_keys($actor->permissionSlugs, true);
-        $visibility = $this->visibilityResolver->resolve(
-            $context->scope->organizationId,
-            $definition,
-            $operation,
-            $exportFormat,
-            static fn (string $permission): bool => isset($permissions[$permission]),
-        );
+        if ($context->grant !== null) {
+            if (! $context->grant->matches($definition, $operation, $exportFormat)) {
+                $this->deny();
+            }
+
+            $visibility = $context->visibility;
+        } else {
+            $actor = $this->reloadActor($context);
+            $visibility = $this->legacyVisibility($context, $definition, $operation, $exportFormat, $actor);
+        }
 
         $allowed = match ($operation) {
             ReportOperation::VIEW => $visibility->canView,
@@ -63,6 +64,24 @@ final readonly class ReportAccessService
         }
 
         return $visibility;
+    }
+
+    private function legacyVisibility(
+        ReportExecutionContext $context,
+        ReportDefinition $definition,
+        ReportOperation $operation,
+        ?string $exportFormat,
+        ReportActor $actor,
+    ): ReportVisibility {
+        $permissions = array_fill_keys($actor->permissionSlugs, true);
+
+        return $this->visibilityResolver->resolve(
+            $context->scope->organizationId,
+            $definition,
+            $operation,
+            $exportFormat,
+            static fn (string $permission): bool => isset($permissions[$permission]),
+        );
     }
 
     private function reloadActor(ReportExecutionContext $context): ReportActor

--- a/app/BusinessModules/Core/Reporting/Application/Access/ReportExecutionContextFactory.php
+++ b/app/BusinessModules/Core/Reporting/Application/Access/ReportExecutionContextFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Core\Reporting\Application\Access;
 
 use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthorization;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportAuthorizationGrant;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use Illuminate\Http\Request;
@@ -59,6 +60,11 @@ final readonly class ReportExecutionContextFactory
             $scope,
             $authorization->visibility,
             $decision,
+            new ReportAuthorizationGrant(
+                $authorization->target->definition->definitionHash->value,
+                $authorization->target->operation,
+                $authorization->target->exportFormat,
+            ),
         );
     }
 }

--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportAuthorizationGrant.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportAuthorizationGrant.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Domain\DTO;
+
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
+use InvalidArgumentException;
+
+final readonly class ReportAuthorizationGrant
+{
+    public function __construct(
+        public string $definitionHash,
+        public ReportOperation $operation,
+        public ?string $exportFormat,
+    ) {
+        if (preg_match('/^[a-f0-9]{64}$/D', $definitionHash) !== 1) {
+            throw new InvalidArgumentException('report_authorization_grant_invalid');
+        }
+    }
+
+    public function matches(
+        ReportDefinition $definition,
+        ReportOperation $operation,
+        ?string $exportFormat,
+    ): bool {
+        $operationMatches = $this->operation === $operation
+            || ($this->operation === ReportOperation::VIEW
+                && in_array($operation, [
+                    ReportOperation::VIEW_SENSITIVE,
+                    ReportOperation::VIEW_AUDIT,
+                ], true));
+
+        return $operationMatches
+            && hash_equals($this->definitionHash, $definition->definitionHash->value)
+            && $this->exportFormat === $exportFormat;
+    }
+}

--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportExecutionContext.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportExecutionContext.php
@@ -13,6 +13,7 @@ final readonly class ReportExecutionContext
         public ReportScope $scope,
         public ReportVisibility $visibility,
         public AuthorizationDecisionContext $authorization,
+        public ?ReportAuthorizationGrant $grant = null,
     ) {
         if ($actor->status !== 'active') {
             throw new InvalidArgumentException('execution_context_actor_invalid');

--- a/tests/Unit/Reporting/Access/OrganizationReportScopeResolverTest.php
+++ b/tests/Unit/Reporting/Access/OrganizationReportScopeResolverTest.php
@@ -69,6 +69,9 @@ final class OrganizationReportScopeResolverTest extends TestCase
         self::assertSame(41, $context->actor->id);
         self::assertTrue($context->visibility->canView);
         self::assertSame($this->authorization()->toAuthorizationArray(), $context->authorization->toAuthorizationArray());
+        self::assertSame($definition->definitionHash->value, $context->grant?->definitionHash);
+        self::assertSame(ReportOperation::VIEW, $context->grant?->operation);
+        self::assertNull($context->grant?->exportFormat);
     }
 
     public function test_http_facts_ignore_every_client_and_ambient_authority_field(): void

--- a/tests/Unit/Reporting/Access/ReportAccessServiceTest.php
+++ b/tests/Unit/Reporting/Access/ReportAccessServiceTest.php
@@ -13,10 +13,12 @@ use App\BusinessModules\Core\Reporting\Application\Contracts\Access\ReportModule
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportActor;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportAuthorizationGrant;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinition;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportPermissionPolicy;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceRef;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportVisibility;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportCoreAccessMode;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
@@ -26,6 +28,75 @@ use Tests\Support\Reporting\ReportExecutionContextBuilder;
 
 final class ReportAccessServiceTest extends TestCase
 {
+    public function test_current_authorization_grant_is_not_rejected_by_legacy_flat_permissions(): void
+    {
+        $definition = $this->sourceModuleDefinition();
+        $context = (new ReportExecutionContextBuilder)
+            ->actor(new ReportActor(41, 'active', ['admin.*']))
+            ->visibility(new ReportVisibility(true, true, true, true, false, false, false))
+            ->build();
+        $context = new ReportExecutionContext(
+            $context->actor,
+            $context->scope,
+            $context->visibility,
+            $context->authorization,
+            new ReportAuthorizationGrant(
+                $definition->definitionHash->value,
+                ReportOperation::RUN,
+                null,
+            ),
+        );
+        $loader = new class implements ReportActorLoader
+        {
+            public int $loads = 0;
+
+            public function loadActive(int $actorId): ReportActor
+            {
+                $this->loads++;
+
+                return new ReportActor($actorId, 'active', ['admin.*']);
+            }
+        };
+        $service = new ReportAccessService(
+            $loader,
+            $this->sourceResolver(true),
+            $this->moduleAuthorizer(),
+        );
+
+        self::assertTrue($service->assertOperation(
+            $context,
+            $definition,
+            ReportOperation::RUN,
+            null,
+        )->canRun);
+        self::assertSame(0, $loader->loads);
+    }
+
+    public function test_current_authorization_grant_is_bound_to_definition_and_operation(): void
+    {
+        $definition = $this->definition();
+        $context = (new ReportExecutionContextBuilder)->build();
+        $context = new ReportExecutionContext(
+            $context->actor,
+            $context->scope,
+            $context->visibility,
+            $context->authorization,
+            new ReportAuthorizationGrant(
+                $definition->definitionHash->value,
+                ReportOperation::VIEW,
+                null,
+            ),
+        );
+        $this->expectScopeForbidden();
+
+        $this->service(['reports.view'])->assertOperation(
+            $context,
+            $definition,
+            ReportOperation::RUN,
+            null,
+        );
+    }
+
     public function test_owner_permissions_pass_all_base_operations_without_role_slug_checks(): void
     {
         $permissions = [
@@ -653,8 +724,7 @@ final class ReportAccessServiceTest extends TestCase
         array $sensitivePermissions = [],
         array $auditPermissions = [],
         ?array $exportPermissions = null,
-    ): ReportDefinition
-    {
+    ): ReportDefinition {
         $exportPermissions ??= array_map(
             static fn (string $format): string => match ($format) {
                 'xlsx' => 'act_reports.export.excel',

--- a/tests/Unit/Reporting/Access/ReportHttpAuthorizationOrchestratorTest.php
+++ b/tests/Unit/Reporting/Access/ReportHttpAuthorizationOrchestratorTest.php
@@ -79,6 +79,9 @@ final class ReportHttpAuthorizationOrchestratorTest extends TestCase
         self::assertSame($scope->canonicalIdentity(), $result['context']->scope->canonicalIdentity());
         self::assertSame($operation, $result['authorization']->target->operation);
         self::assertSame($exportFormat, $result['authorization']->target->exportFormat);
+        self::assertSame($definition->definitionHash->value, $result['context']->grant?->definitionHash);
+        self::assertSame($operation, $result['context']->grant?->operation);
+        self::assertSame($exportFormat, $result['context']->grant?->exportFormat);
         self::assertCount(1, $authorizer->exactCalls);
         self::assertSame($scope->canonicalIdentity(), $authorizer->exactCalls[0]['scope']->canonicalIdentity());
         self::assertSame($result['authorization']->target, $authorizer->exactCalls[0]['target']);
@@ -112,6 +115,9 @@ final class ReportHttpAuthorizationOrchestratorTest extends TestCase
         $result = $orchestrator->createRun($request, 'report');
 
         self::assertSame(['context', 'authorization'], array_keys($result));
+        self::assertSame($definition->definitionHash->value, $result['context']->grant?->definitionHash);
+        self::assertSame(ReportOperation::RUN, $result['context']->grant?->operation);
+        self::assertNull($result['context']->grant?->exportFormat);
         self::assertSame(['report'], $resolver->createRunCodes);
         self::assertCount(1, $authorizer->organizationCalls);
         self::assertSame(17, $authorizer->organizationCalls[0]['actorId']);


### PR DESCRIPTION
## Причина\nHTTP-авторизация формировала корректный execution-контекст, но ReportAccessService повторно пересчитывал права через устаревший плоский список. Для системных ролей список терял модульные wildcard-права, поэтому разрешённый запуск завершался REPORT_SCOPE_FORBIDDEN.\n\n## Исправление\n- текущая авторизация передаёт в execution-контекст grant, привязанный к hash определения, операции и формату;\n- ReportAccessService проверяет эту привязку и использует уже вычисленную visibility без второго несовместимого решения;\n- контексты без нового grant сохраняют прежний fail-closed путь;\n- добавлены регрессии на системную роль с admin.* и все HTTP-операции.\n\n## Проверки\n- PHPUnit: 60 тестов, 291 assertion;\n- PHPStan изменённых PHP-файлов: OK;\n- PHP syntax и git diff --check: OK.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced `ReportAuthorizationGrant` DTO to encapsulate report authorization details (definition hash, operation, export format).</li>
<li>Updated `ReportExecutionContext` to optionally include a `ReportAuthorizationGrant`.</li>
<li>Modified `ReportAccessService::assertOperation` to prioritize the new `ReportAuthorizationGrant` for authorization checks if present, falling back to legacy permission-based resolution.</li>
<li>Updated `ReportExecutionContextFactory` to populate the new grant from current authorization.</li>
<li>Added unit tests to verify the new authorization grant logic and its integration with the access service.</li>
</ul></div>