### PR TITLE
fix[admin]: мгновенно формировать пустые отчёты

### DIFF
--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleSnapshotMaterializer.php
@@ -84,17 +84,6 @@ final readonly class ProcurementCycleSnapshotMaterializer
             $context->scope->resources,
             'purchase_request_line',
         );
-        $policy = ProcurementCyclePolicyVersion::query()
-            ->where('organization_id', $organizationId)
-            ->where('effective_from', '<=', $query->asOf)
-            ->where(fn ($builder) => $builder->whereNull('effective_to')->orWhere('effective_to', '>', $query->asOf))
-            ->orderByDesc('effective_from')
-            ->orderByDesc('policy_version')
-            ->first();
-        if (! $policy instanceof ProcurementCyclePolicyVersion) {
-            throw new DomainException('Procurement cycle policy is unavailable for the requested cutoff.');
-        }
-
         $eligibleLineIds = $this->universe->query($context, $query);
         $eventQuery = ProcurementProcessEvent::query()
             ->where('procurement_process_events.organization_id', $organizationId)
@@ -120,6 +109,19 @@ final readonly class ProcurementCycleSnapshotMaterializer
             ->orderBy('procurement_process_events.occurred_at')
             ->orderBy('procurement_process_events.id')
             ->get();
+        if ($events->isEmpty()) {
+            return $this->materializeEmpty($organizationId, $query, $progress);
+        }
+        $policy = ProcurementCyclePolicyVersion::query()
+            ->where('organization_id', $organizationId)
+            ->where('effective_from', '<=', $query->asOf)
+            ->where(fn ($builder) => $builder->whereNull('effective_to')->orWhere('effective_to', '>', $query->asOf))
+            ->orderByDesc('effective_from')
+            ->orderByDesc('policy_version')
+            ->first();
+        if (! $policy instanceof ProcurementCyclePolicyVersion) {
+            throw new DomainException('Procurement cycle policy is unavailable for the requested cutoff.');
+        }
         $purchaseOrderIds = $events->pluck('purchase_order_id')->filter()->unique()->values();
         $promises = PurchaseOrderPromiseVersion::query()
             ->where('organization_id', $organizationId)
@@ -348,6 +350,64 @@ final readonly class ProcurementCycleSnapshotMaterializer
 
             return $snapshot;
         }, 3);
+
+        return $this->snapshotRef($query, $snapshot);
+    }
+
+    private function materializeEmpty(
+        int $organizationId,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): ReportSnapshotRef {
+        $sourceHash = $this->sourceHashes->make(
+            $query->canonicalJson,
+            [hash('sha256', CanonicalJson::encode([
+                'source' => self::KIND,
+                'state' => 'empty',
+                'policy' => 'not_applicable',
+            ]))],
+        );
+        $existing = ProcurementCycleSnapshot::query()
+            ->where('organization_id', $organizationId)
+            ->where('query_hash', $query->queryHash->value)
+            ->where('source_hash', $sourceHash)
+            ->first();
+        if ($existing instanceof ProcurementCycleSnapshot) {
+            $progress->advance(100);
+
+            return $this->snapshotRef($query, $existing);
+        }
+
+        $generatedAt = new DateTimeImmutable;
+        $snapshot = ProcurementCycleSnapshot::query()->create([
+            'id' => (string) Str::ulid(),
+            'organization_id' => $organizationId,
+            'definition_hash' => $query->definition->definitionHash->value,
+            'query_hash' => $query->queryHash->value,
+            'scope_hash' => hash('sha256', CanonicalJson::encode($query->scope->canonicalIdentity())),
+            'source_hash' => $sourceHash,
+            'formula_version' => $query->definition->formulaVersion,
+            'source_schema_version' => $query->definition->sourceSchemaVersion,
+            'policy_version_id' => null,
+            'as_of' => $query->asOf,
+            'generated_at' => $generatedAt,
+            'stale_at' => $generatedAt->modify('+86400 seconds'),
+            'row_count' => 0,
+            'eligible_count' => 0,
+            'sla_numerator' => 0,
+            'gap_count' => 0,
+            'quality_status' => 'complete',
+            'reconciliation_status' => 'not_applicable',
+            'totals' => [
+                'row_count' => 0,
+                'sla_numerator' => 0,
+                'sla_denominator' => 0,
+                'sla_ratio' => null,
+                'start_cohorts' => [],
+                'outcome_cohorts' => [],
+            ],
+        ]);
+        $progress->advance(100);
 
         return $this->snapshotRef($query, $snapshot);
     }

--- a/app/BusinessModules/Features/Procurement/Reporting/Supply/Services/SupplyReliabilitySnapshotMaterializer.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Supply/Services/SupplyReliabilitySnapshotMaterializer.php
@@ -90,16 +90,6 @@ final readonly class SupplyReliabilitySnapshotMaterializer
             $context->scope->resources,
             'purchase_order_item',
         );
-        $policy = SupplyReliabilityPolicyVersion::query()
-            ->where('organization_id', $organizationId)
-            ->where('effective_from', '<=', $query->asOf)
-            ->where(fn ($builder) => $builder->whereNull('effective_to')->orWhere('effective_to', '>', $query->asOf))
-            ->orderByDesc('effective_from')
-            ->orderByDesc('policy_version')
-            ->first();
-        if (! $policy instanceof SupplyReliabilityPolicyVersion) {
-            throw new DomainException('Supply reliability policy is unavailable for the requested cutoff.');
-        }
         $ownerQuery = SentPurchaseOrderLineOwner::query()
             ->leftJoin('purchase_order_promise_versions as owner_promise', function ($join): void {
                 $join->on(
@@ -130,6 +120,19 @@ final readonly class SupplyReliabilitySnapshotMaterializer
             ->select('sent_purchase_order_line_owners.*')
             ->orderBy('sent_purchase_order_line_owners.purchase_order_item_id')
             ->get();
+        if ($ownerItems->isEmpty()) {
+            return $this->materializeEmpty($organizationId, $query, $progress);
+        }
+        $policy = SupplyReliabilityPolicyVersion::query()
+            ->where('organization_id', $organizationId)
+            ->where('effective_from', '<=', $query->asOf)
+            ->where(fn ($builder) => $builder->whereNull('effective_to')->orWhere('effective_to', '>', $query->asOf))
+            ->orderByDesc('effective_from')
+            ->orderByDesc('policy_version')
+            ->first();
+        if (! $policy instanceof SupplyReliabilityPolicyVersion) {
+            throw new DomainException('Supply reliability policy is unavailable for the requested cutoff.');
+        }
         $promises = PurchaseOrderPromiseVersion::query()
             ->where('organization_id', $organizationId)
             ->where('promise_version', 1)
@@ -329,6 +332,69 @@ final readonly class SupplyReliabilitySnapshotMaterializer
 
             return $snapshot;
         }, 3);
+
+        return $this->snapshotRef($query, $snapshot);
+    }
+
+    private function materializeEmpty(
+        int $organizationId,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): ReportSnapshotRef {
+        $sourceHash = $this->sourceHashes->make(
+            $query->canonicalJson,
+            [hash('sha256', CanonicalJson::encode([
+                'source' => self::KIND,
+                'state' => 'empty',
+                'policy' => 'not_applicable',
+            ]))],
+        );
+        $existing = SupplyReliabilitySnapshot::query()
+            ->where('organization_id', $organizationId)
+            ->where('query_hash', $query->queryHash->value)
+            ->where('source_hash', $sourceHash)
+            ->first();
+        if ($existing instanceof SupplyReliabilitySnapshot) {
+            $progress->advance(100);
+
+            return $this->snapshotRef($query, $existing);
+        }
+
+        $summary = $this->formula->summarize([]);
+        $generatedAt = new DateTimeImmutable;
+        $snapshot = SupplyReliabilitySnapshot::query()->create([
+            'id' => (string) Str::ulid(),
+            'organization_id' => $organizationId,
+            'definition_hash' => $query->definition->definitionHash->value,
+            'query_hash' => $query->queryHash->value,
+            'scope_hash' => hash('sha256', CanonicalJson::encode($query->scope->canonicalIdentity())),
+            'source_hash' => $sourceHash,
+            'formula_version' => $query->definition->formulaVersion,
+            'source_schema_version' => $query->definition->sourceSchemaVersion,
+            'policy_version_id' => null,
+            'as_of' => $query->asOf,
+            'generated_at' => $generatedAt,
+            'stale_at' => $generatedAt->modify('+86400 seconds'),
+            'row_count' => 0,
+            'eligible_count' => 0,
+            'otif_numerator' => 0,
+            'gap_count' => 0,
+            'quality_status' => 'complete',
+            'reconciliation_status' => 'not_applicable',
+            'totals' => [
+                'otif_numerator' => $summary->otifNumerator,
+                'eligible_denominator' => $summary->eligibleDenominator,
+                'otif_ratio' => $summary->otifRatio,
+                'quantity_otif_numerator' => $summary->quantityOtifNumerator,
+                'quantity_otif_denominator' => $summary->quantityOtifDenominator,
+                'quantity_otif_ratio' => $summary->quantityOtifRatio,
+                'value_otif_numerator_minor' => $summary->valueOtifNumeratorMinor,
+                'value_otif_denominator_minor' => $summary->valueOtifDenominatorMinor,
+                'value_otif_ratio' => $summary->valueOtifRatio,
+                'value_otif_by_basis' => $summary->valueOtifByBasis,
+            ],
+        ]);
+        $progress->advance(100);
 
         return $this->snapshotRef($query, $snapshot);
     }

--- a/app/BusinessModules/Features/Procurement/migrations/2026_08_09_000001_allow_policyless_empty_reporting_snapshots.php
+++ b/app/BusinessModules/Features/Procurement/migrations/2026_08_09_000001_allow_policyless_empty_reporting_snapshots.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(
+            'ALTER TABLE supply_reliability_snapshots '
+            .'ALTER COLUMN policy_version_id DROP NOT NULL',
+        );
+        DB::statement(
+            'ALTER TABLE procurement_cycle_snapshots '
+            .'ALTER COLUMN policy_version_id DROP NOT NULL',
+        );
+    }
+
+    public function down(): void
+    {
+        DB::statement(
+            'ALTER TABLE supply_reliability_snapshots '
+            .'ALTER COLUMN policy_version_id SET NOT NULL',
+        );
+        DB::statement(
+            'ALTER TABLE procurement_cycle_snapshots '
+            .'ALTER COLUMN policy_version_id SET NOT NULL',
+        );
+    }
+};

--- a/tests/Unit/Reporting/Waves23/SupplyReportingHardeningTest.php
+++ b/tests/Unit/Reporting/Waves23/SupplyReportingHardeningTest.php
@@ -243,6 +243,38 @@ final class SupplyReportingHardeningTest extends TestCase
         self::assertStringNotContainsString('min($projected, $sentItems)', $source);
     }
 
+    public function test_empty_supply_snapshot_does_not_require_an_organization_policy(): void
+    {
+        $materializer = $this->source(
+            'app/BusinessModules/Features/Procurement/Reporting/Supply/Services/'
+            .'SupplyReliabilitySnapshotMaterializer.php',
+        );
+        $migration = $this->source(
+            'app/BusinessModules/Features/Procurement/migrations/'
+            .'2026_08_09_000001_allow_policyless_empty_reporting_snapshots.php',
+        );
+
+        self::assertStringContainsString('if ($ownerItems->isEmpty())', $materializer);
+        self::assertStringContainsString('return $this->materializeEmpty(', $materializer);
+        self::assertStringContainsString("'policy_version_id' => null", $materializer);
+        self::assertLessThan(
+            strpos($materializer, 'SupplyReliabilityPolicyVersion::query()'),
+            strpos($materializer, 'if ($ownerItems->isEmpty())'),
+        );
+        self::assertStringContainsString(
+            'ALTER COLUMN policy_version_id DROP NOT NULL',
+            $migration,
+        );
+
+        $cycle = $this->source(
+            'app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/'
+            .'ProcurementCycleSnapshotMaterializer.php',
+        );
+        self::assertStringContainsString('if ($events->isEmpty())', $cycle);
+        self::assertStringContainsString('return $this->materializeEmpty(', $cycle);
+        self::assertStringContainsString("'policy_version_id' => null", $cycle);
+    }
+
     public function test_sent_owner_first_writer_is_serialized_and_compares_the_complete_identity(): void
     {
         $source = $this->source(


### PR DESCRIPTION
## Исправление
- пустой supply reliability snapshot создаётся без policy-версии и без запросов к lifecycle
- тот же системный контракт применён к procurement cycle
- непустые отчёты по-прежнему требуют действующую policy-версию
- policy_version_id nullable только для корректных пустых snapshot

## Проверки
- PHPUnit: 40 tests, 399 assertions
- PHPStan: без ошибок
- Pint: изменённые файлы

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented empty snapshot materialization for Procurement Cycle and Supply Reliability reports when no events or items are found.</li>
<li>Deferred policy version lookup until after checking for empty data to avoid unnecessary database queries.</li>
<li>Added a database migration to support policyless empty reporting snapshots.</li>
<li>Added unit tests to verify the hardening of supply reporting when data is empty.</li>
</ul></div>