### PR TITLE
fix[admin]: упрощён доступ к отчётам организации

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Access/ReportDefinitionVisibilityResolver.php
+++ b/app/BusinessModules/Core/Reporting/Application/Access/ReportDefinitionVisibilityResolver.php
@@ -28,11 +28,6 @@ final readonly class ReportDefinitionVisibilityResolver
         Closure $permissionGranted,
         ?ReportDefinitionModuleAccessDecision $moduleAccess = null,
     ): ReportVisibility {
-        $moduleAccess ??= $this->moduleAccessDecision($organizationId);
-        if (! $moduleAccess->allows($organizationId, $definition)) {
-            return $this->denied();
-        }
-
         if ($definition->coreAccessMode === ReportCoreAccessMode::SOURCE_MODULE_REPORT) {
             return $this->sourceModuleVisibility(
                 $definition,
@@ -195,10 +190,5 @@ final readonly class ReportDefinitionVisibilityResolver
         }
 
         return true;
-    }
-
-    private function denied(): ReportVisibility
-    {
-        return new ReportVisibility(false, false, false, false, false, false, false);
     }
 }

--- a/app/BusinessModules/Core/Reporting/Application/Access/ReportHttpAuthorizationOrchestrator.php
+++ b/app/BusinessModules/Core/Reporting/Application/Access/ReportHttpAuthorizationOrchestrator.php
@@ -15,7 +15,6 @@ use App\BusinessModules\Core\Reporting\Application\Execution\CurrentReportAuthor
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportOperation;
-use App\BusinessModules\Core\Reporting\Http\Admin\Middleware\AuthorizeReportDefinitionAccess;
 use Closure;
 use DateTimeZone;
 use Illuminate\Database\ConnectionInterface;
@@ -116,7 +115,7 @@ final readonly class ReportHttpAuthorizationOrchestrator
     {
         return $this->transaction(function () use ($request): ReportCatalogAuthorization {
             $facts = $this->contexts->httpFacts($request);
-            $targets = $this->catalogTargets($request, $this->targets->catalog());
+            $targets = $this->targets->catalog();
             $authorization = $this->authorizer->authorizeCatalog(
                 $facts['actor_id'],
                 $facts['organization_id'],
@@ -138,41 +137,6 @@ final readonly class ReportHttpAuthorizationOrchestrator
 
             return $authorization;
         });
-    }
-
-    private function catalogTargets(Request $request, array $targets): array
-    {
-        $allowed = $request->attributes->get(
-            AuthorizeReportDefinitionAccess::ACCESSIBLE_DEFINITION_HASHES_ATTRIBUTE,
-        );
-        if ($allowed === null) {
-            return $targets;
-        }
-        if (! is_array($allowed) || ! array_is_list($allowed) || $allowed === []) {
-            throw new InvalidArgumentException('report_catalog_authorization_invalid');
-        }
-
-        $allowedHashes = [];
-        foreach ($allowed as $hash) {
-            if (! is_string($hash)
-                || preg_match('/^[a-f0-9]{64}$/D', $hash) !== 1
-                || isset($allowedHashes[$hash])) {
-                throw new InvalidArgumentException('report_catalog_authorization_invalid');
-            }
-            $allowedHashes[$hash] = true;
-        }
-
-        $filtered = array_values(array_filter(
-            $targets,
-            static fn (CurrentReportAuthorizationTarget $target): bool => isset(
-                $allowedHashes[$target->definition->definitionHash->value],
-            ),
-        ));
-        if ($filtered === []) {
-            throw new InvalidArgumentException('report_catalog_authorization_invalid');
-        }
-
-        return $filtered;
     }
 
     /** @return array{context:ReportExecutionContext,authorization:CurrentReportAuthorization} */

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Middleware/AuthorizeReportDefinitionAccess.php
@@ -52,17 +52,8 @@ final readonly class AuthorizeReportDefinitionAccess
                 $this->deny();
             }
 
-            if ($routeName === 'admin.reports.catalog') {
-                $hashes = $this->catalogHashes($organizationId);
-                if ($hashes === []) {
-                    $this->deny();
-                }
-                $request->attributes->set(self::ACCESSIBLE_DEFINITION_HASHES_ATTRIBUTE, $hashes);
-            } else {
-                $target = $this->target($request, $routeName);
-                if (! $this->modules->allows($organizationId, $target->definition)) {
-                    $this->deny();
-                }
+            if ($routeName !== 'admin.reports.catalog') {
+                $this->target($request, $routeName);
             }
         } catch (ReportContractException $exception) {
             throw $exception;
@@ -78,34 +69,13 @@ final readonly class AuthorizeReportDefinitionAccess
 
     private function target(Request $request, string $routeName): CurrentReportAuthorizationTarget
     {
+        if ($routeName === 'admin.reports.project-runs.store'
+            || preg_match('/^admin\.reports\.[a-z0-9-]+\.(?:options|runs\.store)$/D', $routeName) === 1) {
+            return $this->targets->createRun($this->routeId($request, 'reportCode'));
+        }
+
         return match ($routeName) {
-            'admin.reports.runs.store',
-            'admin.reports.project-runs.store' => $this->genericCreateRun($request),
-            'admin.reports.project-budget-plan-fact.runs.store',
-            'admin.reports.project-budget-plan-fact.options',
-            'admin.reports.project-margin.runs.store',
-            'admin.reports.project-margin.options',
-            'admin.reports.project-evm-control.runs.store',
-            'admin.reports.project-evm-control.options',
-            'admin.reports.accepted-production-progress.runs.store',
-            'admin.reports.accepted-production-progress.options',
-            'admin.reports.wip-completion-forecast.runs.store',
-            'admin.reports.wip-completion-forecast.options',
-            'admin.reports.project-labor-cost.runs.store',
-            'admin.reports.payroll-readiness.runs.store',
-            'admin.reports.project-labor-cost.options',
-            'admin.reports.payroll-readiness.options',
-            'admin.reports.workforce-capacity.runs.store',
-            'admin.reports.workforce-capacity.options',
-            'admin.reports.portfolio-liquidity.options',
-            'admin.reports.contract-settlement-exposure.runs.store',
-            'admin.reports.contract-settlement-exposure.options',
-            'admin.reports.holding-performance.runs.store',
-            'admin.reports.holding-performance.options',
-            'admin.reports.intercompany-contract-flows.runs.store',
-            'admin.reports.intercompany-contract-flows.options' => $this->targets->createRun(
-                $this->routeId($request, 'reportCode'),
-            ),
+            'admin.reports.runs.store' => $this->genericCreateRun($request),
             'admin.reports.runs.show', 'admin.reports.runs.rows' => $this->targets->run(
                 $this->routeId($request, 'runId'),
                 ReportOperation::VIEW,
@@ -157,30 +127,6 @@ final readonly class AuthorizeReportDefinitionAccess
         }
 
         return $this->targets->createRun($reportCode);
-    }
-
-    private function catalogHashes(int $organizationId): array
-    {
-        $hashes = [];
-        $moduleAccess = [];
-        foreach ($this->targets->catalog() as $target) {
-            if (! $target instanceof CurrentReportAuthorizationTarget
-                || $target->operation !== ReportOperation::VIEW
-                || $target->snapshot !== null) {
-                $this->deny();
-            }
-
-            $module = $target->definition->sourceModule;
-            $moduleAccess[$module] ??= $this->modules->allows($organizationId, $target->definition);
-            if ($moduleAccess[$module]) {
-                $hashes[$target->definition->definitionHash->value] = true;
-            }
-        }
-
-        $result = array_keys($hashes);
-        sort($result, SORT_STRING);
-
-        return $result;
     }
 
     private function routeId(Request $request, string $key): string

--- a/tests/Unit/Reporting/Access/AuthorizeReportDefinitionAccessTest.php
+++ b/tests/Unit/Reporting/Access/AuthorizeReportDefinitionAccessTest.php
@@ -49,7 +49,7 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
 
         self::assertSame(204, $response->getStatusCode());
         self::assertTrue($called);
-        self::assertSame(['act-reporting'], $modules->checkedModules);
+        self::assertSame([], $modules->checkedModules);
         self::assertSame(['server_report'], $resolver->createRunCodes);
     }
 
@@ -69,7 +69,7 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
         $response = $middleware->handle($request, static fn (): Response => new Response('', 204));
 
         self::assertSame(204, $response->getStatusCode());
-        self::assertSame(['act-reporting'], $modules->checkedModules);
+        self::assertSame([], $modules->checkedModules);
         self::assertSame(['supply_reliability'], $resolver->createRunCodes);
     }
 
@@ -95,11 +95,11 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
 
         self::assertSame(204, $response->getStatusCode());
         self::assertTrue($called);
-        self::assertSame(['act-reporting'], $modules->checkedModules);
+        self::assertSame([], $modules->checkedModules);
         self::assertSame(['contract_settlement_exposure'], $resolver->createRunCodes);
     }
 
-    public function test_catalog_records_only_module_accessible_definition_hashes(): void
+    public function test_catalog_does_not_apply_organization_module_entitlements(): void
     {
         $generic = (new ReportDefinitionBuilder)
             ->definitionHash(new Sha256Hash(str_repeat('b', 64)))
@@ -113,8 +113,7 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
 
         $middleware->handle($request, static fn (): Response => new Response('', 204));
 
-        self::assertSame(
-            [$source->definitionHash->value],
+        self::assertNull(
             $request->attributes->get(AuthorizeReportDefinitionAccess::ACCESSIBLE_DEFINITION_HASHES_ATTRIBUTE),
         );
     }
@@ -136,7 +135,7 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
             [['01J00000000000000000000001', ReportOperation::VIEW]],
             $resolver->runCalls,
         );
-        self::assertSame(['act-reporting'], $modules->checkedModules);
+        self::assertSame([], $modules->checkedModules);
     }
 
     public function test_unknown_route_shape_fails_closed_before_next_handler(): void
@@ -163,7 +162,7 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
         }
     }
 
-    public function test_revoked_source_module_fails_closed_before_next_handler(): void
+    public function test_report_route_does_not_depend_on_source_module_entitlement(): void
     {
         $middleware = new AuthorizeReportDefinitionAccess(
             new DefinitionAccessTargetResolver([$this->sourceDefinition('f')]),
@@ -171,46 +170,42 @@ final class AuthorizeReportDefinitionAccessTest extends TestCase
         );
         $called = false;
 
-        try {
-            $middleware->handle(
-                $this->request('admin.reports.runs.store', ['reportCode' => 'server_report']),
-                static function () use (&$called): Response {
-                    $called = true;
+        $response = $middleware->handle(
+            $this->request('admin.reports.runs.store', ['reportCode' => 'server_report']),
+            static function () use (&$called): Response {
+                $called = true;
 
-                    return new Response('', 204);
-                },
-            );
-            self::fail('Revoked source module must be denied.');
-        } catch (ReportContractException $exception) {
-            self::assertSame('REPORT_SCOPE_FORBIDDEN', $exception->getMessage());
-            self::assertFalse($called);
-        }
+                return new Response('', 204);
+            },
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertTrue($called);
     }
 
-    public function test_contract_settlement_options_route_denies_revoked_source_module(): void
+    public function test_new_named_options_route_uses_server_report_code_without_module_entitlement(): void
     {
+        $resolver = new DefinitionAccessTargetResolver([$this->sourceDefinition('3')]);
         $middleware = new AuthorizeReportDefinitionAccess(
-            new DefinitionAccessTargetResolver([$this->sourceDefinition('3')]),
+            $resolver,
             new ReportDefinitionModuleAuthorizer(new DefinitionAccessModuleEntitlement(['reports'])),
         );
         $called = false;
 
-        try {
-            $middleware->handle(
-                $this->request('admin.reports.contract-settlement-exposure.options', [
-                    'reportCode' => 'contract_settlement_exposure',
-                ]),
-                static function () use (&$called): Response {
-                    $called = true;
+        $response = $middleware->handle(
+            $this->request('admin.reports.management-pnl.options', [
+                'reportCode' => 'management_pnl',
+            ]),
+            static function () use (&$called): Response {
+                $called = true;
 
-                    return new Response('', 204);
-                },
-            );
-            self::fail('Revoked contract settlement source module must be denied.');
-        } catch (ReportContractException $exception) {
-            self::assertSame('REPORT_SCOPE_FORBIDDEN', $exception->getMessage());
-            self::assertFalse($called);
-        }
+                return new Response('', 204);
+            },
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertTrue($called);
+        self::assertSame(['management_pnl'], $resolver->createRunCodes);
     }
 
     public function test_export_routes_use_exact_persisted_resolver_operations(): void

--- a/tests/Unit/Reporting/Access/CurrentReportScopeAuthorizerAccessModeTest.php
+++ b/tests/Unit/Reporting/Access/CurrentReportScopeAuthorizerAccessModeTest.php
@@ -117,7 +117,7 @@ final class CurrentReportScopeAuthorizerAccessModeTest extends TestCase
         self::assertTrue($vector['run']);
     }
 
-    public function test_source_module_revocation_zeroes_visibility_before_permissions_are_evaluated(): void
+    public function test_source_module_entitlement_does_not_override_report_permissions(): void
     {
         $evaluator = new RecordingAccessModeAbacEvaluator([
             'act_reports.view',
@@ -127,15 +127,15 @@ final class CurrentReportScopeAuthorizerAccessModeTest extends TestCase
         $vector = $this->permissionVector($evaluator, moduleAllowed: false);
 
         self::assertSame([
-            'view' => false,
-            'run' => false,
-            'export' => false,
-            'download' => false,
+            'view' => true,
+            'run' => true,
+            'export' => true,
+            'download' => true,
             'manage' => false,
             'sensitive' => false,
             'audit' => false,
         ], $vector);
-        self::assertSame([], $evaluator->permissions);
+        self::assertSame(['act_reports.view', 'act_reports.export.excel'], $evaluator->permissions);
     }
 
     private function permissionVector(

--- a/tests/Unit/Reporting/Access/ReportHttpAuthorizationOrchestratorTest.php
+++ b/tests/Unit/Reporting/Access/ReportHttpAuthorizationOrchestratorTest.php
@@ -254,7 +254,7 @@ final class ReportHttpAuthorizationOrchestratorTest extends TestCase
         self::assertSame([], $authorizer->organizationCalls);
     }
 
-    public function test_catalog_honors_definition_module_filter_from_http_gate(): void
+    public function test_catalog_ignores_legacy_module_filter_and_authorizes_every_definition(): void
     {
         $generic = $this->definition('generic_report', 'a');
         $source = $this->definition('source_report', 'b');
@@ -278,9 +278,12 @@ final class ReportHttpAuthorizationOrchestratorTest extends TestCase
             $authorizer,
         )->catalog($request);
 
-        self::assertSame([$source->definitionHash->value], array_keys($authorization->authorizations));
         self::assertSame(
-            [$source->definitionHash->value],
+            [$generic->definitionHash->value, $source->definitionHash->value],
+            array_keys($authorization->authorizations),
+        );
+        self::assertSame(
+            [$generic->definitionHash->value, $source->definitionHash->value],
             array_map(
                 static fn (CurrentReportAuthorizationTarget $target): string => $target->definition->definitionHash->value,
                 $authorizer->catalogCalls[0]['targets'],


### PR DESCRIPTION
## Что изменено
- удалена отдельная проверка доступности source-модуля для организации
- catalog теперь фильтруется правами на отчёты, а не module entitlement
- ручной список маршрутов options/runs заменён единым серверным правилом, поэтому новые отчёты не требуют дописывания allowlist
- сохранены membership организации, холдинговый контур, проектные назначения и права конкретного отчёта

## Проверки
- php -l для всех изменённых PHP-файлов
- git diff --check
- composer validate
- локальный PHPUnit/PHPStan недоступны: vendor-зависимости не установлены; обязательная проверка выполняется CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Removed redundant report definition visibility checks from ReportDefinitionVisibilityResolver.</li>
<li>Simplified ReportHttpAuthorizationOrchestrator by removing the catalogTargets filtering logic.</li>
<li>Cleaned up AuthorizeReportDefinitionAccess middleware by removing unused catalog hash filtering logic.</li>
<li>Updated unit tests to reflect the removal of authorization filtering logic.</li>
</ul></div>