### PR TITLE
fix[admin]: исправлена обработка пустых отчетов

### DIFF
--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Models/InventoryRiskSnapshot.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Models/InventoryRiskSnapshot.php
@@ -28,6 +28,7 @@ final class InventoryRiskSnapshot extends Model
             'row_count' => 'integer',
             'gap_count' => 'integer',
             'totals' => 'array',
+            'as_of' => 'immutable_datetime',
             'generated_at' => 'immutable_datetime',
             'stale_at' => 'immutable_datetime',
         ];

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
-use App\BusinessModules\Core\Reporting\Domain\Enums\ReportErrorCode;
-use App\BusinessModules\Core\Reporting\Domain\Exceptions\ReportContractException;
 use App\Enums\CurrencyCode;
 use App\Models\Project;
 use App\Support\Reporting\StableReportingSourceView;

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/Models/SupplierAwardSnapshot.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/Models/SupplierAwardSnapshot.php
@@ -29,6 +29,7 @@ final class SupplierAwardSnapshot extends Model
             'eligible_count' => 'integer',
             'gap_count' => 'integer',
             'totals' => 'array',
+            'as_of' => 'immutable_datetime',
             'generated_at' => 'immutable_datetime',
             'stale_at' => 'immutable_datetime',
         ];

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Models/ProcurementCycleSnapshot.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Models/ProcurementCycleSnapshot.php
@@ -31,6 +31,7 @@ final class ProcurementCycleSnapshot extends Model
             'sla_numerator' => 'integer',
             'gap_count' => 'integer',
             'totals' => 'array',
+            'as_of' => 'immutable_datetime',
             'generated_at' => 'immutable_datetime',
             'stale_at' => 'immutable_datetime',
         ];

--- a/app/BusinessModules/Features/Procurement/Reporting/Supply/Models/SupplyReliabilitySnapshot.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Supply/Models/SupplyReliabilitySnapshot.php
@@ -31,6 +31,7 @@ final class SupplyReliabilitySnapshot extends Model
             'otif_numerator' => 'integer',
             'gap_count' => 'integer',
             'totals' => 'array',
+            'as_of' => 'immutable_datetime',
             'generated_at' => 'immutable_datetime',
             'stale_at' => 'immutable_datetime',
         ];

--- a/app/Jobs/ReportingSourceBackfillJob.php
+++ b/app/Jobs/ReportingSourceBackfillJob.php
@@ -60,6 +60,29 @@ final class ReportingSourceBackfillJob implements ShouldBeUniqueUntilProcessing,
                 ->first();
             [$targetCursor, $ownerFacts] = self::ownerCutoff($organizationId, $sourceCode);
             $checksum = hash('sha256', CanonicalJson::encode($ownerFacts));
+            if (self::isEmptyTargetCursor($targetCursor)
+                && (int) $ledger->source_count === 0
+                && (int) $ledger->projected_count === 0
+                && (int) $ledger->gap_count === 0
+                && (int) $ledger->unknown_count === 0) {
+                DB::table('report_source_sync_ledgers')->where('id', $ledger->id)->update([
+                    'cursor' => json_encode($targetCursor, JSON_THROW_ON_ERROR),
+                    'target_cursor' => json_encode($targetCursor, JSON_THROW_ON_ERROR),
+                    'owner_checksum' => $checksum,
+                    'status' => 'ready',
+                    'source_count' => 0,
+                    'projected_count' => 0,
+                    'gap_count' => 0,
+                    'unknown_count' => 0,
+                    'unknown_owner_keys' => '[]',
+                    'source_watermark' => null,
+                    'completed_owner_checksum' => $checksum,
+                    'completed_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
+                return;
+            }
             $shouldDispatch = $ledger->status !== 'ready'
                 || CanonicalJson::encode(json_decode((string) $ledger->cursor, true, 512, JSON_THROW_ON_ERROR))
                     !== CanonicalJson::encode(json_decode((string) $ledger->target_cursor, true, 512, JSON_THROW_ON_ERROR));
@@ -235,5 +258,20 @@ final class ReportingSourceBackfillJob implements ShouldBeUniqueUntilProcessing,
         $generation = ReportSourceOwnerGeneration::capture($organizationId, $sourceCode);
 
         return [$generation['target_cursor'], $generation['facts']];
+    }
+
+    private static function isEmptyTargetCursor(array $targetCursor): bool
+    {
+        if (array_keys($targetCursor) === ['id']) {
+            return $targetCursor['id'] === 0;
+        }
+
+        if (array_keys($targetCursor) !== ['incident_id', 'violation_id', 'action_id']) {
+            return false;
+        }
+
+        return $targetCursor['incident_id'] === 0
+            && $targetCursor['violation_id'] === 0
+            && $targetCursor['action_id'] === 0;
     }
 }

--- a/app/Support/Reporting/OwnerReportFilterApplier.php
+++ b/app/Support/Reporting/OwnerReportFilterApplier.php
@@ -18,11 +18,10 @@ final readonly class OwnerReportFilterApplier
             $mapping = $columns[$filter] ?? null;
             $invertBoolean = is_array($mapping) && ($mapping['invert_boolean'] ?? false) === true;
             $column = is_array($mapping) ? ($mapping['column'] ?? null) : $mapping;
-            if ((! is_string($column) && ! $column instanceof Expression) || ! is_array($condition)) {
+            if (! is_string($column) && ! $column instanceof Expression) {
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_UNSUPPORTED);
             }
-            $operator = $condition['operator'] ?? null;
-            $value = $condition['value'] ?? null;
+            [$operator, $value] = self::normalizeCondition($condition);
             if ($invertBoolean && is_bool($value)) {
                 $value = ! $value;
             }
@@ -52,6 +51,19 @@ final readonly class OwnerReportFilterApplier
     public function only(ReportFilterSet $filters, array $names): ReportFilterSet
     {
         return new ReportFilterSet(array_intersect_key($filters->values, array_flip($names)));
+    }
+
+    private static function normalizeCondition(mixed $condition): array
+    {
+        if (is_array($condition) && ! array_is_list($condition)) {
+            if (array_keys($condition) !== ['operator', 'value'] || ! is_string($condition['operator'])) {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_UNSUPPORTED);
+            }
+
+            return [$condition['operator'], $condition['value']];
+        }
+
+        return [is_array($condition) ? 'in' : 'eq', $condition];
     }
 
     private function escaped(string $value): string

--- a/tests/Unit/Reporting/Waves23/OwnerReportFilterApplierContractTest.php
+++ b/tests/Unit/Reporting/Waves23/OwnerReportFilterApplierContractTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\Support\Reporting\OwnerReportFilterApplier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class OwnerReportFilterApplierContractTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('conditions')]
+    public function canonical_and_operator_aware_filters_share_one_application_contract(
+        mixed $condition,
+        array $expected,
+    ): void {
+        $method = new ReflectionMethod(OwnerReportFilterApplier::class, 'normalizeCondition');
+
+        self::assertSame($expected, $method->invoke(null, $condition));
+    }
+
+    public static function conditions(): array
+    {
+        return [
+            'canonical scalar' => [52, ['eq', 52]],
+            'canonical list' => [[1, 2], ['in', [1, 2]]],
+            'operator aware scalar' => [
+                ['operator' => 'gte', 'value' => 10],
+                ['gte', 10],
+            ],
+            'operator aware list' => [
+                ['operator' => 'not_in', 'value' => ['closed']],
+                ['not_in', ['closed']],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Reporting/Waves23/ReportingEmptySourceGenerationTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingEmptySourceGenerationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\Jobs\ReportingSourceBackfillJob;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class ReportingEmptySourceGenerationTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('targetCursors')]
+    public function only_a_generation_without_owner_rows_is_empty(array $cursor, bool $expected): void
+    {
+        $method = new ReflectionMethod(ReportingSourceBackfillJob::class, 'isEmptyTargetCursor');
+
+        self::assertSame($expected, $method->invoke(null, $cursor));
+    }
+
+    public static function targetCursors(): array
+    {
+        return [
+            'linear empty' => [['id' => 0], true],
+            'linear non-empty' => [['id' => 1], false],
+            'incident empty' => [[
+                'incident_id' => 0,
+                'violation_id' => 0,
+                'action_id' => 0,
+            ], true],
+            'incident non-empty' => [[
+                'incident_id' => 0,
+                'violation_id' => 4,
+                'action_id' => 0,
+            ], false],
+            'unknown shape' => [[], false],
+        ];
+    }
+}

--- a/tests/Unit/Reporting/Waves23/ReportingSnapshotDateCastTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSnapshotDateCastTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\BusinessModules\Features\BasicWarehouse\Reporting\InventoryRisk\Models\InventoryRiskSnapshot;
+use App\BusinessModules\Features\Procurement\Reporting\Award\Models\SupplierAwardSnapshot;
+use App\BusinessModules\Features\Procurement\Reporting\Cycle\Models\ProcurementCycleSnapshot;
+use App\BusinessModules\Features\Procurement\Reporting\Supply\Models\SupplyReliabilitySnapshot;
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ReportingSnapshotDateCastTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('snapshotModels')]
+    public function snapshot_as_of_is_an_immutable_date(string $modelClass): void
+    {
+        $snapshot = new $modelClass(['as_of' => '2026-08-09T00:00:00+00:00']);
+
+        self::assertInstanceOf(CarbonImmutable::class, $snapshot->as_of);
+        self::assertSame('2026-08-09T00:00:00+00:00', $snapshot->as_of->toAtomString());
+    }
+
+    public static function snapshotModels(): array
+    {
+        return [
+            'procurement cycle' => [ProcurementCycleSnapshot::class],
+            'supplier award' => [SupplierAwardSnapshot::class],
+            'supply reliability' => [SupplyReliabilitySnapshot::class],
+            'inventory risk' => [InventoryRiskSnapshot::class],
+        ];
+    }
+}


### PR DESCRIPTION
Системно исправляет production-дефекты отчетов: канонические фильтры owner-источников, мгновенное завершение действительно пустых ledger-источников, immutable cast даты снимка и корректный доменный контракт параметров портфеля. Добавлены регрессионные тесты; локально выполнены PHP syntax и diff checks, полный PHPUnit/PHPStan выполняет CI (vendor локально отсутствует).

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added 'as_of' field with 'immutable_datetime' cast to multiple snapshot models (InventoryRisk, SupplierAward, ProcurementCycle, SupplyReliability).</li>
<li>Refactored namespace imports in ProjectPortfolioHealthOptionsService to use correct application error classes.</li>
<li>Updated ReportingSourceBackfillJob to handle empty target cursors by marking the sync ledger as 'ready' and resetting counts when no data is present.</li>
<li>Added unit tests for OwnerReportFilterApplier, empty source generation, and snapshot date casting.</li>
</ul></div>