### PR TITLE
fix[admin]: исправлена идентичность источников отчетов

### DIFF
--- a/app/Support/Reporting/OwnerSnapshotResultFactory.php
+++ b/app/Support/Reporting/OwnerSnapshotResultFactory.php
@@ -97,7 +97,7 @@ final readonly class OwnerSnapshotResultFactory
             $snapshot->kind,
             'snapshot_'.strtolower($snapshot->id),
             $sourceSchemaVersion,
-            $watermark,
+            self::watermarkIdentifier($watermark),
             $rowCount,
             $snapshot->sourceHash,
         );
@@ -111,5 +111,10 @@ final readonly class OwnerSnapshotResultFactory
             $rowSchema,
             $capabilities,
         );
+    }
+
+    private static function watermarkIdentifier(string $watermark): string
+    {
+        return 'watermark_'.substr(hash('sha256', $watermark), 0, 32);
     }
 }

--- a/tests/Unit/Reporting/Waves23/OwnerSnapshotResultFactoryTest.php
+++ b/tests/Unit/Reporting/Waves23/OwnerSnapshotResultFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Waves23;
+
+use App\Support\Reporting\OwnerSnapshotResultFactory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class OwnerSnapshotResultFactoryTest extends TestCase
+{
+    #[Test]
+    public function date_watermarks_are_encoded_as_safe_stable_provenance_identifiers(): void
+    {
+        $method = new ReflectionMethod(OwnerSnapshotResultFactory::class, 'watermarkIdentifier');
+
+        $first = $method->invoke(null, '2026-08-09T00:45:00+00:00');
+        $same = $method->invoke(null, '2026-08-09T00:45:00+00:00');
+        $other = $method->invoke(null, '2026-08-09T00:46:00+00:00');
+
+        self::assertMatchesRegularExpression('/^watermark_[a-f0-9]{32}$/', $first);
+        self::assertSame($first, $same);
+        self::assertNotSame($first, $other);
+    }
+}


### PR DESCRIPTION
Исправляет общий контракт provenance для owner-снимков: временная отметка кодируется в безопасный детерминированный идентификатор. Устраняет REPORT_INTERNAL_ERROR после успешной материализации отчетов закупок и склада. Добавлен регрессионный тест; локально выполнены PHP syntax и diff checks.