### PR TITLE
fix[admin]: разблокирован отчет по качеству с неполной историей

### DIFF
--- a/app/BusinessModules/Core/Reporting/Support/CompletedReportSourceLedgerBinding.php
+++ b/app/BusinessModules/Core/Reporting/Support/CompletedReportSourceLedgerBinding.php
@@ -14,6 +14,20 @@ final class CompletedReportSourceLedgerBinding
 {
     public static function capture(int $organizationId, array $sourceCodes): array
     {
+        return self::captureGeneration($organizationId, $sourceCodes, false);
+    }
+
+    public static function captureWithDocumentedGaps(int $organizationId, array $sourceCodes): array
+    {
+        return self::captureGeneration($organizationId, $sourceCodes, true);
+    }
+
+    private static function captureGeneration(
+        int $organizationId,
+        array $sourceCodes,
+        bool $allowDocumentedGaps,
+    ): array
+    {
         $codes = array_values(array_unique(array_map('strval', $sourceCodes)));
         sort($codes, SORT_STRING);
         $records = DB::table('report_source_sync_ledgers')
@@ -33,9 +47,13 @@ final class CompletedReportSourceLedgerBinding
                 $record = $records->get($code);
                 $cursor = self::json((string) $record->cursor);
                 $targetCursor = self::json((string) $record->target_cursor);
-                if ($record->status !== 'ready'
-                    || (int) $record->gap_count !== 0
-                    || (int) $record->unknown_count !== 0
+                $gapCount = (int) $record->gap_count;
+                $unknownCount = (int) $record->unknown_count;
+                $acceptedStatuses = $allowDocumentedGaps ? ['ready', 'partial'] : ['ready'];
+                if (! in_array($record->status, $acceptedStatuses, true)
+                    || (! $allowDocumentedGaps && ($gapCount !== 0 || $unknownCount !== 0))
+                    || $gapCount < 0
+                    || $unknownCount < 0
                     || ! is_string($record->owner_checksum)
                     || ! is_string($record->completed_owner_checksum)
                     || ! hash_equals($record->owner_checksum, $record->completed_owner_checksum)
@@ -47,7 +65,7 @@ final class CompletedReportSourceLedgerBinding
                     ? CarbonImmutable::parse((string) $record->completed_at)
                     : CarbonImmutable::parse((string) $record->source_watermark);
                 $watermark = $watermark === null || $sourceWatermark > $watermark ? $sourceWatermark : $watermark;
-                $sources[$code] = [
+                $source = [
                     'checksum' => $record->completed_owner_checksum,
                     'completed_at' => CarbonImmutable::parse((string) $record->completed_at)->toAtomString(),
                     'cursor' => $cursor,
@@ -57,6 +75,15 @@ final class CompletedReportSourceLedgerBinding
                         : CarbonImmutable::parse((string) $record->source_watermark)->toAtomString(),
                     'target_cursor' => $targetCursor,
                 ];
+                if ($allowDocumentedGaps) {
+                    $source += [
+                        'gap_count' => $gapCount,
+                        'status' => (string) $record->status,
+                        'unknown_count' => $unknownCount,
+                        'unknown_owner_keys' => self::nullableJson($record->unknown_owner_keys),
+                    ];
+                }
+                $sources[$code] = $source;
             }
         } catch (ReportContractException $exception) {
             throw $exception;
@@ -67,8 +94,20 @@ final class CompletedReportSourceLedgerBinding
             );
         }
 
+        if (! $allowDocumentedGaps) {
+            return [
+                'hash' => hash('sha256', CanonicalJson::encode($sources)),
+                'sources' => $sources,
+                'watermark' => $watermark?->toAtomString(),
+            ];
+        }
+
         return [
-            'hash' => hash('sha256', CanonicalJson::encode($sources)),
+            'hash' => hash('sha256', CanonicalJson::encode([
+                'integrity_mode' => 'documented_gaps',
+                'sources' => $sources,
+            ])),
+            'integrity_mode' => 'documented_gaps',
             'sources' => $sources,
             'watermark' => $watermark?->toAtomString(),
         ];
@@ -84,7 +123,11 @@ final class CompletedReportSourceLedgerBinding
         try {
             return hash_equals(
                 (string) ($binding['hash'] ?? ''),
-                (string) self::capture($organizationId, array_keys($sources))['hash'],
+                (string) self::captureGeneration(
+                    $organizationId,
+                    array_keys($sources),
+                    ($binding['integrity_mode'] ?? null) === 'documented_gaps',
+                )['hash'],
             );
         } catch (ReportContractException) {
             return false;
@@ -121,5 +164,14 @@ final class CompletedReportSourceLedgerBinding
         }
 
         return $decoded;
+    }
+
+    private static function nullableJson(mixed $value): array
+    {
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        return self::json((string) $value);
     }
 }

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class QualityDefectFlowCandidateContract
     public const FORMULA_VERSION = 'quality_defect_flow_v1';
     public const SOURCE_SCHEMA_VERSION = 'quality_defect_flow_v1';
     public const FORMULA_HASH = 'acae0365d20840207443202b4e9992034797843ac61e64382823e398edbc3f7a';
-    public const SOURCE_HASH = '8c0972a1b979d4afb341953874051b758051669729d651b90c4ada66fa8d927a';
+    public const SOURCE_HASH = '78393ec39335e7764e8b17ef3b8b929656bc2e248798f368ae90450650240e89';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
@@ -37,7 +37,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
     {
         $organizationId = $context->scope->organizationId;
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::QUALITY_DEFECTS);
-        $ledgerBinding = CompletedReportSourceLedgerBinding::capture(
+        $ledgerBinding = CompletedReportSourceLedgerBinding::captureWithDocumentedGaps(
             $organizationId,
             [ReportingSourceBackfillJob::QUALITY_DEFECTS],
         );

--- a/app/BusinessModules/Features/QualityControl/Services/QualityDefectService.php
+++ b/app/BusinessModules/Features/QualityControl/Services/QualityDefectService.php
@@ -343,6 +343,14 @@ final class QualityDefectService
             'comment' => $comment,
             'changed_by' => $userId,
             'changed_at' => now(),
+            'reporting_dimensions' => [
+                'contractor_id' => $defect->contractor_id === null ? null : (int) $defect->contractor_id,
+                'due_date' => $defect->due_date?->toDateString(),
+                'project_id' => (int) $defect->project_id,
+                'schedule_task_id' => $defect->schedule_task_id === null ? null : (int) $defect->schedule_task_id,
+                'severity' => $defect->severity->value,
+            ],
+            'reporting_evidence_refs' => [],
         ]);
 
         return $history;

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -155,6 +155,31 @@ final class ReportingSourcePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function quality_flow_accepts_only_hashed_documented_source_gaps_and_new_events_pin_dimensions(): void
+    {
+        $materializer = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/'
+            .'QualityDefectFlowSnapshotMaterializer.php',
+        );
+        $binding = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Core/Reporting/Support/CompletedReportSourceLedgerBinding.php',
+        );
+        $writer = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/QualityControl/Services/QualityDefectService.php',
+        );
+
+        self::assertIsString($materializer);
+        self::assertIsString($binding);
+        self::assertIsString($writer);
+        self::assertStringContainsString('captureWithDocumentedGaps', $materializer);
+        self::assertStringContainsString("'integrity_mode' => 'documented_gaps'", $binding);
+        self::assertStringContainsString("'gap_count' => \$gapCount", $binding);
+        self::assertStringContainsString("'unknown_owner_keys' => self::nullableJson", $binding);
+        self::assertStringContainsString("'reporting_dimensions' => [", $writer);
+        self::assertStringContainsString("'reporting_evidence_refs' => []", $writer);
+    }
+
+    #[Test]
     public function materializers_dispatch_chunk_jobs_without_full_scan_calls(): void
     {
         foreach ([


### PR DESCRIPTION
## Что исправлено
- для отчета качества разрешено материализовать завершенное поколение с документированными пропусками
- статус и детали пропусков включены в криптографическую identity источника
- строгий контракт остальных источников и совместимость существующих снимков сохранены
- новые переходы дефектов сохраняют неизменяемые reporting dimensions и больше не создают непроецируемую историю

## Проверки
- PHP syntax для всех измененных PHP-файлов
- git diff --check
- проверка совпадения SOURCE_HASH с материализатором
- PHPUnit/PHPStan локально недоступны: vendor отсутствует; обязательные проверки выполнятся в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated CompletedReportSourceLedgerBinding to support an integrity mode that allows documented gaps in report sources.</li>
<li>Modified QualityDefectFlowSnapshotMaterializer to use the new captureWithDocumentedGaps method for ledger binding.</li>
<li>Updated QualityDefectService to include reporting dimensions and evidence references when recording defect status history.</li>
<li>Updated the source hash constant in QualityDefectFlowCandidateContract to reflect the changes.</li>
<li>Added a unit test to verify the new integrity mode and reporting dimension structure.</li>
</ul></div>