### PR TITLE
fix[admin]: пустые отчеты отвязаны от неиспользуемых политик

### DIFF
--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class QualityDefectFlowCandidateContract
     public const FORMULA_VERSION = 'quality_defect_flow_v1';
     public const SOURCE_SCHEMA_VERSION = 'quality_defect_flow_v1';
     public const FORMULA_HASH = 'acae0365d20840207443202b4e9992034797843ac61e64382823e398edbc3f7a';
-    public const SOURCE_HASH = '78393ec39335e7764e8b17ef3b8b929656bc2e248798f368ae90450650240e89';
+    public const SOURCE_HASH = '8b94b4a10608d38bdb83ee9e9c7cd833338faf50928b430feba4fff0ff034458';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
@@ -69,7 +69,6 @@ final readonly class QualityDefectFlowSnapshotMaterializer
         $events = $this->filterSubjects($events, $query, $periodFrom, $periodTo);
         $projectIds = $events->pluck('project_id')
             ->map(static fn (mixed $id): int => (int) $id)
-            ->merge($context->scope->projectIds)
             ->unique()
             ->sort()
             ->values()
@@ -287,9 +286,8 @@ final readonly class QualityDefectFlowSnapshotMaterializer
 
     private function policies(int $organizationId, array $projectIds, CarbonImmutable $asOf): array
     {
-        $keys = $projectIds === [] ? [0] : $projectIds;
         $policies = [];
-        foreach ($keys as $projectId) {
+        foreach ($projectIds as $projectId) {
             $policy = QualityDefectFlowPolicyVersion::query()
                 ->where('organization_id', $organizationId)
                 ->where('created_at', '<=', $asOf)

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class SafetyIncidentActionsCandidateContract
     public const FORMULA_VERSION = 'safety_incident_actions_v1';
     public const SOURCE_SCHEMA_VERSION = 'safety_incident_actions_v1';
     public const FORMULA_HASH = 'f0e98a08eb88ece897c5e552142134cf8b3247fcd8e19a873760b7fad399c790';
-    public const SOURCE_HASH = 'f762593825f2523ef2c4c109023779fec762dd0fc28bdbf61e506328b55b30c6';
+    public const SOURCE_HASH = 'cc2da7bbb257ec9c170101e053366c4d13052dca87cc808be334543d01ffd09b';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
@@ -82,7 +82,6 @@ final readonly class SafetyIncidentSnapshotMaterializer
         $events = $this->filterSubjects($events, $query, $periodFrom, $periodTo);
         $projectIds = $events->pluck('project_id')
             ->map(static fn (mixed $id): int => (int) $id)
-            ->merge($context->scope->projectIds)
             ->unique()
             ->sort()
             ->values()
@@ -129,22 +128,29 @@ final readonly class SafetyIncidentSnapshotMaterializer
         $analysis['gaps'] += $missingExposureDays;
         $analysis['unknowns'] += $missingExposureDays;
         $multipliers = collect($policies)->pluck('frequency_multiplier')->map(static fn (mixed $value): int => (int) $value)->unique();
-        if ($multipliers->count() !== 1) {
+        $emptyPolicyIndependent = $policies === [] && $analysis['rows'] === [];
+        if (! $emptyPolicyIndependent && $multipliers->count() !== 1) {
             throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
         }
-        $qualifying = count(array_filter(
-            $analysis['rows'],
-            static function (array $row) use ($policies): bool {
-                $policy = $policies[$row['project_id']] ?? null;
+        $qualifying = $emptyPolicyIndependent
+            ? 0
+            : count(array_filter(
+                $analysis['rows'],
+                static function (array $row) use ($policies): bool {
+                    $policy = $policies[$row['project_id']] ?? null;
 
-                return $policy instanceof SafetyIncidentPolicyVersion
-                    && $row['subject_type'] === 'incident'
-                    && $row['created_flag']
-                    && in_array($row['category'], $policy->qualifying_incident_types, true);
-            },
-        ));
+                    return $policy instanceof SafetyIncidentPolicyVersion
+                        && $row['subject_type'] === 'incident'
+                        && $row['created_flag']
+                        && in_array($row['category'], $policy->qualifying_incident_types, true);
+                },
+            ));
         $frequency = $coverage['complete']
-            ? $this->formula->frequency($qualifying, $coverage['hours'], (int) $multipliers->first())
+            ? $this->formula->frequency(
+                $qualifying,
+                $coverage['hours'],
+                $emptyPolicyIndependent ? 1 : (int) $multipliers->first(),
+            )
             : null;
         $analysis['exposure'] = $coverage;
         $analysis['incident_frequency'] = $frequency;
@@ -365,9 +371,8 @@ final readonly class SafetyIncidentSnapshotMaterializer
 
     private function policies(int $organizationId, array $projectIds, CarbonImmutable $asOf): array
     {
-        $keys = $projectIds === [] ? [0] : $projectIds;
         $policies = [];
-        foreach ($keys as $projectId) {
+        foreach ($projectIds as $projectId) {
             $policy = SafetyIncidentPolicyVersion::query()
                 ->where('organization_id', $organizationId)
                 ->where('created_at', '<=', $asOf)

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -180,6 +180,27 @@ final class ReportingSourcePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function empty_fact_sets_do_not_require_unused_project_policies(): void
+    {
+        $quality = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/'
+            .'QualityDefectFlowSnapshotMaterializer.php',
+        );
+        $safety = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/'
+            .'SafetyIncidentSnapshotMaterializer.php',
+        );
+
+        self::assertIsString($quality);
+        self::assertIsString($safety);
+        self::assertStringNotContainsString('->merge($context->scope->projectIds)', $quality);
+        self::assertStringNotContainsString('->merge($context->scope->projectIds)', $safety);
+        self::assertStringNotContainsString('$projectIds === [] ? [0]', $quality);
+        self::assertStringNotContainsString('$projectIds === [] ? [0]', $safety);
+        self::assertStringContainsString('$emptyPolicyIndependent = $policies === []', $safety);
+    }
+
+    #[Test]
     public function materializers_dispatch_chunk_jobs_without_full_scan_calls(): void
     {
         foreach ([


### PR DESCRIPTION
## Что исправлено
- отчеты качества и охраны труда запрашивают policy только для фактов, реально участвующих в расчете
- пустой набор больше не блокируется отсутствующей проектной policy
- нулевая safety-частота вычисляется независимо от multiplier, который математически не влияет на результат при отсутствии инцидентов
- обновлены semantic source hashes и регрессионный контракт

## Проверки
- PHP syntax измененных файлов
- git diff --check
- проверка SOURCE_HASH обоих материализаторов
- PHPUnit/PHPStan локально недоступны: vendor отсутствует

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Removed unnecessary project ID merging from snapshot materializers in Quality Control and Safety Management modules.</li>
<li>Refactored policy retrieval logic to iterate directly over project IDs instead of defaulting to a dummy key when empty.</li>
<li>Updated SafetyIncidentSnapshotMaterializer to handle empty policy sets gracefully, preventing unnecessary report contract exceptions.</li>
<li>Updated source hashes in candidate contracts for QualityDefectFlow and SafetyIncidentActions.</li>
<li>Added a unit test to verify that empty fact sets no longer require unused project policies.</li>
</ul></div>