### PR TITLE
fix[admin]: согласован контракт печатей операционных отчетов

### DIFF
--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWarning;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportFreshnessStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportQualityStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportReconciliationStatus;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportWarningSeverity;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\ReportSnapshotSealBackfill;
@@ -44,7 +45,9 @@ final readonly class QualityDefectFlowReportProvider implements ReportDataProvid
     ): ReportSnapshotRef {
         $snapshot = $this->materializer->materialize($context, $query);
         $progress->advance(100);
-        $this->sealBackfill->ensureCovered('quality_defect_flow');
+        if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
+            $this->sealBackfill->ensureCovered('quality_defect_flow');
+        }
 
         return $this->reference($context, $snapshot, $query->definition->snapshotClassification);
     }
@@ -96,7 +99,7 @@ final readonly class QualityDefectFlowReportProvider implements ReportDataProvid
     private function reference(
         ReportExecutionContext $context,
         QualityDefectFlowSnapshot $snapshot,
-        \App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification $classification,
+        ReportSnapshotClassification $classification,
     ): ReportSnapshotRef {
         return new ReportSnapshotRef(
             kind: 'quality_defect_flow',
@@ -109,7 +112,9 @@ final readonly class QualityDefectFlowReportProvider implements ReportDataProvid
             staleAt: DateTimeImmutable::createFromInterface($snapshot->stale_at),
             watermarks: ['quality_defect_transitions' => $snapshot->source_watermark->toAtomString()],
             classification: $classification,
-            seal: $this->seals->get('quality_defect_flow', (string) $snapshot->id),
+            seal: $classification === ReportSnapshotClassification::OFFICIAL
+                ? $this->seals->get('quality_defect_flow', (string) $snapshot->id)
+                : null,
         );
     }
 

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class QualityDefectFlowCandidateContract
     public const FORMULA_VERSION = 'quality_defect_flow_v1';
     public const SOURCE_SCHEMA_VERSION = 'quality_defect_flow_v1';
     public const FORMULA_HASH = 'acae0365d20840207443202b4e9992034797843ac61e64382823e398edbc3f7a';
-    public const SOURCE_HASH = '8b94b4a10608d38bdb83ee9e9c7cd833338faf50928b430feba4fff0ff034458';
+    public const SOURCE_HASH = '706958dabc86df2589e14ca82ae6af35030fb9cc3753ee31ab6dfffc21068ac7';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Core\Reporting\Support\CompletedReportSourceLedgerBinding;
 use App\BusinessModules\Core\Reporting\Support\ReportSnapshotFirstWriter;
@@ -202,13 +203,15 @@ final readonly class QualityDefectFlowSnapshotMaterializer
                     $snapshot->output_hash = (string) DB::table('quality_defect_flow_snapshots')
                         ->where('id', $snapshot->id)->value('output_hash');
                     $snapshot->sealed_at = $generatedAt;
-                    $this->seals->create(
-                        'quality_defect_flow',
-                        (string) $snapshot->id,
-                        $generatedAt->toDateTimeImmutable(),
-                        new Sha256Hash((string) $snapshot->source_hash),
-                        $generatedAt->toDateTimeImmutable(),
-                    );
+                    if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
+                        $this->seals->create(
+                            'quality_defect_flow',
+                            (string) $snapshot->id,
+                            $generatedAt->toDateTimeImmutable(),
+                            new Sha256Hash((string) $snapshot->source_hash),
+                            $generatedAt->toDateTimeImmutable(),
+                        );
+                    }
 
                     return $snapshot;
                 });

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWarning;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportFreshnessStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportQualityStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportReconciliationStatus;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportWarningSeverity;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\ReportSnapshotSealBackfill;
@@ -44,7 +45,9 @@ final readonly class WorkforceAdmissionReportProvider implements ReportDataProvi
     ): ReportSnapshotRef {
         $record = $this->materializer->materialize($context, $query);
         $progress->advance(100);
-        $this->sealBackfill->ensureCovered('workforce_admission');
+        if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
+            $this->sealBackfill->ensureCovered('workforce_admission');
+        }
 
         return new ReportSnapshotRef(
             kind: 'workforce_admission',
@@ -57,7 +60,9 @@ final readonly class WorkforceAdmissionReportProvider implements ReportDataProvi
             staleAt: DateTimeImmutable::createFromInterface($record->stale_at),
             watermarks: ['workforce_admission' => $record->source_watermark->toAtomString()],
             classification: $query->definition->snapshotClassification,
-            seal: $this->seals->get('workforce_admission', (string) $record->id),
+            seal: $query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL
+                ? $this->seals->get('workforce_admission', (string) $record->id)
+                : null,
         );
     }
 

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Core\Reporting\Support\CompletedReportSourceLedgerBinding;
 use App\BusinessModules\Core\Reporting\Support\ReportIdentitySetReconciler;
@@ -239,13 +240,15 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
                     $snapshot->output_hash = (string) DB::table('safety_admission_snapshots')
                         ->where('id', $snapshot->id)->value('output_hash');
                     $snapshot->sealed_at = $generatedAt;
-                    $this->seals->create(
-                        'workforce_admission',
-                        (string) $snapshot->id,
-                        $generatedAt->toDateTimeImmutable(),
-                        new Sha256Hash((string) $snapshot->source_hash),
-                        $generatedAt->toDateTimeImmutable(),
-                    );
+                    if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
+                        $this->seals->create(
+                            'workforce_admission',
+                            (string) $snapshot->id,
+                            $generatedAt->toDateTimeImmutable(),
+                            new Sha256Hash((string) $snapshot->source_hash),
+                            $generatedAt->toDateTimeImmutable(),
+                        );
+                    }
 
                     return $snapshot;
                 });

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class WorkforceAdmissionCandidateContract
     public const FORMULA_VERSION = 'workforce_admission_v1';
     public const SOURCE_SCHEMA_VERSION = 'workforce_admission_v1';
     public const FORMULA_HASH = '4df1641fb5a5c69fffbc38b3a7ad11abe2d81869d15f46ce47be44384e43f106';
-    public const SOURCE_HASH = 'd9831fb19829c9acc43efe244f708d69f73ac312a1a20adc28a90d639c7970e9';
+    public const SOURCE_HASH = 'ba87a104f95684c44878c4bf0ad12448275852889c13f75660dd0243821a3643';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php
@@ -22,6 +22,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWarning;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportFreshnessStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportQualityStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportReconciliationStatus;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportWarningSeverity;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\ReportSnapshotSealBackfill;
@@ -44,7 +45,9 @@ final readonly class SafetyIncidentActionsReportProvider implements ReportDataPr
     ): ReportSnapshotRef {
         $record = $this->materializer->materialize($context, $query);
         $progress->advance(100);
-        $this->sealBackfill->ensureCovered('safety_incident_actions');
+        if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
+            $this->sealBackfill->ensureCovered('safety_incident_actions');
+        }
 
         return new ReportSnapshotRef(
             kind: 'safety_incident_actions',
@@ -57,7 +60,9 @@ final readonly class SafetyIncidentActionsReportProvider implements ReportDataPr
             staleAt: DateTimeImmutable::createFromInterface($record->stale_at),
             watermarks: ['safety_transitions' => $record->source_watermark->toAtomString()],
             classification: $query->definition->snapshotClassification,
-            seal: $this->seals->get('safety_incident_actions', (string) $record->id),
+            seal: $query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL
+                ? $this->seals->get('safety_incident_actions', (string) $record->id)
+                : null,
         );
     }
 

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class SafetyIncidentActionsCandidateContract
     public const FORMULA_VERSION = 'safety_incident_actions_v1';
     public const SOURCE_SCHEMA_VERSION = 'safety_incident_actions_v1';
     public const FORMULA_HASH = 'f0e98a08eb88ece897c5e552142134cf8b3247fcd8e19a873760b7fad399c790';
-    public const SOURCE_HASH = 'cc2da7bbb257ec9c170101e053366c4d13052dca87cc808be334543d01ffd09b';
+    public const SOURCE_HASH = '8ed3cc6b01f56a103cdb2ab2b9264bc6e859859e32aecee3c735aaeffb0fb5bd';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
 use App\BusinessModules\Core\Reporting\Support\CanonicalJson;
 use App\BusinessModules\Core\Reporting\Support\CompletedReportSourceLedgerBinding;
 use App\BusinessModules\Core\Reporting\Support\ReportSnapshotFirstWriter;
@@ -272,13 +273,15 @@ final readonly class SafetyIncidentSnapshotMaterializer
                     $snapshot->output_hash = (string) DB::table('safety_incident_snapshots')
                         ->where('id', $snapshot->id)->value('output_hash');
                     $snapshot->sealed_at = $generatedAt;
-                    $this->seals->create(
-                        'safety_incident_actions',
-                        (string) $snapshot->id,
-                        $generatedAt->toDateTimeImmutable(),
-                        new Sha256Hash((string) $snapshot->source_hash),
-                        $generatedAt->toDateTimeImmutable(),
-                    );
+                    if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
+                        $this->seals->create(
+                            'safety_incident_actions',
+                            (string) $snapshot->id,
+                            $generatedAt->toDateTimeImmutable(),
+                            new Sha256Hash((string) $snapshot->source_hash),
+                            $generatedAt->toDateTimeImmutable(),
+                        );
+                    }
 
                     return $snapshot;
                 });

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -201,6 +201,21 @@ final class ReportingSourcePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function operational_quality_snapshots_never_expose_official_seals(): void
+    {
+        foreach ([
+            'app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php',
+            'app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php',
+            'app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php',
+        ] as $relativePath) {
+            $provider = file_get_contents(dirname(__DIR__, 4).'/'.$relativePath);
+            self::assertIsString($provider);
+            self::assertStringContainsString('ReportSnapshotClassification::OFFICIAL', $provider);
+            self::assertMatchesRegularExpression('/seal: .*OFFICIAL[\\s\\S]*?\\? \\$this->seals->get/', $provider);
+        }
+    }
+
+    #[Test]
     public function materializers_dispatch_chunk_jobs_without_full_scan_calls(): void
     {
         foreach ([


### PR DESCRIPTION
## Что исправлено
- operational snapshots больше не создают и не публикуют official seal
- official snapshots по-прежнему требуют и получают seal
- единый контракт применен к quality defect flow, safety incident actions и workforce admission
- обновлены semantic source hashes материализаторов

## Проверки
- PHP syntax всех измененных файлов
- git diff --check
- совпадение SOURCE_HASH трех материализаторов
- регрессионный контракт для трех providers

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Restricted snapshot sealing and seal retrieval to only occur when the snapshot classification is set to OFFICIAL.</li>
<li>Updated QualityDefectFlowCandidateContract with a new source hash.</li>
<li>Applied conditional logic to snapshot materializers for QualityDefectFlow, WorkforceAdmission, and SafetyIncidentActions to skip sealing for non-official snapshots.</li>
<li>Updated unit tests in ReportingSourcePersistenceContractTest to reflect changes in persistence contracts.</li>
</ul></div>