### PR TITLE
fix[admin]: переиспользована завершенная частичная проекция

### DIFF
--- a/app/Jobs/ReportingSourceBackfillJob.php
+++ b/app/Jobs/ReportingSourceBackfillJob.php
@@ -83,7 +83,9 @@ final class ReportingSourceBackfillJob implements ShouldBeUniqueUntilProcessing,
 
                 return;
             }
-            $shouldDispatch = $ledger->status !== 'ready'
+            $isSettled = $ledger->status === 'ready'
+                || ($ledger->status === 'partial' && $ledger->completed_at !== null);
+            $shouldDispatch = ! $isSettled
                 || CanonicalJson::encode(json_decode((string) $ledger->cursor, true, 512, JSON_THROW_ON_ERROR))
                     !== CanonicalJson::encode(json_decode((string) $ledger->target_cursor, true, 512, JSON_THROW_ON_ERROR));
             if ($ledger->completed_owner_checksum !== $checksum) {

--- a/tests/Integration/Reporting/Waves23/SafetyIncidentReportingPostgresTest.php
+++ b/tests/Integration/Reporting/Waves23/SafetyIncidentReportingPostgresTest.php
@@ -216,6 +216,58 @@ SQL);
     }
 
     #[Test]
+    public function completed_partial_generation_is_reused_until_owner_content_changes(): void
+    {
+        $this->requirePostgres();
+        Queue::fake();
+        $organization = Organization::factory()->create();
+        $project = Project::factory()->create(['organization_id' => $organization->id]);
+        $actor = User::factory()->create();
+        SafetyIncident::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'reported_by_user_id' => $actor->id,
+            'incident_number' => 'HSE-PARTIAL-REUSE-1',
+            'title' => 'Stable partial projection',
+            'incident_type' => 'near_miss',
+            'severity' => 'minor',
+            'status' => 'reported',
+            'occurred_at' => now()->subMinute(),
+        ]);
+
+        ReportingSourceBackfillJob::request(
+            (int) $organization->id,
+            ReportingSourceBackfillJob::SAFETY_INCIDENTS,
+        );
+        $ledger = DB::table('report_source_sync_ledgers')
+            ->where('organization_id', $organization->id)
+            ->where('source_code', ReportingSourceBackfillJob::SAFETY_INCIDENTS)
+            ->first();
+        self::assertNotNull($ledger);
+        DB::table('report_source_sync_ledgers')->where('id', $ledger->id)->update([
+            'cursor' => $ledger->target_cursor,
+            'completed_owner_checksum' => $ledger->owner_checksum,
+            'status' => 'partial',
+            'gap_count' => 1,
+            'unknown_count' => 1,
+            'unknown_owner_keys' => json_encode(['incident:'.$ledger->id], JSON_THROW_ON_ERROR),
+            'completed_at' => now(),
+        ]);
+        Queue::assertPushedTimes(ReportingSourceBackfillJob::class, 1);
+
+        ReportingSourceBackfillJob::request(
+            (int) $organization->id,
+            ReportingSourceBackfillJob::SAFETY_INCIDENTS,
+        );
+
+        Queue::assertPushedTimes(ReportingSourceBackfillJob::class, 1);
+        self::assertSame(
+            'partial',
+            DB::table('report_source_sync_ledgers')->where('id', $ledger->id)->value('status'),
+        );
+    }
+
+    #[Test]
     public function violation_resolution_authorizer_uses_the_exact_evidence_id_and_current_owner_state(): void
     {
         $this->requirePostgres();


### PR DESCRIPTION
## Что исправлено
- завершённая частичная генерация источника больше не ставится в очередь повторно при неизменных owner-данных
- polling больше не меняет identity снимка через новый completed_at
- добавлен PostgreSQL-регрессионный тест на повторное использование partial ledger

## Проверки
- php -l изменённых PHP-файлов
- git diff --check
- PHPUnit локально недоступен: vendor отсутствует; тест обязателен в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated ReportingSourceBackfillJob to prevent unnecessary job dispatching when a partial ledger is already completed.</li>
<li>Added a new integration test case to verify that completed partial generations are reused until the owner content changes.</li>
</ul></div>