### PR TITLE
fix[admin]: канонизирована identity операционных отчетов

### DIFF
--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\QualityControl\Reporting\DefectFlow\Providers;
 
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSnapshotSealStore;
+use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
@@ -36,6 +37,7 @@ final readonly class QualityDefectFlowReportProvider implements ReportDataProvid
         private QualityDefectFlowSnapshotMaterializer $materializer,
         private ReportSnapshotSealStore $seals,
         private ReportSnapshotSealBackfill $sealBackfill,
+        private CanonicalReportSourceHashBuilder $identities,
     ) {}
 
     public function materialize(
@@ -49,7 +51,23 @@ final readonly class QualityDefectFlowReportProvider implements ReportDataProvid
             $this->sealBackfill->ensureCovered('quality_defect_flow');
         }
 
-        return $this->reference($context, $snapshot, $query->definition->snapshotClassification);
+        $provisional = $this->reference($context, $snapshot, $query->definition->snapshotClassification);
+        $canonical = $this->identities->build($query, $provisional, $this->result($context, $provisional));
+
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
+        );
     }
 
     public function result(ReportExecutionContext $context, ReportSnapshotRef $snapshot): ReportResult
@@ -123,7 +141,7 @@ final readonly class QualityDefectFlowReportProvider implements ReportDataProvid
         $record = QualityDefectFlowSnapshot::query()
             ->whereKey($reference->id)
             ->where('organization_id', $context->scope->organizationId)
-            ->where('source_hash', $reference->sourceHash->value)
+            ->where('source_hash', $reference->materializedSourceHash->value)
             ->where('definition_hash', $reference->definitionHash->value)
             ->first();
         if (! $record instanceof QualityDefectFlowSnapshot) {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\SafetyManagement\Reporting\Admission\Providers;
 
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSnapshotSealStore;
+use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
@@ -36,6 +37,7 @@ final readonly class WorkforceAdmissionReportProvider implements ReportDataProvi
         private WorkforceAdmissionSnapshotMaterializer $materializer,
         private ReportSnapshotSealStore $seals,
         private ReportSnapshotSealBackfill $sealBackfill,
+        private CanonicalReportSourceHashBuilder $identities,
     ) {}
 
     public function materialize(
@@ -49,7 +51,7 @@ final readonly class WorkforceAdmissionReportProvider implements ReportDataProvi
             $this->sealBackfill->ensureCovered('workforce_admission');
         }
 
-        return new ReportSnapshotRef(
+        $provisional = new ReportSnapshotRef(
             kind: 'workforce_admission',
             id: (string) $record->id,
             scope: $context->scope,
@@ -63,6 +65,22 @@ final readonly class WorkforceAdmissionReportProvider implements ReportDataProvi
             seal: $query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL
                 ? $this->seals->get('workforce_admission', (string) $record->id)
                 : null,
+        );
+        $canonical = $this->identities->build($query, $provisional, $this->result($context, $provisional));
+
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
         );
     }
 
@@ -128,7 +146,7 @@ final readonly class WorkforceAdmissionReportProvider implements ReportDataProvi
         $record = SafetyAdmissionSnapshot::query()
             ->whereKey($snapshot->id)
             ->where('organization_id', $context->scope->organizationId)
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->where('definition_hash', $snapshot->definitionHash->value)
             ->first();
         if (! $record instanceof SafetyAdmissionSnapshot) {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\SafetyManagement\Reporting\IncidentActions\Providers;
 
 use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSnapshotSealStore;
+use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
@@ -36,6 +37,7 @@ final readonly class SafetyIncidentActionsReportProvider implements ReportDataPr
         private SafetyIncidentSnapshotMaterializer $materializer,
         private ReportSnapshotSealStore $seals,
         private ReportSnapshotSealBackfill $sealBackfill,
+        private CanonicalReportSourceHashBuilder $identities,
     ) {}
 
     public function materialize(
@@ -49,7 +51,7 @@ final readonly class SafetyIncidentActionsReportProvider implements ReportDataPr
             $this->sealBackfill->ensureCovered('safety_incident_actions');
         }
 
-        return new ReportSnapshotRef(
+        $provisional = new ReportSnapshotRef(
             kind: 'safety_incident_actions',
             id: (string) $record->id,
             scope: $context->scope,
@@ -63,6 +65,22 @@ final readonly class SafetyIncidentActionsReportProvider implements ReportDataPr
             seal: $query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL
                 ? $this->seals->get('safety_incident_actions', (string) $record->id)
                 : null,
+        );
+        $canonical = $this->identities->build($query, $provisional, $this->result($context, $provisional));
+
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
         );
     }
 
@@ -117,7 +135,7 @@ final readonly class SafetyIncidentActionsReportProvider implements ReportDataPr
         $record = SafetyIncidentSnapshot::query()
             ->whereKey($snapshot->id)
             ->where('organization_id', $context->scope->organizationId)
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->where('definition_hash', $snapshot->definitionHash->value)
             ->first();
         if (! $record instanceof SafetyIncidentSnapshot) {

--- a/tests/Architecture/Reporting/OperationalProviderCanonicalHashContractTest.php
+++ b/tests/Architecture/Reporting/OperationalProviderCanonicalHashContractTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OperationalProviderCanonicalHashContractTest extends TestCase
+{
+    #[Test]
+    public function operational_providers_preserve_materialized_identity_and_publish_canonical_identity(): void
+    {
+        foreach ([
+            'app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php',
+            'app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php',
+            'app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php',
+        ] as $file) {
+            $source = file_get_contents(base_path($file));
+            self::assertIsString($source, $file);
+            foreach ([
+                'CanonicalReportSourceHashBuilder',
+                '$this->identities->build(',
+                '$this->result($context, $provisional)',
+                'sourceHash: $canonical',
+                'materializedSourceHash: $provisional->materializedSourceHash',
+            ] as $required) {
+                self::assertStringContainsString($required, $source, $file);
+            }
+            self::assertMatchesRegularExpression(
+                "/->where\\('source_hash', \\$[a-z]+->materializedSourceHash->value\\)/",
+                $source,
+                $file,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Что исправлено
- quality, safety и workforce providers публикуют канонический source hash
- физический hash снимка сохраняется отдельно и используется для чтения materialized snapshot
- добавлен единый архитектурный контракт для всех трёх providers

## Проверки
- php -l всех изменённых PHP-файлов
- git diff --check
- PHPUnit/PHPStan локально недоступны: vendor отсутствует; проверки остаются CI-gate