### PR TITLE
fix[admin]: чтение строк привязано к снимку

### DIFF
--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Queries/QualityDefectFlowRowQuery.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Queries/QualityDefectFlowRowQuery.php
@@ -122,7 +122,7 @@ final readonly class QualityDefectFlowRowQuery implements ReportRowQuery
         $record = QualityDefectFlowSnapshot::query()
             ->whereKey($snapshot->id)
             ->where('organization_id', $context->scope->organizationId)
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->where('definition_hash', $snapshot->definitionHash->value)
             ->where('formula_version', $snapshot->formulaVersion)
             ->first();

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Queries/WorkforceAdmissionRowQuery.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Queries/WorkforceAdmissionRowQuery.php
@@ -114,7 +114,7 @@ final readonly class WorkforceAdmissionRowQuery implements ReportRowQuery
         $record = SafetyAdmissionSnapshot::query()
             ->whereKey($snapshot->id)
             ->where('organization_id', $context->scope->organizationId)
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->where('definition_hash', $snapshot->definitionHash->value)
             ->where('formula_version', $snapshot->formulaVersion)
             ->first();

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Queries/SafetyIncidentRowQuery.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Queries/SafetyIncidentRowQuery.php
@@ -114,7 +114,7 @@ final readonly class SafetyIncidentRowQuery implements ReportRowQuery
         $record = SafetyIncidentSnapshot::query()
             ->whereKey($snapshot->id)
             ->where('organization_id', $context->scope->organizationId)
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->where('definition_hash', $snapshot->definitionHash->value)
             ->where('formula_version', $snapshot->formulaVersion)
             ->first();

--- a/app/BusinessModules/Features/TimeTracking/Reporting/Infrastructure/DatabaseProjectLaborCostAdapter.php
+++ b/app/BusinessModules/Features/TimeTracking/Reporting/Infrastructure/DatabaseProjectLaborCostAdapter.php
@@ -735,7 +735,7 @@ final readonly class DatabaseProjectLaborCostAdapter implements ProjectLaborCost
         $record = $this->connection->table('project_labor_cost_report_snapshots')
             ->where('organization_id', $context->scope->organizationId)
             ->where('id', $snapshot->id)
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->first();
         if ($record === null || $snapshot->scope->organizationId !== $context->scope->organizationId) {
             throw new DomainException('REPORT_FILTER_VALUE_NOT_FOUND');

--- a/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabasePayrollReadinessAdapter.php
+++ b/app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabasePayrollReadinessAdapter.php
@@ -1067,7 +1067,7 @@ final readonly class DatabasePayrollReadinessAdapter implements PayrollReadiness
             ->where('organization_id', $context->scope->organizationId)
             ->where('id', $snapshot->id)
             ->where('report_code', 'payroll_readiness')
-            ->where('source_hash', $snapshot->sourceHash->value)
+            ->where('source_hash', $snapshot->materializedSourceHash->value)
             ->first();
         if ($record === null || $snapshot->scope->organizationId !== $context->scope->organizationId) {
             throw new DomainException('REPORT_FILTER_VALUE_NOT_FOUND');

--- a/tests/Architecture/Reporting/ReportRowMaterializedIdentityContractTest.php
+++ b/tests/Architecture/Reporting/ReportRowMaterializedIdentityContractTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ReportRowMaterializedIdentityContractTest extends TestCase
+{
+    #[Test]
+    public function physical_snapshot_readers_use_materialized_identity(): void
+    {
+        foreach ([
+            'app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Queries/QualityDefectFlowRowQuery.php',
+            'app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Queries/SafetyIncidentRowQuery.php',
+            'app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Queries/WorkforceAdmissionRowQuery.php',
+            'app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabasePayrollReadinessAdapter.php',
+            'app/BusinessModules/Features/TimeTracking/Reporting/Infrastructure/DatabaseProjectLaborCostAdapter.php',
+        ] as $file) {
+            $source = file_get_contents(base_path($file));
+            self::assertIsString($source, $file);
+            self::assertStringContainsString(
+                "->where('source_hash', \$snapshot->materializedSourceHash->value)",
+                $source,
+                $file,
+            );
+            self::assertStringNotContainsString(
+                "->where('source_hash', \$snapshot->sourceHash->value)",
+                $source,
+                $file,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Что исправлено
- физические строки читаются по materialized hash снимка, а не по каноническому hash запуска
- контракт применён к quality, safety, admission, payroll и labor-cost readers
- добавлен архитектурный тест против повторного смешения двух identity

## Проверки
- php -l всех изменённых PHP-файлов
- git diff --check
- PHPUnit/PHPStan локально недоступны: vendor отсутствует; проверки остаются CI-gate