### PR TITLE
fix[admin]: возвращён пустой отчёт ликвидности

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityAsOfSource.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityAsOfSource.php
@@ -7,8 +7,6 @@ namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
 use App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem;
 use App\BusinessModules\Core\Payments\DTOs\PaymentCalendarSourceFilters;
 use App\BusinessModules\Core\Payments\Services\PaymentCalendarSourceService;
-use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
-use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Features\Budgeting\DTOs\CashGapOpeningBalanceSnapshot;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\Models\PortfolioLiquiditySourceGap;
 use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\Models\PortfolioLiquiditySourceVersion;
@@ -74,10 +72,6 @@ final readonly class PortfolioLiquidityAsOfSource
                 'recorded_at' => $gap->recorded_at?->format(DateTimeInterface::ATOM),
             ])
             ->all();
-        if ($versions->isEmpty()) {
-            throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
-        }
-
         $calendarItems = [];
         $balances = [];
         foreach ($versions as $version) {

--- a/tests/Integration/Reporting/WaveOne/BudgetingPortfolioProviderTest.php
+++ b/tests/Integration/Reporting/WaveOne/BudgetingPortfolioProviderTest.php
@@ -34,6 +34,24 @@ use Tests\TestCase;
 final class BudgetingPortfolioProviderTest extends TestCase
 {
     #[Test]
+    public function liquidity_as_of_returns_an_empty_versioned_source_for_an_empty_organization(): void
+    {
+        $organizationId = 799999;
+        $result = (new PortfolioLiquidityAsOfSource(new PaymentCalendarSourceService))->read(
+            $organizationId,
+            new PaymentCalendarSourceFilters($organizationId, '2026-08-01', '2026-08-31', currency: 'RUB'),
+            new DateTimeImmutable('2026-08-31T23:59:59+00:00'),
+            new DateTimeImmutable('2026-09-01T00:00:00+00:00'),
+        );
+
+        self::assertSame([], $result['calendar']);
+        self::assertSame([], $result['balances']);
+        self::assertSame([], $result['versions']);
+        self::assertSame([], $result['gaps']);
+        self::assertSame('2026-09-01T00:00:00+00:00', $result['ingestion_watermark']);
+    }
+
+    #[Test]
     public function liquidity_source_version_is_append_only_in_postgres(): void
     {
         if (config('database.default') !== 'pgsql') {


### PR DESCRIPTION
## Что исправлено
- отсутствие версионированных данных ликвидности теперь является корректным пустым источником
- пустая организация больше не уходит в повторные попытки REPORT_SOURCE_UNAVAILABLE
- добавлен регрессионный интеграционный тест пустого источника

## Проверки
- PHP syntax для изменённых файлов
- git diff --check
- PostgreSQL-регрессия выполняется в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Removed an exception throw when no versions are found in PortfolioLiquidityAsOfSource, allowing the report to return empty results instead of failing.</li>
<li>Added a new integration test case to verify that an empty organization correctly returns empty arrays for calendar, balances, versions, and gaps.</li>
</ul></div>