### PR TITLE
fix[admin]: разделена идентичность портфельных снимков

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/BudgetingPortfolioProjectionService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/BudgetingPortfolioProjectionService.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\Payments\DTOs\PaymentCalendarItem;
 use App\BusinessModules\Core\Payments\Enums\PaymentTransactionStatus;
 use App\BusinessModules\Core\Payments\Models\PaymentTransaction;
 use App\BusinessModules\Core\Payments\Services\PaymentCalendarSourceService;
+use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCoverage;
@@ -68,6 +69,7 @@ final readonly class BudgetingPortfolioProjectionService
         private CashGapOpeningBalanceService $openingBalances,
         private CashGapForecastService $cashGapForecasts,
         private CfoProjectPortfolioAggregator $portfolioAggregator,
+        private CanonicalReportSourceHashBuilder $identities,
     ) {}
 
     public function persistHealth(
@@ -223,9 +225,29 @@ final readonly class BudgetingPortfolioProjectionService
     ): ReportSnapshotRef {
         $this->assertQuery($context, $query, $code);
 
-        return $code === self::HEALTH_CODE
+        $provisional = $code === self::HEALTH_CODE
             ? $this->materializeHealth($context, $query, $progress)
             : $this->materializeLiquidity($context, $query, $progress);
+        $canonical = $this->identities->build(
+            $query,
+            $provisional,
+            $this->result($context, $provisional, $code),
+        );
+
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
+        );
     }
 
     public function result(
@@ -239,7 +261,7 @@ final readonly class BudgetingPortfolioProjectionService
             ->where('report_code', $code)
             ->first();
         if (! $record instanceof BudgetingPortfolioSnapshot
-            || ! hash_equals((string) $record->source_hash, $snapshot->sourceHash->value)
+            || ! hash_equals((string) $record->source_hash, $snapshot->materializedSourceHash->value)
             || ! hash_equals((string) $record->definition_hash, $snapshot->definitionHash->value)
             || ! hash_equals((string) $record->formula_version, $snapshot->formulaVersion)
             || ! hash_equals((string) $record->query_hash, (string) ($snapshot->watermarks['query_hash'] ?? ''))) {

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityCandidateContract.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquidityCandidateContract.php
@@ -23,7 +23,7 @@ final readonly class PortfolioLiquidityCandidateContract
 
     public const FORMULA_HASH = 'c74d47950d55c2d8c2f701c05a1c6847b81597375de275c673135c812cbcc09b';
 
-    public const SOURCE_HASH = '5efb77458488c7ad959fa20f86e9ce6ef72f3e500946a3b30e81a4f159273785';
+    public const SOURCE_HASH = '00e74e98ee36aebf51211ac2d6e9058fcb95bfb3c8c117b4d3dfc28fbc122666';
 
     public function filters(): array
     {

--- a/tests/Architecture/Reporting/BudgetingPortfolioCanonicalHashContractTest.php
+++ b/tests/Architecture/Reporting/BudgetingPortfolioCanonicalHashContractTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class BudgetingPortfolioCanonicalHashContractTest extends TestCase
+{
+    #[Test]
+    public function portfolio_providers_preserve_materialized_identity_and_publish_canonical_identity(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 3)
+            .'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/BudgetingPortfolioProjectionService.php',
+        );
+
+        self::assertStringContainsString('CanonicalReportSourceHashBuilder $identities', $source);
+        self::assertStringContainsString('$this->identities->build(', $source);
+        self::assertStringContainsString('sourceHash: $canonical', $source);
+        self::assertStringContainsString('materializedSourceHash: $provisional->materializedSourceHash', $source);
+        self::assertStringContainsString(
+            '$snapshot->materializedSourceHash->value',
+            $source,
+        );
+    }
+}


### PR DESCRIPTION
Портфельные провайдеры теперь публикуют канонический hash запуска, сохраняя физический hash материализованного снимка для чтения. Исправляет REPORT_SNAPSHOT_NOT_READY на корректных пустых снимках. Добавлен архитектурный контракт.