### PR TITLE
fix[admin]: строки портфеля читаются по снимку

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/BudgetingPortfolioQueryService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/BudgetingPortfolioQueryService.php
@@ -258,7 +258,7 @@ final readonly class BudgetingPortfolioQueryService implements ReportDrillDownPr
             ->whereKey($snapshot->id)
             ->first();
         if (! $record instanceof BudgetingPortfolioSnapshot
-            || ! hash_equals((string) $record->source_hash, $snapshot->sourceHash->value)
+            || ! hash_equals((string) $record->source_hash, $snapshot->materializedSourceHash->value)
             || ! hash_equals((string) $record->definition_hash, $snapshot->definitionHash->value)
             || ! hash_equals((string) $record->formula_version, $snapshot->formulaVersion)
             || ! hash_equals((string) $record->query_hash, (string) ($snapshot->watermarks['query_hash'] ?? ''))) {

--- a/tests/Architecture/Reporting/BudgetingPortfolioCanonicalHashContractTest.php
+++ b/tests/Architecture/Reporting/BudgetingPortfolioCanonicalHashContractTest.php
@@ -25,5 +25,14 @@ final class BudgetingPortfolioCanonicalHashContractTest extends TestCase
             '$snapshot->materializedSourceHash->value',
             $source,
         );
+
+        $querySource = (string) file_get_contents(
+            dirname(__DIR__, 3)
+            .'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/BudgetingPortfolioQueryService.php',
+        );
+        self::assertStringContainsString(
+            '$snapshot->materializedSourceHash->value',
+            $querySource,
+        );
     }
 }


### PR DESCRIPTION
Row reader портфельных отчётов использует физический hash материализованного снимка, сохраняя канонический hash запуска для integrity-контракта. Добавлена регрессия.