### PR TITLE
fix[admin]: канонизирован снимок передачи объекта

### DIFF
--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/HandoverReadinessReportProvider.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/HandoverReadinessReportProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Providers;
 
+use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCoverage;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -26,9 +27,10 @@ use InvalidArgumentException;
 
 final readonly class HandoverReadinessReportProvider implements ReportDataProvider
 {
-    public function __construct(private HandoverReadinessSnapshotMaterializer $materializer)
-    {
-    }
+    public function __construct(
+        private HandoverReadinessSnapshotMaterializer $materializer,
+        private CanonicalReportSourceHashBuilder $identities,
+    ) {}
 
     public function materialize(
         ReportExecutionContext $context,
@@ -36,10 +38,28 @@ final readonly class HandoverReadinessReportProvider implements ReportDataProvid
         ReportProgress $progress,
     ): ReportSnapshotRef {
         $progress->advance(10);
-        $snapshot = $this->materializer->materialize($context, $query);
+        $provisional = $this->materializer->materialize($context, $query);
         $progress->advance(100);
+        $canonical = $this->identities->build(
+            $query,
+            $provisional,
+            $this->result($context, $provisional),
+        );
 
-        return $snapshot;
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
+        );
     }
 
     public function result(ReportExecutionContext $context, ReportSnapshotRef $snapshot): ReportResult

--- a/tests/Architecture/Reporting/HandoverReadinessCanonicalHashContractTest.php
+++ b/tests/Architecture/Reporting/HandoverReadinessCanonicalHashContractTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class HandoverReadinessCanonicalHashContractTest extends TestCase
+{
+    #[Test]
+    public function provider_preserves_materialized_identity_and_publishes_canonical_identity(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 3)
+            .'/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/HandoverReadinessReportProvider.php',
+        );
+
+        self::assertStringContainsString('CanonicalReportSourceHashBuilder $identities', $source);
+        self::assertStringContainsString('$this->identities->build(', $source);
+        self::assertStringContainsString('sourceHash: $canonical', $source);
+        self::assertStringContainsString('materializedSourceHash: $provisional->materializedSourceHash', $source);
+    }
+}


### PR DESCRIPTION
Провайдер готовности к передаче теперь публикует канонический hash запуска и отдельно сохраняет физическую идентичность снимка. Исправляет REPORT_SNAPSHOT_NOT_READY для пустых и непустых снимков. Добавлена регрессия.