### PR TITLE
fix[admin]: исправлены параметры здоровья портфеля

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php
@@ -63,7 +63,7 @@ final readonly class ProjectPortfolioHealthOptionsService
             ->where('project_user.role', 'project_manager')
             ->where('project_user.is_active', true)
             ->whereNull('users.deleted_at')
-            ->selectRaw("users.id, NULLIF(TRIM(CONCAT_WS(' ', users.last_name, users.first_name, users.middle_name)), '') AS name")
+            ->selectRaw("users.id, NULLIF(TRIM(users.name), '') AS name")
             ->distinct()
             ->orderBy('name')
             ->orderBy('users.id')

--- a/tests/Architecture/Reporting/ProjectPortfolioHealthOptionsSchemaContractTest.php
+++ b/tests/Architecture/Reporting/ProjectPortfolioHealthOptionsSchemaContractTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ProjectPortfolioHealthOptionsSchemaContractTest extends TestCase
+{
+    #[Test]
+    public function manager_options_use_the_canonical_user_name_column(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 3)
+            .'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOptionsService.php',
+        );
+
+        self::assertStringContainsString("NULLIF(TRIM(users.name), '') AS name", $source);
+        self::assertStringNotContainsString('users.last_name', $source);
+        self::assertStringNotContainsString('users.first_name', $source);
+        self::assertStringNotContainsString('users.middle_name', $source);
+    }
+}


### PR DESCRIPTION
Запрос менеджеров отчёта использует каноническое поле users.name вместо отсутствующих составных колонок. Добавлен контракт схемы.