### PR TITLE
fix[admin]: канонизирован снимок SLA заказчика

### DIFF
--- a/app/Services/Customer/Reporting/Sla/Providers/CustomerSlaReportProvider.php
+++ b/app/Services/Customer/Reporting/Sla/Providers/CustomerSlaReportProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Customer\Reporting\Sla\Providers;
 
+use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportCoverage;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
@@ -18,6 +19,7 @@ use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceRef;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportFreshnessStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportQualityStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportReconciliationStatus;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use App\Services\Customer\Reporting\Sla\Models\CustomerSlaRow;
 use App\Services\Customer\Reporting\Sla\Models\CustomerSlaSnapshot;
 use App\Services\Customer\Reporting\Sla\Services\CustomerSlaSnapshotMaterializer;
@@ -26,9 +28,10 @@ use InvalidArgumentException;
 
 final readonly class CustomerSlaReportProvider implements ReportDataProvider
 {
-    public function __construct(private CustomerSlaSnapshotMaterializer $materializer)
-    {
-    }
+    public function __construct(
+        private CustomerSlaSnapshotMaterializer $materializer,
+        private CanonicalReportSourceHashBuilder $identities,
+    ) {}
 
     public function materialize(
         ReportExecutionContext $context,
@@ -36,10 +39,28 @@ final readonly class CustomerSlaReportProvider implements ReportDataProvider
         ReportProgress $progress,
     ): ReportSnapshotRef {
         $progress->advance(10);
-        $snapshot = $this->materializer->materialize($context, $query);
+        $provisional = $this->materializer->materialize($context, $query);
         $progress->advance(100);
+        $canonical = $this->identities->build(
+            $query,
+            $provisional,
+            $this->result($context, $provisional),
+        );
 
-        return $snapshot;
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
+        );
     }
 
     public function result(ReportExecutionContext $context, ReportSnapshotRef $snapshot): ReportResult
@@ -113,7 +134,7 @@ final readonly class CustomerSlaReportProvider implements ReportDataProvider
                     'customer_sla_v1',
                     'event_'.(string) ($record->watermarks['last_event_id'] ?? 0),
                     $rowCount,
-                    $snapshot->sourceHash,
+                    new Sha256Hash((string) $record->source_hash),
                 )],
                 $snapshot->sourceHash,
                 null,

--- a/tests/Architecture/Reporting/CustomerSlaCanonicalHashContractTest.php
+++ b/tests/Architecture/Reporting/CustomerSlaCanonicalHashContractTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture\Reporting;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CustomerSlaCanonicalHashContractTest extends TestCase
+{
+    #[Test]
+    public function provider_preserves_materialized_identity_and_publishes_canonical_identity(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__, 3).'/app/Services/Customer/Reporting/Sla/Providers/CustomerSlaReportProvider.php',
+        );
+
+        self::assertStringContainsString('CanonicalReportSourceHashBuilder $identities', $source);
+        self::assertStringContainsString('$this->identities->build(', $source);
+        self::assertStringContainsString('sourceHash: $canonical', $source);
+        self::assertStringContainsString('materializedSourceHash: $provisional->materializedSourceHash', $source);
+        self::assertStringContainsString("new Sha256Hash((string) \$record->source_hash)", $source);
+    }
+}


### PR DESCRIPTION
SLA-провайдер разделяет канонический hash запуска и физический hash снимка; source ref остаётся привязан к владельцу данных. Добавлена регрессия.