### PR TITLE
fix[admin]: разрешены пустые снимки здоровья портфеля

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSource.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthImmutableSource.php
@@ -92,13 +92,17 @@ final readonly class ProjectPortfolioHealthImmutableSource
             $expectedAsOf = (new DateTimeImmutable($component->asOf))->getTimestamp();
             $version = trim((string) $snapshot->formula_version)
                 .'|'.trim((string) $snapshot->source_schema_version);
-            if ($asOf !== $expectedAsOf
-                || $version !== $component->version
-                || (string) $snapshot->quality_status !== 'complete'
-                || (int) $snapshot->row_count !== $rows->count()
-                || (int) $snapshot->coverage_numerator !== $rows->count()
-                || (int) $snapshot->coverage_denominator !== $rows->count()
-                || $rows->isEmpty()) {
+            if (! (new ProjectPortfolioHealthSnapshotEvidence)->isComplete(
+                actualAsOf: $asOf,
+                expectedAsOf: $expectedAsOf,
+                actualVersion: $version,
+                expectedVersion: $component->version,
+                qualityStatus: (string) $snapshot->quality_status,
+                declaredRowCount: (int) $snapshot->row_count,
+                coverageNumerator: (int) $snapshot->coverage_numerator,
+                coverageDenominator: (int) $snapshot->coverage_denominator,
+                actualRowCount: $rows->count(),
+            )) {
                 $this->unavailable();
             }
             $rowsByKind[$component->kind] = $rows

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSnapshotEvidence.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthSnapshotEvidence.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\Budgeting\Reporting\Portfolio;
+
+final class ProjectPortfolioHealthSnapshotEvidence
+{
+    public function isComplete(
+        ?int $actualAsOf,
+        int $expectedAsOf,
+        string $actualVersion,
+        string $expectedVersion,
+        string $qualityStatus,
+        int $declaredRowCount,
+        int $coverageNumerator,
+        int $coverageDenominator,
+        int $actualRowCount,
+    ): bool {
+        return $actualAsOf === $expectedAsOf
+            && $actualVersion === $expectedVersion
+            && $qualityStatus === 'complete'
+            && $declaredRowCount === $actualRowCount
+            && $coverageNumerator === $actualRowCount
+            && $coverageDenominator === $actualRowCount;
+    }
+}

--- a/tests/Unit/Reporting/WaveOne/ProjectPortfolioHealthSnapshotEvidenceTest.php
+++ b/tests/Unit/Reporting/WaveOne/ProjectPortfolioHealthSnapshotEvidenceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\WaveOne;
+
+use App\BusinessModules\Features\Budgeting\Reporting\Portfolio\ProjectPortfolioHealthSnapshotEvidence;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectPortfolioHealthSnapshotEvidenceTest extends TestCase
+{
+    #[Test]
+    public function complete_zero_row_snapshot_is_valid_source_evidence(): void
+    {
+        self::assertTrue((new ProjectPortfolioHealthSnapshotEvidence)->isComplete(
+            actualAsOf: 1786233600,
+            expectedAsOf: 1786233600,
+            actualVersion: 'portfolio-margin-v1|portfolio-margin-source-v1',
+            expectedVersion: 'portfolio-margin-v1|portfolio-margin-source-v1',
+            qualityStatus: 'complete',
+            declaredRowCount: 0,
+            coverageNumerator: 0,
+            coverageDenominator: 0,
+            actualRowCount: 0,
+        ));
+    }
+
+    #[Test]
+    public function mismatched_row_count_is_not_valid_source_evidence(): void
+    {
+        self::assertFalse((new ProjectPortfolioHealthSnapshotEvidence)->isComplete(
+            actualAsOf: 1786233600,
+            expectedAsOf: 1786233600,
+            actualVersion: 'portfolio-margin-v1|portfolio-margin-source-v1',
+            expectedVersion: 'portfolio-margin-v1|portfolio-margin-source-v1',
+            qualityStatus: 'complete',
+            declaredRowCount: 1,
+            coverageNumerator: 1,
+            coverageDenominator: 1,
+            actualRowCount: 0,
+        ));
+    }
+}


### PR DESCRIPTION
Исправляет бесконечную материализацию отчёта здоровья портфеля на корректных завершённых снимках с нулём строк. Пустой снимок теперь считается валидным, если дата, версии, качество, row_count и coverage согласованы. Добавлены регрессионные тесты валидного пустого снимка и рассогласования количества строк.\n\nЛокально: php -l для изменённых файлов, git diff --check. PHPUnit недоступен без vendor; тест обязателен в CI.