### PR TITLE
fix[admin]: приняты пустые источники портфельного отчета

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/EloquentProjectPortfolioHealthSourceReader.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/EloquentProjectPortfolioHealthSourceReader.php
@@ -97,7 +97,7 @@ final readonly class EloquentProjectPortfolioHealthSourceReader implements Proje
                 ->where('formula_version', $contract['formula'])
                 ->where('source_schema_version', $contract['schema'])
                 ->where('quality_status', 'complete')
-                ->where('coverage_numerator', '>', 0)
+                ->where('coverage_numerator', '>=', 0)
                 ->whereColumn('coverage_numerator', 'coverage_denominator')
                 ->whereColumn('coverage_numerator', 'row_count')
                 ->where('generated_at', '<=', $query->asOf)

--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOwnerSourcePolicy.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOwnerSourcePolicy.php
@@ -110,7 +110,7 @@ final class ProjectPortfolioHealthOwnerSourcePolicy
             || $staleAt === null || $staleAt <= $asOf
             || $parentGeneratedAt === null || $parentGeneratedAt > $asOf
             || $parentStaleAt === null || $parentStaleAt <= $asOf
-            || $rowCount === null || $rowCount < 1
+            || $rowCount === null
             || $coverageNumerator === null || $coverageNumerator !== $rowCount
             || $coverageDenominator === null || $coverageDenominator !== $rowCount
             || $rowsCount === null || $rowsCount !== $rowCount
@@ -176,6 +176,7 @@ final class ProjectPortfolioHealthOwnerSourcePolicy
         $counterpartyIds = $this->ids($request['counterparty_ids']);
         $rowProjectIds = $this->ids($source['row_project_ids']);
         $rowCurrencies = $this->currencies($source['row_currencies']);
+        $emptySnapshot = $this->nonNegativeInt($source['row_count'] ?? null) === 0;
 
         if ($scopeProjectIds === null || $scopeProjectIds === []
             || $projectIds === null || $projectIds === []
@@ -183,14 +184,14 @@ final class ProjectPortfolioHealthOwnerSourcePolicy
             || $currencies === null
             || $responsibilityCenterIds === null
             || $counterpartyIds === null
-            || $rowProjectIds === null || $rowProjectIds === []
-            || $rowCurrencies === null || $rowCurrencies === []) {
+            || $rowProjectIds === null || (! $emptySnapshot && $rowProjectIds === [])
+            || $rowCurrencies === null || (! $emptySnapshot && $rowCurrencies === [])) {
             return false;
         }
 
         if (array_key_exists('kind', $request)) {
-            return $rowProjectIds === $projectIds
-                && ($currencies === [] || array_diff($currencies, $rowCurrencies) === [])
+            return ($emptySnapshot || $rowProjectIds === $projectIds)
+                && ($emptySnapshot || $currencies === [] || array_diff($currencies, $rowCurrencies) === [])
                 && $this->canonicalQueryFilters($request, $source) !== null;
         }
 

--- a/tests/Unit/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOwnerSourcePolicyTest.php
+++ b/tests/Unit/Budgeting/Reporting/Portfolio/ProjectPortfolioHealthOwnerSourcePolicyTest.php
@@ -134,6 +134,27 @@ final class ProjectPortfolioHealthOwnerSourcePolicyTest extends TestCase
     }
 
     #[Test]
+    public function it_accepts_a_complete_owner_snapshot_without_rows(): void
+    {
+        $source = [
+            ...$this->snapshotSource(),
+            'row_count' => 0,
+            'coverage_numerator' => 0,
+            'coverage_denominator' => 0,
+            'rows_count' => 0,
+            'row_organization_ids' => [],
+            'row_report_codes' => [],
+            'row_project_ids' => [],
+            'row_currencies' => [],
+        ];
+
+        self::assertTrue((new ProjectPortfolioHealthOwnerSourcePolicy)->accepts(
+            $this->snapshotRequest(),
+            $source,
+        ));
+    }
+
+    #[Test]
     public function it_accepts_a_selected_project_subset_and_multi_currency_coverage(): void
     {
         $policy = new ProjectPortfolioHealthOwnerSourcePolicy;


### PR DESCRIPTION
Устраняет повторный REPORT_SOURCE_UNAVAILABLE для здоровья портфеля: source reader теперь выбирает согласованные снимки с нулевым покрытием, а owner policy принимает их только при row_count=coverage=rows_count=0 и сохранении всех остальных identity/integrity проверок. Добавлен регрессионный тест пустого complete snapshot.\n\nПроверено: php -l изменённых PHP-файлов, git diff --check. PHPUnit локально недоступен без vendor; тест запускается CI.