### PR TITLE
fix[admin]: проверять готовность источников до запуска отчета

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Persistence/ReadinessGuardedReportRunStore.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Persistence/ReadinessGuardedReportRunStore.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Reporting\Infrastructure\Persistence;
+
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportRunStore;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
+use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunExportSource;
+use App\BusinessModules\Core\Reporting\Application\Execution\ReportRunRetrySource;
+use App\BusinessModules\Core\Reporting\Application\Readiness\ReportCandidateReadinessGate;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceReadinessProbe;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportResult;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportRun;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSavedViewRef;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\IdempotencyKey;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use DateTimeImmutable;
+
+final readonly class ReadinessGuardedReportRunStore implements ReportRunStore
+{
+    public function __construct(
+        private ReportRunStore $runs,
+        private ReportDefinitionBindingMap $bindings,
+        private ReportCandidateReadinessGate $gate,
+    ) {}
+
+    public function createOrReuse(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        ?ReportSavedViewRef $savedView,
+        IdempotencyKey $idempotencyKey,
+    ): ReportRun {
+        $binding = $this->bindings->get($query->definition->code);
+        $probe = $binding->readinessProbe;
+        if ($probe instanceof ReportSourceReadinessProbe) {
+            $this->gate->assertReady(
+                $query->definition->code,
+                $probe->inspect($context, $query),
+            );
+        }
+
+        return $this->runs->createOrReuse($context, $query, $savedView, $idempotencyKey);
+    }
+
+    public function get(ReportExecutionContext $context, string $runId): ReportRun
+    {
+        return $this->runs->get($context, $runId);
+    }
+
+    public function queryForRun(ReportExecutionContext $context, string $runId): ReportQuery
+    {
+        return $this->runs->queryForRun($context, $runId);
+    }
+
+    public function retrySource(ReportExecutionContext $context, string $runId): ReportRunRetrySource
+    {
+        return $this->runs->retrySource($context, $runId);
+    }
+
+    public function exportSource(ReportExecutionContext $context, string $runId): ReportRunExportSource
+    {
+        return $this->runs->exportSource($context, $runId);
+    }
+
+    public function claimMaterialization(
+        ReportExecutionContext $context,
+        string $runId,
+        string $leaseToken,
+        DateTimeImmutable $leaseExpiresAt,
+        DateTimeImmutable $occurredAt,
+    ): ReportRun {
+        return $this->runs->claimMaterialization($context, $runId, $leaseToken, $leaseExpiresAt, $occurredAt);
+    }
+
+    public function persistProgress(
+        ReportExecutionContext $context,
+        string $runId,
+        string $leaseToken,
+        ReportProgress $progress,
+        DateTimeImmutable $leaseExpiresAt,
+        DateTimeImmutable $occurredAt,
+    ): ReportRun {
+        return $this->runs->persistProgress($context, $runId, $leaseToken, $progress, $leaseExpiresAt, $occurredAt);
+    }
+
+    public function sealReady(
+        ReportExecutionContext $context,
+        string $runId,
+        string $leaseToken,
+        ReportSnapshotRef $snapshot,
+        ReportResult $result,
+        Sha256Hash $sourceHash,
+        DateTimeImmutable $occurredAt,
+    ): ReportRun {
+        return $this->runs->sealReady($context, $runId, $leaseToken, $snapshot, $result, $sourceHash, $occurredAt);
+    }
+
+    public function fail(
+        ReportExecutionContext $context,
+        string $runId,
+        ?string $leaseToken,
+        ReportErrorCode $errorCode,
+        DateTimeImmutable $occurredAt,
+    ): ReportRun {
+        return $this->runs->fail($context, $runId, $leaseToken, $errorCode, $occurredAt);
+    }
+
+    public function cancel(
+        ReportExecutionContext $context,
+        string $runId,
+        DateTimeImmutable $occurredAt,
+    ): ReportRun {
+        return $this->runs->cancel($context, $runId, $occurredAt);
+    }
+}

--- a/app/BusinessModules/Core/Reporting/ReportingExecutionServiceProvider.php
+++ b/app/BusinessModules/Core/Reporting/ReportingExecutionServiceProvider.php
@@ -74,6 +74,7 @@ use App\BusinessModules\Core\Reporting\Application\Exports\ReportExportLimits;
 use App\BusinessModules\Core\Reporting\Application\Exports\ReportPdfDocumentBuilder;
 use App\BusinessModules\Core\Reporting\Application\Exports\ReportPdfDocumentRenderer;
 use App\BusinessModules\Core\Reporting\Application\Exports\ReportPdfRenderBudget;
+use App\BusinessModules\Core\Reporting\Application\Readiness\ReportCandidateReadinessGate;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\DefinitionBoundReportSourceAccessResolver;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\LaravelCurrentReportAbacEvaluator;
 use App\BusinessModules\Core\Reporting\Infrastructure\Access\LaravelReportHttpAuthorizationTargetResolver;
@@ -113,6 +114,7 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReport
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReportRunAttemptLifecycleStore;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReportRunLeaseRecoveryStore;
 use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\EloquentReportRunStore;
+use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\ReadinessGuardedReportRunStore;
 use App\BusinessModules\Core\Reporting\Infrastructure\Queue\LaravelReportExportDispatcher;
 use App\BusinessModules\Core\Reporting\Infrastructure\Queue\LaravelReportMaterializationDispatcher;
 use App\BusinessModules\Core\Reporting\Infrastructure\Security\ContentHashReportSnapshotSealVerifier;
@@ -249,7 +251,16 @@ final class ReportingExecutionServiceProvider extends ServiceProvider
         $this->app->when(EloquentReportRunStore::class)
             ->needs('$pollAfterMs')
             ->give(fn (): int => $this->configArray('runs')['poll_after_ms']);
-        $this->app->singleton(ReportRunStore::class, EloquentReportRunStore::class);
+        $this->app->singleton(EloquentReportRunStore::class);
+        $this->app->singleton(ReportCandidateReadinessGate::class);
+        $this->app->singleton(
+            ReportRunStore::class,
+            static fn (Container $app): ReadinessGuardedReportRunStore => new ReadinessGuardedReportRunStore(
+                $app->make(EloquentReportRunStore::class),
+                $app->make(\App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap::class),
+                $app->make(ReportCandidateReadinessGate::class),
+            ),
+        );
         $this->app->when(EloquentReportExportStore::class)
             ->needs('$exportTtlSeconds')
             ->give(fn (): int => $this->configArray('exports')['ttl_seconds']);

--- a/tests/Unit/Reporting/Readiness/ReadinessGuardedReportRunStoreTest.php
+++ b/tests/Unit/Reporting/Readiness/ReadinessGuardedReportRunStoreTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Readiness;
+
+use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportRunStore;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Readiness\ReportCandidateReadinessGate;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDrillDownProvider;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportRowQuery;
+use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceReadinessProbe;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBinding;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSourceReadiness;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSourceReadinessStatus;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\IdempotencyKey;
+use App\BusinessModules\Core\Reporting\Infrastructure\Persistence\ReadinessGuardedReportRunStore;
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\Reporting\ReportDefinitionBuilder;
+use Tests\Support\Reporting\ReportExecutionContextBuilder;
+
+final class ReadinessGuardedReportRunStoreTest extends TestCase
+{
+    #[Test]
+    public function unavailable_source_is_rejected_before_a_run_is_persisted(): void
+    {
+        $definition = (new ReportDefinitionBuilder)->code('project_portfolio_health')->payload();
+        $context = (new ReportExecutionContextBuilder)->build();
+        $query = new ReportQuery(
+            $definition,
+            $context->scope,
+            new ReportFilterSet([]),
+            [],
+            new CarbonImmutable('2026-08-09T00:00:00+00:00'),
+            'ru',
+        );
+        $readiness = new ReportSourceReadiness(
+            ReportSourceReadinessStatus::UNAVAILABLE,
+            4,
+            0,
+            4,
+            0,
+            'portfolio:missing',
+            str_repeat('a', 64),
+            str_repeat('b', 64),
+            new CarbonImmutable('2026-08-09T00:00:00+00:00'),
+        );
+        $probe = $this->createMock(ReportSourceReadinessProbe::class);
+        $probe->expects(self::once())->method('inspect')->with($context, $query)->willReturn($readiness);
+        $delegate = $this->createMock(ReportRunStore::class);
+        $delegate->expects(self::never())->method('createOrReuse');
+        $binding = new ReportDefinitionBinding(
+            $definition->code,
+            $definition->definitionHash,
+            $definition->contractVersion,
+            $this->createMock(ReportDataProvider::class),
+            $this->createMock(ReportRowQuery::class),
+            $this->createMock(ReportDrillDownProvider::class),
+            $probe,
+        );
+        $store = new ReadinessGuardedReportRunStore(
+            $delegate,
+            new ReportDefinitionBindingMap([$definition->code => $binding]),
+            new ReportCandidateReadinessGate,
+        );
+
+        $this->expectException(ReportContractException::class);
+        $store->createOrReuse($context, $query, null, new IdempotencyKey('readiness-guard'));
+    }
+}


### PR DESCRIPTION
## Что изменено
- readiness-проверки выполняются до создания run и outbox
- недоступный источник возвращает доменную ошибку без queued/materializing и polling
- добавлен регрессионный тест отсутствия записи запуска

## Проверки
- php -l изменённых PHP-файлов
- git diff --check
- PHPUnit/PHPStan: CI (локально отсутствует vendor)

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced ReadinessGuardedReportRunStore to enforce readiness checks before report execution.</li>
<li>Updated ReportingExecutionServiceProvider to inject the new readiness-guarded store as the primary ReportRunStore implementation.</li>
<li>Added a new unit test to verify that report runs are rejected when the data source is unavailable.</li>
</ul></div>