### PR TITLE
fix[admin]: поддержана канонизация скалярных значений отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Support/CanonicalJson.php
+++ b/app/BusinessModules/Core/Reporting/Support/CanonicalJson.php
@@ -9,7 +9,7 @@ use JsonException;
 
 final class CanonicalJson
 {
-    public static function encode(array $value): string
+    public static function encode(mixed $value): string
     {
         try {
             json_encode($value, JSON_THROW_ON_ERROR);

--- a/tests/Unit/Reporting/Contracts/ReportValueObjectContractTest.php
+++ b/tests/Unit/Reporting/Contracts/ReportValueObjectContractTest.php
@@ -79,6 +79,15 @@ final class ReportValueObjectContractTest extends TestCase
     }
 
     #[Test]
+    public function canonical_json_encodes_scalar_values_used_in_streamed_documents(): void
+    {
+        self::assertSame('"2026-08-09T00:00:00+00:00"', CanonicalJson::encode('2026-08-09T00:00:00+00:00'));
+        self::assertSame('null', CanonicalJson::encode(null));
+        self::assertSame('true', CanonicalJson::encode(true));
+        self::assertSame('1.0', CanonicalJson::encode(1.0));
+    }
+
+    #[Test]
     public function canonical_json_rejects_unsupported_values(): void
     {
         $resource = fopen('php://memory', 'rb');


### PR DESCRIPTION
Исправляет падение materialization базового графика при канонизации даты и аналогичные вызовы с null/boolean/float. Добавлена регрессия для скалярных значений. Локально: PHP syntax и git diff --check; PHPUnit недоступен без vendor.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated CanonicalJson::encode to accept mixed types instead of only arrays, allowing for broader data serialization.</li>
<li>Added unit tests to verify that scalar values like strings, null, booleans, and floats are correctly encoded by CanonicalJson.</li>
</ul></div>