### PR TITLE
fix[admin]: исправлена идентичность базового графика

### DIFF
--- a/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceProvider.php
+++ b/app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\ScheduleManagement\Reporting;
 
+use App\BusinessModules\Core\Reporting\Application\Execution\CanonicalReportSourceHashBuilder;
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDataProvider;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
@@ -18,6 +19,7 @@ final readonly class BaselineScheduleVarianceProvider implements ReportDataProvi
     public function __construct(
         private BaselineScheduleSnapshotService $snapshots,
         private OwnerProjectionResultFactory $results,
+        private CanonicalReportSourceHashBuilder $identities,
     ) {
     }
 
@@ -32,10 +34,29 @@ final readonly class BaselineScheduleVarianceProvider implements ReportDataProvi
         ReportProgress $progress,
     ): ReportSnapshotRef {
         $progress->advance(10);
-        $snapshot = $this->snapshots->materialize($context->scope, $query);
+        $provisional = $this->snapshots->materialize($context->scope, $query);
         $progress->advance(100);
 
-        return $snapshot;
+        $canonical = $this->identities->build(
+            $query,
+            $provisional,
+            $this->result($context, $provisional),
+        );
+
+        return new ReportSnapshotRef(
+            kind: $provisional->kind,
+            id: $provisional->id,
+            scope: $provisional->scope,
+            definitionHash: $provisional->definitionHash,
+            formulaVersion: $provisional->formulaVersion,
+            sourceHash: $canonical,
+            generatedAt: $provisional->generatedAt,
+            staleAt: $provisional->staleAt,
+            watermarks: $provisional->watermarks,
+            classification: $provisional->classification,
+            seal: $provisional->seal,
+            materializedSourceHash: $provisional->materializedSourceHash,
+        );
     }
 
     public function result(

--- a/tests/Architecture/Reporting/Waves23ProductionContractsTest.php
+++ b/tests/Architecture/Reporting/Waves23ProductionContractsTest.php
@@ -29,6 +29,22 @@ final class Waves23ProductionContractsTest extends TestCase
     }
 
     #[Test]
+    public function baseline_schedule_provider_preserves_materialized_and_canonical_identities(): void
+    {
+        $provider = $this->source(
+            'app/BusinessModules/Features/ScheduleManagement/Reporting/BaselineScheduleVarianceProvider.php'
+        );
+
+        self::assertStringContainsString('CanonicalReportSourceHashBuilder $identities', $provider);
+        self::assertStringContainsString('$this->identities->build(', $provider);
+        self::assertStringContainsString('sourceHash: $canonical', $provider);
+        self::assertStringContainsString(
+            'materializedSourceHash: $provisional->materializedSourceHash',
+            $provider,
+        );
+    }
+
+    #[Test]
     public function accepted_production_reversal_and_backfill_use_canonical_owner_timestamps(): void
     {
         $service = $this->source('app/Services/Contract/ContractPerformanceActService.php');


### PR DESCRIPTION
Провайдер сохраняет materialized hash источника отдельно и возвращает канонический hash полного отчёта, как требует общий execution contract. Добавлена архитектурная регрессия. Локально проверены PHP syntax и git diff --check.