### PR TITLE
fix[admin]: публикация прогресса во время расчета отчетов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Application/Execution/ReportProgressWritePolicy.php
+++ b/app/BusinessModules/Core/Reporting/Application/Execution/ReportProgressWritePolicy.php
@@ -17,6 +17,7 @@ final class ReportProgressWritePolicy
     ): bool {
         return $current->percent() < 100
             && $current->percent() >= $persisted->percent() + 1
-            && $occurredAt >= $persistedAt->modify('+5 seconds');
+            && ($current->percent() >= $persisted->percent() + 5
+                || $occurredAt >= $persistedAt->modify('+5 seconds'));
     }
 }

--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportProgress.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportProgress.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Core\Reporting\Domain\DTO;
 
+use Closure;
 use InvalidArgumentException;
 
 final class ReportProgress
 {
     private int $state;
 
-    public function __construct(int $percent)
+    public function __construct(
+        int $percent,
+        private readonly ?Closure $onAdvance = null,
+    )
     {
         self::assertPercent($percent);
 
@@ -35,6 +39,9 @@ final class ReportProgress
         }
 
         $this->state = $percent;
+        if ($this->onAdvance !== null) {
+            ($this->onAdvance)($this);
+        }
 
         return true;
     }

--- a/app/BusinessModules/Core/Reporting/Infrastructure/Jobs/MaterializeReportRunJob.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Jobs/MaterializeReportRunJob.php
@@ -107,7 +107,41 @@ final class MaterializeReportRunJob implements ShouldQueue
             ]);
 
             $persistedProgress = new ReportProgress($run->progress);
-            $progress = new ReportProgress($run->progress);
+            $persistedAt = $run->updatedAt;
+            $progress = new ReportProgress(
+                $run->progress,
+                function (ReportProgress $current) use (
+                    $clock,
+                    $context,
+                    $leaseToken,
+                    $progressPolicy,
+                    &$persistedAt,
+                    $persistedProgress,
+                    $runs,
+                    $runtime,
+                ): void {
+                    $occurredAt = $clock->now();
+                    if (! $progressPolicy->shouldPersist(
+                        $persistedProgress,
+                        $current,
+                        $persistedAt,
+                        $occurredAt,
+                    )) {
+                        return;
+                    }
+
+                    $runs->persistProgress(
+                        $context,
+                        $this->runId,
+                        $leaseToken,
+                        $current,
+                        $occurredAt->modify("+{$runtime->executionLeaseSeconds} seconds"),
+                        $occurredAt,
+                    );
+                    $persistedProgress->advance($current->percent());
+                    $persistedAt = $occurredAt;
+                },
+            );
             try {
                 $snapshot = $binding->dataProvider->materialize($context, $query, $progress);
             } catch (ReportSnapshotIdentityViolation $exception) {
@@ -115,18 +149,6 @@ final class MaterializeReportRunJob implements ShouldQueue
             } catch (\InvalidArgumentException $exception) {
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR, previous: $exception);
             }
-            $afterMaterialization = $clock->now();
-            if ($progressPolicy->shouldPersist($persistedProgress, $progress, $run->updatedAt, $afterMaterialization)) {
-                $runs->persistProgress(
-                    $context,
-                    $this->runId,
-                    $leaseToken,
-                    $progress,
-                    $afterMaterialization->modify("+{$runtime->executionLeaseSeconds} seconds"),
-                    $afterMaterialization,
-                );
-            }
-
             $result = $binding->dataProvider->result($context, $snapshot);
             $sourceHash = $sourceHashes->build($query, $snapshot, $result);
             if (! hash_equals($snapshot->canonicalReportHash->value, $sourceHash->value)

--- a/tests/Unit/Reporting/Contracts/ReportExecutionContractTest.php
+++ b/tests/Unit/Reporting/Contracts/ReportExecutionContractTest.php
@@ -279,6 +279,20 @@ final class ReportExecutionContractTest extends TestCase
     }
 
     #[Test]
+    public function progress_notifies_observer_immediately_after_each_advance(): void
+    {
+        $observed = [];
+        $progress = new ReportProgress(0, static function (ReportProgress $current) use (&$observed): void {
+            $observed[] = $current->percent();
+        });
+
+        $progress->advance(10);
+        $progress->advance(25);
+
+        self::assertSame([10, 25], $observed);
+    }
+
+    #[Test]
     public function window_sort_validates_its_field(): void
     {
         $sort = new ReportWindowSort('created_at', ReportSortDirection::DESC);

--- a/tests/Unit/Reporting/Execution/ReportProgressWritePolicyTest.php
+++ b/tests/Unit/Reporting/Execution/ReportProgressWritePolicyTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 final class ReportProgressWritePolicyTest extends TestCase
 {
     #[DataProvider('decisions')]
-    public function test_it_persists_only_a_real_stage_after_five_seconds(
+    public function test_it_persists_significant_stages_immediately_and_small_steps_periodically(
         int $persisted,
         int $current,
         string $previousAt,
@@ -32,7 +32,8 @@ final class ReportProgressWritePolicyTest extends TestCase
     {
         yield 'one percent after five seconds' => [10, 11, '2026-07-26T10:00:00Z', '2026-07-26T10:00:05Z', true];
         yield 'same stage' => [10, 10, '2026-07-26T10:00:00Z', '2026-07-26T10:00:10Z', false];
-        yield 'too soon' => [10, 20, '2026-07-26T10:00:00Z', '2026-07-26T10:00:04.999999Z', false];
+        yield 'significant stage immediately' => [10, 20, '2026-07-26T10:00:00Z', '2026-07-26T10:00:00Z', true];
+        yield 'small step too soon' => [10, 11, '2026-07-26T10:00:00Z', '2026-07-26T10:00:04.999999Z', false];
         yield 'terminal stage is sealed separately' => [99, 100, '2026-07-26T10:00:00Z', '2026-07-26T10:00:10Z', false];
     }
 }


### PR DESCRIPTION
Промежуточный прогресс теперь сохраняется непосредственно при advance() провайдера, а не после завершения materialize(). Значимые этапы (5+ п.п.) публикуются сразу, мелкие — не чаще раза в 5 секунд; 100% остаётся атомарной частью sealReady. Добавлены регрессии observer и write policy. Локально: PHP syntax и git diff --check; PHPUnit недоступен без vendor.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored report progress persistence to allow immediate updates for significant progress (>= 5%) alongside the existing 5-second interval rule.</li>
<li>Updated ReportProgress DTO to support an optional 'onAdvance' callback, enabling reactive persistence logic.</li>
<li>Migrated progress persistence logic from MaterializeReportRunJob into the ReportProgress callback, ensuring more granular and timely updates during materialization.</li>
<li>Added unit tests to verify the new callback functionality and updated existing policy tests to reflect the new persistence criteria.</li>
</ul></div>