### PR TITLE
fix[admin]: чтение снимков по материализованной identity

### DIFF
--- a/app/Support/Reporting/OwnerProjectionResultFactory.php
+++ b/app/Support/Reporting/OwnerProjectionResultFactory.php
@@ -35,7 +35,10 @@ final readonly class OwnerProjectionResultFactory
             ->whereKey($snapshot->id)
             ->where('organization_id', $context->scope->organizationId)
             ->first();
-        if ($record === null || !hash_equals((string) $record->getAttribute('source_hash'), $snapshot->sourceHash->value)) {
+        if ($record === null || !hash_equals(
+            (string) $record->getAttribute('source_hash'),
+            $snapshot->materializedSourceHash->value,
+        )) {
             throw new InvalidArgumentException('owner_projection_snapshot_missing');
         }
 

--- a/tests/Architecture/Reporting/Waves23ProductionContractsTest.php
+++ b/tests/Architecture/Reporting/Waves23ProductionContractsTest.php
@@ -42,6 +42,13 @@ final class Waves23ProductionContractsTest extends TestCase
             'materializedSourceHash: $provisional->materializedSourceHash',
             $provider,
         );
+
+        $resultFactory = $this->source('app/Support/Reporting/OwnerProjectionResultFactory.php');
+        self::assertStringContainsString('$snapshot->materializedSourceHash->value', $resultFactory);
+        self::assertStringNotContainsString(
+            "getAttribute('source_hash'), \$snapshot->sourceHash->value",
+            $resultFactory,
+        );
     }
 
     #[Test]


### PR DESCRIPTION
OwnerProjectionResultFactory теперь проверяет сохранённый source_hash по materializedSourceHash, сохраняя отдельный canonical report hash для общего execution contract. Это исправляет чтение всех owner-projection отчётов после канонизации. Добавлена архитектурная регрессия.