### PR TITLE
fix[admin]: нормализовать версии схем снимков отчетов

### DIFF
--- a/app/Support/Reporting/OwnerSnapshotResultFactory.php
+++ b/app/Support/Reporting/OwnerSnapshotResultFactory.php
@@ -96,7 +96,7 @@ final readonly class OwnerSnapshotResultFactory
             $source,
             $snapshot->kind,
             'snapshot_'.strtolower($snapshot->id),
-            $sourceSchemaVersion,
+            self::schemaVersionIdentifier($sourceSchemaVersion),
             self::watermarkIdentifier($watermark),
             $rowCount,
             $snapshot->sourceHash,
@@ -116,5 +116,10 @@ final readonly class OwnerSnapshotResultFactory
     private static function watermarkIdentifier(string $watermark): string
     {
         return 'watermark_'.substr(hash('sha256', $watermark), 0, 32);
+    }
+
+    private static function schemaVersionIdentifier(string $schemaVersion): string
+    {
+        return 'schema_'.substr(hash('sha256', $schemaVersion), 0, 32);
     }
 }

--- a/tests/Unit/Reporting/Support/OwnerSnapshotResultFactoryTest.php
+++ b/tests/Unit/Reporting/Support/OwnerSnapshotResultFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Reporting\Support;
+
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
+use App\BusinessModules\Core\Reporting\Domain\Enums\ReportReconciliationStatus;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
+use App\Support\Reporting\OwnerSnapshotResultFactory;
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OwnerSnapshotResultFactoryTest extends TestCase
+{
+    #[Test]
+    public function semantic_schema_version_is_encoded_as_safe_source_identifier(): void
+    {
+        $factory = new OwnerSnapshotResultFactory;
+        $snapshot = $factory->snapshot(
+            'supplier_award_competitiveness',
+            '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+            new ReportScope(1, [1], [52], [], new DateTimeZone('UTC')),
+            new Sha256Hash(str_repeat('a', 64)),
+            'supplier-award.v1',
+            str_repeat('b', 64),
+            new DateTimeImmutable('2026-08-09T00:00:00+00:00'),
+            null,
+            ['as_of' => '2026-08-09T00:00:00+00:00'],
+        );
+
+        $result = $factory->result(
+            $snapshot,
+            0,
+            0,
+            [],
+            'supplier_award_competitiveness',
+            'supplier-award.v1',
+            '2026-08-09T00:00:00+00:00',
+            [['id' => 'row_key']],
+            ['export' => true],
+            ReportReconciliationStatus::NOT_APPLICABLE,
+        );
+
+        self::assertSame(
+            'schema_'.substr(hash('sha256', 'supplier-award.v1'), 0, 32),
+            $result->provenance->sourceRefs[0]->schemaVersion,
+        );
+    }
+}


### PR DESCRIPTION
## Что изменено
- provenance owner-snapshot отчётов получает безопасный стабильный идентификатор версии схемы
- версии вроде supplier-award.v1 больше не приводят к REPORT_INTERNAL_ERROR
- добавлен регрессионный тест для пустого отчёта выбора поставщика

## Проверки
- php -l изменённых файлов
- git diff --check
- PHPUnit локально недоступен: vendor отсутствует; тест обязателен в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated OwnerSnapshotResultFactory to hash the schema version identifier using SHA-256.</li>
<li>Added a new private static method schemaVersionIdentifier to handle the hashing logic.</li>
<li>Added a new unit test to verify that the schema version is correctly encoded as a safe source identifier.</li>
</ul></div>