### PR TITLE
fix[admin]: канонизировать identity снимков отчетов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Jobs/MaterializeReportRunJob.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Jobs/MaterializeReportRunJob.php
@@ -18,9 +18,11 @@ use App\BusinessModules\Core\Reporting\Application\Execution\ReportProgressWrite
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportDefinitionRegistry;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDefinitionBindingMap;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportRunStatus;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotIdentityViolationReason;
 use App\BusinessModules\Core\Reporting\Domain\Exceptions\ReportSnapshotIdentityViolation;
+use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -151,6 +153,11 @@ final class MaterializeReportRunJob implements ShouldQueue
             }
             $result = $binding->dataProvider->result($context, $snapshot);
             $sourceHash = $sourceHashes->build($query, $snapshot, $result);
+            if (! hash_equals($snapshot->canonicalReportHash->value, $sourceHash->value)) {
+                $snapshot = $this->withCanonicalSourceHash($snapshot, $sourceHash);
+                $result = $binding->dataProvider->result($context, $snapshot);
+                $sourceHash = $sourceHashes->build($query, $snapshot, $result);
+            }
             if (! hash_equals($snapshot->canonicalReportHash->value, $sourceHash->value)
                 || ! hash_equals($result->provenance->sourceHash->value, $sourceHash->value)) {
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_SNAPSHOT_NOT_READY);
@@ -236,6 +243,26 @@ final class MaterializeReportRunJob implements ShouldQueue
             ]);
             throw ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR, previous: $exception);
         }
+    }
+
+    private function withCanonicalSourceHash(
+        ReportSnapshotRef $snapshot,
+        Sha256Hash $sourceHash,
+    ): ReportSnapshotRef {
+        return new ReportSnapshotRef(
+            kind: $snapshot->kind,
+            id: $snapshot->id,
+            scope: $snapshot->scope,
+            definitionHash: $snapshot->definitionHash,
+            formulaVersion: $snapshot->formulaVersion,
+            sourceHash: $sourceHash,
+            generatedAt: $snapshot->generatedAt,
+            staleAt: $snapshot->staleAt,
+            watermarks: $snapshot->watermarks,
+            classification: $snapshot->classification,
+            seal: $snapshot->seal,
+            materializedSourceHash: $snapshot->materializedSourceHash,
+        );
     }
 
     private function envelopeUuid(): string

--- a/tests/Unit/Reporting/Jobs/MaterializeReportRunJobTest.php
+++ b/tests/Unit/Reporting/Jobs/MaterializeReportRunJobTest.php
@@ -41,6 +41,7 @@ use App\BusinessModules\Core\Reporting\Infrastructure\Jobs\MaterializeReportRunJ
 use DateTimeImmutable;
 use Illuminate\Contracts\Queue\Job;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
@@ -51,6 +52,37 @@ use Tests\Support\Reporting\ReportRunBuilder;
 
 final class MaterializeReportRunJobTest extends TestCase
 {
+    #[Test]
+    public function canonicalization_preserves_materialized_snapshot_identity(): void
+    {
+        $context = (new ReportExecutionContextBuilder)->build();
+        $definition = (new ReportDefinitionBuilder)->payload();
+        $materializedHash = new Sha256Hash(str_repeat('c', 64));
+        $canonicalHash = new Sha256Hash(str_repeat('d', 64));
+        $provisional = new ReportSnapshotRef(
+            'sales_snapshot',
+            'snapshot_1',
+            $context->scope,
+            $definition->definitionHash,
+            $definition->formulaVersion,
+            $materializedHash,
+            new DateTimeImmutable('2026-07-26T09:00:00Z'),
+            null,
+            ['source' => 'watermark_1'],
+            ReportSnapshotClassification::OPERATIONAL,
+            null,
+        );
+        $method = new ReflectionMethod(MaterializeReportRunJob::class, 'withCanonicalSourceHash');
+
+        $snapshot = $method->invoke(new MaterializeReportRunJob('01ARZ3NDEKTSV4RRFFQ69G5FAV'), $provisional, $canonicalHash);
+
+        self::assertInstanceOf(ReportSnapshotRef::class, $snapshot);
+        self::assertSame($canonicalHash->value, $snapshot->canonicalReportHash->value);
+        self::assertSame($materializedHash->value, $snapshot->materializedSourceHash->value);
+        self::assertSame($provisional->id, $snapshot->id);
+        self::assertSame($provisional->scope, $snapshot->scope);
+    }
+
     public function test_job_payload_and_retry_runtime_are_closed(): void
     {
         $job = new MaterializeReportRunJob('01J00000000000000000000000');


### PR DESCRIPTION
## Что изменено
- runtime централизованно переводит материализованный hash снимка в канонический hash запуска
- физический hash сохраняется отдельно для чтения строк
- результат пересобирается с канонической provenance identity перед seal
- добавлен регрессионный тест сохранения обеих identity

## Проверки
- php -l изменённых файлов
- git diff --check
- PHPUnit локально недоступен: vendor отсутствует; CI остаётся gate