### PR TITLE
fix[admin]: добавить пропорциональный прогресс отчётов

### DIFF
--- a/app/BusinessModules/Core/Reporting/Domain/DTO/ReportProgress.php
+++ b/app/BusinessModules/Core/Reporting/Domain/DTO/ReportProgress.php
@@ -46,6 +46,26 @@ final class ReportProgress
         return true;
     }
 
+    public function advanceProportion(
+        int $completed,
+        int $total,
+        int $startPercent = 10,
+        int $endPercent = 90,
+    ): bool {
+        self::assertPercent($startPercent);
+        self::assertPercent($endPercent);
+        if ($total < 1 || $completed < 0 || $completed > $total || $startPercent > $endPercent) {
+            throw new InvalidArgumentException('report_progress_proportion_invalid');
+        }
+
+        $percent = $startPercent + intdiv(
+            ($endPercent - $startPercent) * $completed,
+            $total,
+        );
+
+        return $this->advance(max($this->state, $percent));
+    }
+
     private static function assertPercent(int $percent): void
     {
         if ($percent < 0 || $percent > 100) {

--- a/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Reporting/InventoryRisk/Services/InventoryRiskSnapshotMaterializer.php
@@ -185,6 +185,7 @@ final readonly class InventoryRiskSnapshotMaterializer
                 ...$policies->pluck('source_hash')->all(),
             ],
         );
+        $progress->advance(max($progress->percent(), 45));
         $existing = InventoryRiskSnapshot::query()
             ->where('organization_id', $context->scope->organizationId)
             ->where('query_hash', $query->queryHash->value)
@@ -211,7 +212,9 @@ final readonly class InventoryRiskSnapshotMaterializer
             $gapCount = 0;
             $valueByCurrency = [];
             $riskStatusCounts = ['healthy' => 0, 'reorder' => 0, 'excess' => 0];
-            foreach ($balanceRows as $balance) {
+            $balanceCount = $balanceRows->count();
+            foreach ($balanceRows as $balanceIndex => $balance) {
+                $progress->advanceProportion($balanceIndex, $balanceCount, 45, 85);
                 $warnings = is_array($balance->quality_warnings) ? $balance->quality_warnings : [];
                 $demand = $this->demandFor($balance, $demands);
                 $policy = $this->policyFor($balance, $policies);
@@ -293,6 +296,7 @@ final readonly class InventoryRiskSnapshotMaterializer
                 ];
             }
 
+            $progress->advance(85);
             ksort($valueByCurrency, SORT_STRING);
             $generatedAt = new DateTimeImmutable;
             $freshnessTtl = $policies
@@ -322,7 +326,9 @@ final readonly class InventoryRiskSnapshotMaterializer
                     'value_by_currency' => $valueByCurrency,
                 ],
             ]);
-            foreach ($rows as $row) {
+            $rowCount = count($rows);
+            foreach ($rows as $rowIndex => $row) {
+                $progress->advanceProportion($rowIndex, $rowCount, 90, 99);
                 $row['snapshot_id'] = $snapshot->getKey();
                 InventoryRiskRow::query()->create($row);
             }

--- a/app/BusinessModules/Features/Procurement/Reporting/Award/Services/SupplierAwardSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Award/Services/SupplierAwardSnapshotMaterializer.php
@@ -77,6 +77,7 @@ final readonly class SupplierAwardSnapshotMaterializer
             ->orderBy('decision_id')
             ->orderBy('decision_version')
             ->get();
+        $progress->advance(10);
         $versionIds = $decisions->flatMap(
             static fn (SupplierAwardDecisionVersion $decision): array => $decision->comparable_proposal_version_ids,
         )->unique()->values()->all();
@@ -106,6 +107,7 @@ final readonly class SupplierAwardSnapshotMaterializer
                 ...$versionHashes,
             ],
         );
+        $progress->advance(20);
         $existing = SupplierAwardSnapshot::query()
             ->where('organization_id', $organizationId)
             ->where('query_hash', $query->queryHash->value)
@@ -128,7 +130,8 @@ final readonly class SupplierAwardSnapshotMaterializer
             $rows = [];
             $gapCount = 0;
             $premiumByCurrency = [];
-            foreach ($decisions as $decision) {
+            $decisionCount = $decisions->count();
+            foreach ($decisions as $decisionIndex => $decision) {
                 try {
                     $proposals = [];
                     foreach ($decision->comparable_proposal_version_ids as $versionId) {
@@ -157,6 +160,7 @@ final readonly class SupplierAwardSnapshotMaterializer
                     $selectedData = $this->proposalFactory->make($selected);
                 } catch (Throwable) {
                     $gapCount++;
+                    $progress->advanceProportion($decisionIndex + 1, $decisionCount, 20, 85);
 
                     continue;
                 }
@@ -206,8 +210,10 @@ final readonly class SupplierAwardSnapshotMaterializer
                     'selected_at' => $decision->selected_at,
                     'quality_warnings' => [],
                 ];
+                $progress->advanceProportion($decisionIndex + 1, $decisionCount, 20, 85);
             }
 
+            $progress->advance(90);
             $generatedAt = new DateTimeImmutable;
             ksort($premiumByCurrency, SORT_STRING);
             $totals = [
@@ -233,9 +239,11 @@ final readonly class SupplierAwardSnapshotMaterializer
                 'reconciliation_status' => 'not_applicable',
                 'totals' => $totals,
             ]);
-            foreach ($rows as $row) {
+            $rowCount = count($rows);
+            foreach ($rows as $rowIndex => $row) {
                 $row['snapshot_id'] = $snapshot->getKey();
                 SupplierAwardRow::query()->create($row);
+                $progress->advanceProportion($rowIndex + 1, $rowCount, 90, 99);
             }
             $progress->advance(100);
 

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleSnapshotMaterializer.php
@@ -193,6 +193,7 @@ final readonly class ProcurementCycleSnapshotMaterializer
                 ...$supplyEvents->pluck('source_hash')->all(),
             ],
         );
+        $progress->advance(max($progress->percent(), 20));
         $existing = ProcurementCycleSnapshot::query()
             ->where('organization_id', $organizationId)
             ->where('query_hash', $query->queryHash->value)
@@ -209,7 +210,12 @@ final readonly class ProcurementCycleSnapshotMaterializer
             $slaNumerator = 0;
             $slaDenominator = 0;
             $gapCount = 0;
-            foreach ($events->groupBy('purchase_request_line_id') as $lineEvents) {
+            $eventGroups = $events->groupBy('purchase_request_line_id');
+            $eventGroupCount = $eventGroups->count();
+            $processedEventGroups = 0;
+            foreach ($eventGroups as $lineEvents) {
+                $progress->advanceProportion($processedEventGroups, $eventGroupCount, 20, 80);
+                $processedEventGroups++;
                 $first = $lineEvents->first();
                 $last = $lineEvents->last();
                 if (! $first instanceof ProcurementProcessEvent || ! $last instanceof ProcurementProcessEvent) {
@@ -277,6 +283,7 @@ final readonly class ProcurementCycleSnapshotMaterializer
                 ];
             }
 
+            $progress->advance(80);
             $generatedAt = new DateTimeImmutable;
             $startCohorts = [];
             $outcomeCohorts = [];
@@ -342,7 +349,9 @@ final readonly class ProcurementCycleSnapshotMaterializer
                 'reconciliation_status' => 'not_applicable',
                 'totals' => $totals,
             ]);
-            foreach ($rows as $row) {
+            $rowCount = count($rows);
+            foreach ($rows as $rowIndex => $row) {
+                $progress->advanceProportion($rowIndex, $rowCount, 90, 99);
                 $row['snapshot_id'] = $snapshot->getKey();
                 ProcurementCycleRow::query()->create($row);
             }

--- a/app/BusinessModules/Features/Procurement/Reporting/Supply/Services/SupplyReliabilitySnapshotMaterializer.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Supply/Services/SupplyReliabilitySnapshotMaterializer.php
@@ -182,6 +182,7 @@ final readonly class SupplyReliabilitySnapshotMaterializer
                 ...$events->pluck('source_hash')->all(),
             ],
         );
+        $progress->advance(max($progress->percent(), 20));
         $existing = SupplyReliabilitySnapshot::query()
             ->where('organization_id', $organizationId)
             ->where('query_hash', $query->queryHash->value)
@@ -208,7 +209,9 @@ final readonly class SupplyReliabilitySnapshotMaterializer
             $rows = [];
             $metrics = [];
             $gapCount = max(0, $eligibleSentCount - $promises->count());
-            foreach ($promises as $promise) {
+            $promiseCount = $promises->count();
+            foreach ($promises as $promiseIndex => $promise) {
+                $progress->advanceProportion($promiseIndex, $promiseCount, 20, 85);
                 $lineEvents = $eventsByLine->get($promise->purchase_order_item_id, collect());
                 $lineGapCount = 0;
                 if (! $lineEvents->contains('event_type', 'sent')) {
@@ -302,6 +305,7 @@ final readonly class SupplyReliabilitySnapshotMaterializer
                 ];
             }
 
+            $progress->advance(85);
             $summary = $this->formula->summarize($metrics);
             $generatedAt = new DateTimeImmutable;
             $totals = [
@@ -337,7 +341,9 @@ final readonly class SupplyReliabilitySnapshotMaterializer
                 'reconciliation_status' => 'not_applicable',
                 'totals' => $totals,
             ]);
-            foreach ($rows as $row) {
+            $rowCount = count($rows);
+            foreach ($rows as $rowIndex => $row) {
+                $progress->advanceProportion($rowIndex, $rowCount, 90, 99);
                 $row['snapshot_id'] = $snapshot->getKey();
                 SupplyReliabilityRow::query()->create($row);
             }

--- a/tests/Unit/Reporting/Contracts/ReportExecutionContractTest.php
+++ b/tests/Unit/Reporting/Contracts/ReportExecutionContractTest.php
@@ -293,6 +293,19 @@ final class ReportExecutionContractTest extends TestCase
     }
 
     #[Test]
+    public function progress_maps_completed_work_to_a_bounded_stage(): void
+    {
+        $progress = new ReportProgress(5);
+
+        self::assertTrue($progress->advanceProportion(0, 4, 10, 90));
+        self::assertSame(10, $progress->percent());
+        self::assertTrue($progress->advanceProportion(1, 4, 10, 90));
+        self::assertSame(30, $progress->percent());
+        self::assertTrue($progress->advanceProportion(4, 4, 10, 90));
+        self::assertSame(90, $progress->percent());
+    }
+
+    #[Test]
     public function window_sort_validates_its_field(): void
     {
         $sort = new ReportWindowSort('created_at', ReportSortDirection::DESC);


### PR DESCRIPTION
## Что изменено
- добавлено пропорциональное продвижение по этапам материализации
- тяжёлые отчёты закупок и складских рисков публикуют реальный процент
- добавлен контрактный тест расчёта прогресса

## Проверки
- php -l для изменённых PHP-файлов
- git diff --check
- PHPUnit/PHPStan локально недоступны без vendor; обязательны в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added `advanceProportion` method to `ReportProgress` DTO to calculate and update progress percentages based on loop iterations.</li>
<li>Updated `InventoryRiskSnapshotMaterializer` to use `advanceProportion` for granular progress tracking during data processing loops.</li>
<li>Updated `SupplierAwardSnapshotMaterializer`, `ProcurementCycleSnapshotMaterializer`, and `SupplyReliabilitySnapshotMaterializer` to include more frequent progress updates.</li>
<li>Added unit tests in `ReportExecutionContractTest` to verify the new progress tracking functionality.</li>
</ul></div>