### PR TITLE
fix[admin]: поддержать query builder в отчётах охраны труда

### DIFF
--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
@@ -27,6 +27,7 @@ use App\Jobs\ReportingSourceBackfillJob;
 use Carbon\CarbonImmutable;
 use DomainException;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -784,7 +785,7 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
         return true;
     }
 
-    private function applyFilter(Builder $builder, string $column, mixed $value): void
+    private function applyFilter(Builder|QueryBuilder $builder, string $column, mixed $value): void
     {
         $values = $this->filterValues($value);
         if ($values !== []) {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class WorkforceAdmissionCandidateContract
     public const FORMULA_VERSION = 'workforce_admission_v1';
     public const SOURCE_SCHEMA_VERSION = 'workforce_admission_v1';
     public const FORMULA_HASH = '4df1641fb5a5c69fffbc38b3a7ad11abe2d81869d15f46ce47be44384e43f106';
-    public const SOURCE_HASH = 'ba87a104f95684c44878c4bf0ad12448275852889c13f75660dd0243821a3643';
+    public const SOURCE_HASH = '6f0be666f73942d5a7a73bb1a8b6b57118bdf8bfc36f522520a32442a732966f';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class SafetyIncidentActionsCandidateContract
     public const FORMULA_VERSION = 'safety_incident_actions_v1';
     public const SOURCE_SCHEMA_VERSION = 'safety_incident_actions_v1';
     public const FORMULA_HASH = 'f0e98a08eb88ece897c5e552142134cf8b3247fcd8e19a873760b7fad399c790';
-    public const SOURCE_HASH = '8ed3cc6b01f56a103cdb2ab2b9264bc6e859859e32aecee3c735aaeffb0fb5bd';
+    public const SOURCE_HASH = '8184f3ab703f82e6f9bc8043aef46d19f0a2f7eff1f884846f9b068538817f73';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
@@ -26,6 +26,7 @@ use App\Jobs\ReportingSourceBackfillJob;
 use App\Jobs\SafetyExposureZeroFillJob;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -845,7 +846,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
         }
     }
 
-    private function applyFilter(Builder $builder, string $column, mixed $value): void
+    private function applyFilter(Builder|QueryBuilder $builder, string $column, mixed $value): void
     {
         $values = $this->filterValues($value);
         if ($values !== []) {


### PR DESCRIPTION
## Причина
Фильтры отчётов были типизированы только Eloquent Builder, хотя источники назначений и исторических таблиц строятся через Query Builder.

## Исправление
- общий фильтр принимает оба штатных Laravel builder
- исправлены оба отчёта охраны труда с тем же паттерном
- обновлены fail-closed source pins

## Проверки
- php -l
- git diff --check