### PR TITLE
fix[admin]: поддержать query scope отчётов охраны труда

### DIFF
--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
@@ -793,7 +793,7 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
         }
     }
 
-    private function applyResourceScope(Builder $builder, array $resources): void
+    private function applyResourceScope(Builder|QueryBuilder $builder, array $resources): void
     {
         if ($resources === []) {
             return;

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class WorkforceAdmissionCandidateContract
     public const FORMULA_VERSION = 'workforce_admission_v1';
     public const SOURCE_SCHEMA_VERSION = 'workforce_admission_v1';
     public const FORMULA_HASH = '4df1641fb5a5c69fffbc38b3a7ad11abe2d81869d15f46ce47be44384e43f106';
-    public const SOURCE_HASH = '6f0be666f73942d5a7a73bb1a8b6b57118bdf8bfc36f522520a32442a732966f';
+    public const SOURCE_HASH = '828cd5cd710c36c73882e62ade60e9e89fd15ad6f244724f503995dd906f8dad';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class SafetyIncidentActionsCandidateContract
     public const FORMULA_VERSION = 'safety_incident_actions_v1';
     public const SOURCE_SCHEMA_VERSION = 'safety_incident_actions_v1';
     public const FORMULA_HASH = 'f0e98a08eb88ece897c5e552142134cf8b3247fcd8e19a873760b7fad399c790';
-    public const SOURCE_HASH = '8184f3ab703f82e6f9bc8043aef46d19f0a2f7eff1f884846f9b068538817f73';
+    public const SOURCE_HASH = 'd52fda6ba9b3fccfad9f57a9a427a6bb2dd9fec45ef4767c1ceffb832b59a349';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
@@ -854,7 +854,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
         }
     }
 
-    private function applyResourceScope(Builder $builder, array $resources): void
+    private function applyResourceScope(Builder|QueryBuilder $builder, array $resources): void
     {
         if ($resources === []) {
             return;


### PR DESCRIPTION
Расширена типизация общей проверки resource scope на Eloquent и Query Builder в обоих отчётах охраны труда; source pins обновлены.