### PR TITLE
fix[admin]: читать строки по materialized identity

### DIFF
--- a/app/Support/Reporting/EloquentOwnerReportRows.php
+++ b/app/Support/Reporting/EloquentOwnerReportRows.php
@@ -137,7 +137,10 @@ final readonly class EloquentOwnerReportRows
             ->first();
 
         if (! $record instanceof Model
-            || ! hash_equals((string) $record->getAttribute('source_hash'), $snapshot->sourceHash->value)) {
+            || ! hash_equals(
+                (string) $record->getAttribute('source_hash'),
+                $snapshot->materializedSourceHash->value,
+            )) {
             throw new DomainException('Report snapshot is unavailable for the current scope.');
         }
 

--- a/tests/Architecture/Reporting/ReportRowMaterializedIdentityContractTest.php
+++ b/tests/Architecture/Reporting/ReportRowMaterializedIdentityContractTest.php
@@ -18,6 +18,7 @@ final class ReportRowMaterializedIdentityContractTest extends TestCase
             'app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Queries/WorkforceAdmissionRowQuery.php',
             'app/BusinessModules/Features/WorkforceManagement/Reporting/Infrastructure/DatabasePayrollReadinessAdapter.php',
             'app/BusinessModules/Features/TimeTracking/Reporting/Infrastructure/DatabaseProjectLaborCostAdapter.php',
+            'app/Support/Reporting/EloquentOwnerReportRows.php',
         ] as $file) {
             $source = file_get_contents(base_path($file));
             self::assertIsString($source, $file);


### PR DESCRIPTION
Исправляет общий reader строк owner-снимков: физическая запись проверяется по materialized source hash, при этом каноническая identity запуска остаётся неизменной. Добавлен архитектурный контракт.