### PR TITLE
fix[admin]: обслуживать подготовку источников отчётов

### DIFF
--- a/app/Jobs/ReportingSourceBackfillJob.php
+++ b/app/Jobs/ReportingSourceBackfillJob.php
@@ -33,7 +33,10 @@ final class ReportingSourceBackfillJob implements ShouldBeUniqueUntilProcessing,
     public function __construct(
         public readonly int $organizationId,
         public readonly string $sourceCode,
-    ) {}
+    ) {
+        $this->onConnection('redis_reports');
+        $this->onQueue('reports');
+    }
 
     public function uniqueId(): string
     {

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -44,6 +44,8 @@ final class ReportingSourcePersistenceContractTest extends TestCase
         self::assertStringContainsString("->string('completed_owner_checksum', 64)", $migration);
         self::assertStringContainsString('lockForUpdate()', $job);
         self::assertStringContainsString('ShouldBeUniqueUntilProcessing', $job);
+        self::assertStringContainsString("\$this->onConnection('redis_reports')", $job);
+        self::assertStringContainsString("\$this->onQueue('reports')", $job);
         self::assertStringContainsString("'status' => 'pending'", $job);
         self::assertStringContainsString("'completed_owner_checksum' => null", $job);
         self::assertStringContainsString('->afterCommit()', $job);


### PR DESCRIPTION
Направляет общий backfill источников качества и охраны труда в production-очередь reports/redis_reports. Закреплено контрактным тестом.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Configured the ReportingSourceBackfillJob to use the 'redis_reports' connection.</li>
<li>Updated the ReportingSourceBackfillJob to use the 'reports' queue.</li>
<li>Added unit test assertions to verify the new connection and queue configuration in the job.</li>
</ul></div>