### PR TITLE
fix[admin]: показывать документированные пропуски охраны труда

### DIFF
--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
@@ -48,7 +48,7 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
     {
         $organizationId = $context->scope->organizationId;
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::WORKFORCE_ADMISSION);
-        $ledgerBinding = CompletedReportSourceLedgerBinding::capture(
+        $ledgerBinding = CompletedReportSourceLedgerBinding::captureWithDocumentedGaps(
             $organizationId,
             [ReportingSourceBackfillJob::WORKFORCE_ADMISSION],
         );

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
@@ -44,7 +44,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
         $organizationId = $context->scope->organizationId;
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::SAFETY_INCIDENTS);
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::SAFETY_EXPOSURE);
-        $ledgerBinding = CompletedReportSourceLedgerBinding::capture(
+        $ledgerBinding = CompletedReportSourceLedgerBinding::captureWithDocumentedGaps(
             $organizationId,
             [
                 ReportingSourceBackfillJob::SAFETY_INCIDENTS,

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -60,6 +60,21 @@ final class ReportingSourcePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function safety_reports_preserve_documented_source_gaps(): void
+    {
+        foreach ([
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/'
+                .'WorkforceAdmissionSnapshotMaterializer.php',
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/'
+                .'SafetyIncidentSnapshotMaterializer.php',
+        ] as $file) {
+            $materializer = file_get_contents($file);
+            self::assertIsString($materializer);
+            self::assertStringContainsString('captureWithDocumentedGaps', $materializer);
+        }
+    }
+
+    #[Test]
     public function workforce_evidence_is_temporal_and_snapshot_rows_pin_an_exact_version(): void
     {
         $migration = file_get_contents(


### PR DESCRIPTION
Safety-отчёты принимают завершённые source-ledger поколения с документированными gaps/unknowns и отражают их в качестве результата вместо бесконечного REPORT_SOURCE_UNAVAILABLE. Integrity и owner-generation проверки сохраняются.