### PR TITLE
fix[admin]: завершать пустой допуск персонала с прогрессом

### DIFF
--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/WorkforceAdmissionReportProvider.php
@@ -45,7 +45,7 @@ final readonly class WorkforceAdmissionReportProvider implements ReportDataProvi
         ReportQuery $query,
         ReportProgress $progress,
     ): ReportSnapshotRef {
-        $record = $this->materializer->materialize($context, $query);
+        $record = $this->materializer->materialize($context, $query, $progress);
         $progress->advance(100);
         if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
             $this->sealBackfill->ensureCovered('workforce_admission');

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/WorkforceAdmissionSnapshotMaterializer.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSna
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
@@ -44,19 +45,23 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
         private ReportSnapshotSealStore $seals,
     ) {}
 
-    public function materialize(ReportExecutionContext $context, ReportQuery $query): SafetyAdmissionSnapshot
-    {
+    public function materialize(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): SafetyAdmissionSnapshot {
         $organizationId = $context->scope->organizationId;
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::WORKFORCE_ADMISSION);
         $ledgerBinding = CompletedReportSourceLedgerBinding::captureWithDocumentedGaps(
             $organizationId,
             [ReportingSourceBackfillJob::WORKFORCE_ADMISSION],
         );
+        $progress->advance(5);
 
         return ReportSnapshotFirstWriter::run(
             'workforce_admission:'.$organizationId.':'.$query->definition->definitionHash->value
             .':'.$query->queryHash->value.':'.$query->asOf->format(DATE_ATOM),
-            fn (): SafetyAdmissionSnapshot => $this->materializeLocked($context, $query, $ledgerBinding),
+            fn (): SafetyAdmissionSnapshot => $this->materializeLocked($context, $query, $ledgerBinding, $progress),
         );
     }
 
@@ -64,6 +69,7 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
         ReportExecutionContext $context,
         ReportQuery $query,
         array $ledgerBinding,
+        ReportProgress $progress,
     ): SafetyAdmissionSnapshot {
         $organizationId = $context->scope->organizationId;
         CompletedReportSourceLedgerBinding::lockAndAssertOwnerGeneration($organizationId, $ledgerBinding);
@@ -77,7 +83,9 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
             $asOf,
             $query,
         );
-        $projection = $this->projection($organizationId, $assignments, $date, $asOf, $query);
+        $progress->advance(20);
+        $projection = $this->projection($organizationId, $assignments, $date, $asOf, $query, $progress);
+        $progress->advance(82);
         $ownerSources = $assignments->map(static fn (object $ownership): object => (object) [
             'assignment_id' => $ownership->workforce_assignment_id,
             'employee_id' => $ownership->employee_id,
@@ -164,6 +172,7 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
                 $inputHash,
                 $ledgerBinding,
                 $outputHash,
+                $progress,
                 $sourceHash,
                 $scopeHash,
             ): SafetyAdmissionSnapshot {
@@ -187,6 +196,7 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
                     $inputHash,
                     $ledgerBinding,
                     $outputHash,
+                    $progress,
                     $sourceHash,
                     $scopeHash,
                 ): SafetyAdmissionSnapshot {
@@ -225,7 +235,9 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
                         'generated_at' => $generatedAt,
                         'stale_at' => $generatedAt->addMinutes(15),
                     ]);
-                    foreach ($rows as $row) {
+                    $rowCount = count($rows);
+                    foreach ($rows as $rowIndex => $row) {
+                        $progress->advanceProportion($rowIndex, $rowCount, 90, 98);
                         SafetyAdmissionRow::query()->create([
                             'organization_id' => $organizationId,
                             'snapshot_id' => $snapshot->id,
@@ -383,6 +395,7 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
         CarbonImmutable $date,
         CarbonImmutable $asOf,
         ReportQuery $query,
+        ReportProgress $progress,
     ): array {
         $rows = [];
         $metrics = [];
@@ -395,17 +408,9 @@ final readonly class WorkforceAdmissionSnapshotMaterializer
         $gapCount = 0;
         $resolvedEvidenceVersions = [];
 
-        if ($assignments->isEmpty()) {
-            $projectIds = $query->scope->projectIds;
-            $siteIds = $this->filterValues($query->filters->values['safety_site_id'] ?? $query->filters->values['site_id'] ?? null);
-            if (count($projectIds) !== 1 || count($siteIds) !== 1) {
-                throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
-            }
-            $policy = $this->policy($organizationId, (int) $projectIds[0], (int) $siteIds[0], $date, $asOf);
-            $policies[(int) $policy->id] = $policy;
-        }
-
-        foreach ($assignments as $assignment) {
+        $assignmentCount = $assignments->count();
+        foreach ($assignments as $assignmentIndex => $assignment) {
+            $progress->advanceProportion($assignmentIndex, $assignmentCount, 20, 80);
             $policy = $this->policy(
                 $organizationId,
                 (int) $assignment->project_id,

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/WorkforceAdmissionCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class WorkforceAdmissionCandidateContract
     public const FORMULA_VERSION = 'workforce_admission_v1';
     public const SOURCE_SCHEMA_VERSION = 'workforce_admission_v1';
     public const FORMULA_HASH = '4df1641fb5a5c69fffbc38b3a7ad11abe2d81869d15f46ce47be44384e43f106';
-    public const SOURCE_HASH = '4e55396c2e0057c7728f8684b10d0294bef0489effab6cda92d1e7ca73edb441';
+    public const SOURCE_HASH = 'f640304f456761c5729174acfc502e02ea97bde2edb636ceafb8155590effa1b';
 
     public function filters(): array
     {

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -75,6 +75,26 @@ final class ReportingSourcePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function workforce_admission_finishes_empty_scopes_and_reports_live_progress(): void
+    {
+        $materializer = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Services/'
+                .'WorkforceAdmissionSnapshotMaterializer.php',
+        );
+        $provider = file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Features/SafetyManagement/Reporting/Admission/Providers/'
+                .'WorkforceAdmissionReportProvider.php',
+        );
+
+        self::assertIsString($materializer);
+        self::assertIsString($provider);
+        self::assertStringNotContainsString('if ($assignments->isEmpty())', $materializer);
+        self::assertStringContainsString('ReportProgress $progress', $materializer);
+        self::assertStringContainsString('advanceProportion(', $materializer);
+        self::assertStringContainsString('materialize($context, $query, $progress)', $provider);
+    }
+
+    #[Test]
     public function workforce_evidence_is_temporal_and_snapshot_rows_pin_an_exact_version(): void
     {
         $migration = file_get_contents(


### PR DESCRIPTION
Исправляет системный сценарий пустого отчёта допуска персонала: отсутствие назначений больше не требует искусственно выбранной площадки и завершается корректным пустым снимком. Передаёт живой прогресс в материализатор и обновляет его по этапам чтения, расчёта и сохранения строк. Добавлен регрессионный контракт, обновлён fail-closed source pin.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated ReportProgress into WorkforceAdmissionSnapshotMaterializer and WorkforceAdmissionReportProvider to track and report materialization progress.</li>
<li>Implemented granular progress tracking using advanceProportion during assignment processing and row creation.</li>
<li>Removed the conditional logic that handled empty assignments in the projection method.</li>
<li>Updated the WorkforceAdmissionCandidateContract with a new SOURCE_HASH.</li>
<li>Added a unit test to verify the integration of ReportProgress and the removal of the empty assignment check.</li>
</ul></div>