### PR TITLE
fix[admin]: показывать прогресс отчетов по событиям

### DIFF
--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Providers/QualityDefectFlowReportProvider.php
@@ -45,7 +45,7 @@ final readonly class QualityDefectFlowReportProvider implements ReportDataProvid
         ReportQuery $query,
         ReportProgress $progress,
     ): ReportSnapshotRef {
-        $snapshot = $this->materializer->materialize($context, $query);
+        $snapshot = $this->materializer->materialize($context, $query, $progress);
         $progress->advance(100);
         if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
             $this->sealBackfill->ensureCovered('quality_defect_flow');

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/QualityDefectFlowCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class QualityDefectFlowCandidateContract
     public const FORMULA_VERSION = 'quality_defect_flow_v1';
     public const SOURCE_SCHEMA_VERSION = 'quality_defect_flow_v1';
     public const FORMULA_HASH = 'acae0365d20840207443202b4e9992034797843ac61e64382823e398edbc3f7a';
-    public const SOURCE_HASH = '706958dabc86df2589e14ca82ae6af35030fb9cc3753ee31ab6dfffc21068ac7';
+    public const SOURCE_HASH = '31b7affddff5870f8628a2405e9892588d126322f49d44bc6a59ad38e08d3fa0';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/QualityControl/Reporting/DefectFlow/Services/QualityDefectFlowSnapshotMaterializer.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSna
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
@@ -34,19 +35,23 @@ final readonly class QualityDefectFlowSnapshotMaterializer
         private ReportSnapshotSealStore $seals,
     ) {}
 
-    public function materialize(ReportExecutionContext $context, ReportQuery $query): QualityDefectFlowSnapshot
-    {
+    public function materialize(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): QualityDefectFlowSnapshot {
         $organizationId = $context->scope->organizationId;
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::QUALITY_DEFECTS);
         $ledgerBinding = CompletedReportSourceLedgerBinding::captureWithDocumentedGaps(
             $organizationId,
             [ReportingSourceBackfillJob::QUALITY_DEFECTS],
         );
+        $progress->advance(5);
 
         return ReportSnapshotFirstWriter::run(
             'quality_defect_flow:'.$organizationId.':'.$query->definition->definitionHash->value
             .':'.$query->queryHash->value.':'.$query->asOf->format(DATE_ATOM),
-            fn (): QualityDefectFlowSnapshot => $this->materializeLocked($context, $query, $ledgerBinding),
+            fn (): QualityDefectFlowSnapshot => $this->materializeLocked($context, $query, $ledgerBinding, $progress),
         );
     }
 
@@ -54,6 +59,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
         ReportExecutionContext $context,
         ReportQuery $query,
         array $ledgerBinding,
+        ReportProgress $progress,
     ): QualityDefectFlowSnapshot {
         $organizationId = $context->scope->organizationId;
         CompletedReportSourceLedgerBinding::lockAndAssertOwnerGeneration($organizationId, $ledgerBinding);
@@ -68,6 +74,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
             $asOf,
         );
         $events = $this->filterSubjects($events, $query, $periodFrom, $periodTo);
+        $progress->advance(20);
         $projectIds = $events->pluck('project_id')
             ->map(static fn (mixed $id): int => (int) $id)
             ->unique()
@@ -75,7 +82,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
             ->values()
             ->all();
         $policies = $this->policies($organizationId, $projectIds, $asOf);
-        $analysis = $this->analyze($events, $periodFrom, $periodTo, $asOf, $policies);
+        $analysis = $this->analyze($events, $periodFrom, $periodTo, $asOf, $policies, $progress);
         $ownerTransitionCount = $this->ownerTransitionCount(
             $organizationId,
             $context->scope->projectIds,
@@ -84,6 +91,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
             $query,
         );
         $analysis['gaps'] += max(0, $ownerTransitionCount - $events->count());
+        $progress->advance(85);
         $policyIds = collect($policies)->pluck('id')->map(static fn (mixed $id): int => (int) $id)->unique()->sort()->values()->all();
         $inputHash = hash('sha256', CanonicalJson::encode([
             'event_hashes' => $events->pluck('event_hash')->all(),
@@ -122,6 +130,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
                 $inputHash,
                 $ledgerBinding,
                 $outputHash,
+                $progress,
                 $sourceHash,
                 $scopeHash,
                 $query,
@@ -145,6 +154,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
                     $inputHash,
                     $ledgerBinding,
                     $outputHash,
+                    $progress,
                     $sourceHash,
                     $scopeHash,
                     $query,
@@ -187,7 +197,9 @@ final readonly class QualityDefectFlowSnapshotMaterializer
                         'stale_at' => $generatedAt->addDay(),
                     ]);
 
-                    foreach ($analysis['rows'] as $row) {
+                    $rowCount = count($analysis['rows']);
+                    foreach ($analysis['rows'] as $rowIndex => $row) {
+                        $progress->advanceProportion($rowIndex, $rowCount, 90, 98);
                         QualityDefectFlowRow::query()->create([
                             'organization_id' => $organizationId,
                             'snapshot_id' => $snapshot->id,
@@ -362,6 +374,7 @@ final readonly class QualityDefectFlowSnapshotMaterializer
         CarbonImmutable $periodTo,
         CarbonImmutable $asOf,
         array $policies,
+        ReportProgress $progress,
     ): array {
         $rows = [];
         $states = [];
@@ -375,7 +388,9 @@ final readonly class QualityDefectFlowSnapshotMaterializer
         $gaps = 0;
         $unknowns = 0;
 
-        foreach ($events as $event) {
+        $eventCount = $events->count();
+        foreach ($events as $eventIndex => $event) {
+            $progress->advanceProportion($eventIndex, $eventCount, 20, 75);
             $defectId = (int) $event->quality_defect_id;
             $policy = $policies[(int) $event->project_id] ?? null;
             if (! $policy instanceof QualityDefectFlowPolicyVersion) {
@@ -478,7 +493,11 @@ final readonly class QualityDefectFlowSnapshotMaterializer
         $matureCohortCount = 0;
         $firstPassCount = 0;
         $matureReopenedCount = 0;
+        $stateCount = count($states);
+        $completedStates = 0;
         foreach ($states as $state) {
+            $progress->advanceProportion($completedStates, $stateCount, 75, 82);
+            $completedStates++;
             if ($state['due_date'] !== null && $state['due_date']->startOfDay() <= $asOf->startOfDay()) {
                 $dueCount++;
                 if ($state['current_open'] && $state['due_date']->startOfDay() < $asOf->startOfDay()) {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Providers/SafetyIncidentActionsReportProvider.php
@@ -45,7 +45,7 @@ final readonly class SafetyIncidentActionsReportProvider implements ReportDataPr
         ReportQuery $query,
         ReportProgress $progress,
     ): ReportSnapshotRef {
-        $record = $this->materializer->materialize($context, $query);
+        $record = $this->materializer->materialize($context, $query, $progress);
         $progress->advance(100);
         if ($query->definition->snapshotClassification === ReportSnapshotClassification::OFFICIAL) {
             $this->sealBackfill->ensureCovered('safety_incident_actions');

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/SafetyIncidentActionsCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class SafetyIncidentActionsCandidateContract
     public const FORMULA_VERSION = 'safety_incident_actions_v1';
     public const SOURCE_SCHEMA_VERSION = 'safety_incident_actions_v1';
     public const FORMULA_HASH = 'f0e98a08eb88ece897c5e552142134cf8b3247fcd8e19a873760b7fad399c790';
-    public const SOURCE_HASH = '7a030f41819abe4b2624b42a609f71642ba54a929f9a0cfd7446f971273b2c5e';
+    public const SOURCE_HASH = '09e0998183152ba7d5104a85d1e4bfdd836c21f87bc4584ac3bc423e52ff76bf';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/SafetyManagement/Reporting/IncidentActions/Services/SafetyIncidentSnapshotMaterializer.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Contracts\Execution\ReportSna
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScopedResource;
 use App\BusinessModules\Core\Reporting\Domain\ValueObjects\Sha256Hash;
@@ -39,8 +40,11 @@ final readonly class SafetyIncidentSnapshotMaterializer
         private ReportSnapshotSealStore $seals,
     ) {}
 
-    public function materialize(ReportExecutionContext $context, ReportQuery $query): SafetyIncidentSnapshot
-    {
+    public function materialize(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): SafetyIncidentSnapshot {
         $organizationId = $context->scope->organizationId;
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::SAFETY_INCIDENTS);
         ReportingSourceBackfillJob::request($organizationId, ReportingSourceBackfillJob::SAFETY_EXPOSURE);
@@ -51,11 +55,12 @@ final readonly class SafetyIncidentSnapshotMaterializer
                 ReportingSourceBackfillJob::SAFETY_EXPOSURE,
             ],
         );
+        $progress->advance(5);
 
         return ReportSnapshotFirstWriter::run(
             'safety_incident_actions:'.$organizationId.':'.$query->definition->definitionHash->value
             .':'.$query->queryHash->value.':'.$query->asOf->format(DATE_ATOM),
-            fn (): SafetyIncidentSnapshot => $this->materializeLocked($context, $query, $ledgerBinding),
+            fn (): SafetyIncidentSnapshot => $this->materializeLocked($context, $query, $ledgerBinding, $progress),
         );
     }
 
@@ -63,6 +68,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
         ReportExecutionContext $context,
         ReportQuery $query,
         array $ledgerBinding,
+        ReportProgress $progress,
     ): SafetyIncidentSnapshot {
         $organizationId = $context->scope->organizationId;
         $this->assertPublicFilterValues($query);
@@ -82,6 +88,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
             $asOf,
         );
         $events = $this->filterSubjects($events, $query, $periodFrom, $periodTo);
+        $progress->advance(20);
         $projectIds = $events->pluck('project_id')
             ->map(static fn (mixed $id): int => (int) $id)
             ->unique()
@@ -104,7 +111,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
             $periodFrom,
             $periodTo,
         );
-        $analysis = $this->analyze($events, $periodFrom, $periodTo, $asOf, $policies, $sites);
+        $analysis = $this->analyze($events, $periodFrom, $periodTo, $asOf, $policies, $sites, $progress);
         $ownerSubjectCount = $this->ownerSubjectCount(
             $organizationId,
             $context->scope->projectIds,
@@ -129,6 +136,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
         $missingExposureDays = max(0, $coverage['expected_days'] - $coverage['projected_days']);
         $analysis['gaps'] += $missingExposureDays;
         $analysis['unknowns'] += $missingExposureDays;
+        $progress->advance(85);
         $multipliers = collect($policies)->pluck('frequency_multiplier')->map(static fn (mixed $value): int => (int) $value)->unique();
         $emptyPolicyIndependent = $policies === [] && $analysis['rows'] === [];
         if (! $emptyPolicyIndependent && $multipliers->count() !== 1) {
@@ -196,6 +204,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
                 $inputHash,
                 $ledgerBinding,
                 $outputHash,
+                $progress,
                 $sourceHash,
                 $scopeHash,
             ): SafetyIncidentSnapshot {
@@ -221,6 +230,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
                     $inputHash,
                     $ledgerBinding,
                     $outputHash,
+                    $progress,
                     $sourceHash,
                     $scopeHash,
                 ): SafetyIncidentSnapshot {
@@ -258,7 +268,9 @@ final readonly class SafetyIncidentSnapshotMaterializer
                         'generated_at' => $generatedAt,
                         'stale_at' => $generatedAt->addDay(),
                     ]);
-                    foreach ($analysis['rows'] as $row) {
+                    $rowCount = count($analysis['rows']);
+                    foreach ($analysis['rows'] as $rowIndex => $row) {
+                        $progress->advanceProportion($rowIndex, $rowCount, 90, 98);
                         SafetyIncidentRow::query()->create([
                             'organization_id' => $organizationId,
                             'snapshot_id' => $snapshot->id,
@@ -459,6 +471,7 @@ final readonly class SafetyIncidentSnapshotMaterializer
         CarbonImmutable $asOf,
         array $policies,
         Collection $sites,
+        ReportProgress $progress,
     ): array {
         $rows = [];
         $lastVersion = [];
@@ -471,7 +484,9 @@ final readonly class SafetyIncidentSnapshotMaterializer
         $incidentSubjects = [];
         $violationSubjects = [];
 
-        foreach ($events as $event) {
+        $eventCount = $events->count();
+        foreach ($events as $eventIndex => $event) {
+            $progress->advanceProportion($eventIndex, $eventCount, 20, 75);
             $policy = $policies[(int) $event->project_id] ?? null;
             if (! $policy instanceof SafetyIncidentPolicyVersion) {
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
@@ -581,7 +596,11 @@ final readonly class SafetyIncidentSnapshotMaterializer
         $actionDue = 0;
         $actionOverdue = 0;
         $actionClosedOnTime = 0;
+        $stateCount = count($states);
+        $completedStates = 0;
         foreach ($states as $key => $state) {
+            $progress->advanceProportion($completedStates, $stateCount, 75, 82);
+            $completedStates++;
             if (! str_starts_with($key, 'corrective_action:') || $state['due_date'] === null) {
                 continue;
             }

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -95,6 +95,36 @@ final class ReportingSourcePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function safety_and_quality_event_reports_publish_live_progress(): void
+    {
+        foreach ([
+            ['SafetyManagement/Reporting/IncidentActions', 'SafetyIncident'],
+            ['QualityControl/Reporting/DefectFlow', 'QualityDefectFlow'],
+        ] as [$module, $report]) {
+            $materializer = file_get_contents(
+                dirname(__DIR__, 4).'/app/BusinessModules/Features/'.$module.'/Services/'
+                    .$report.'SnapshotMaterializer.php',
+            );
+            $provider = file_get_contents(
+                dirname(__DIR__, 4).'/app/BusinessModules/Features/'.$module.'/Providers/'
+                    .$report.'ActionsReportProvider.php',
+            );
+            if ($report === 'QualityDefectFlow') {
+                $provider = file_get_contents(
+                    dirname(__DIR__, 4).'/app/BusinessModules/Features/'.$module.'/Providers/'
+                        .$report.'ReportProvider.php',
+                );
+            }
+
+            self::assertIsString($materializer);
+            self::assertIsString($provider);
+            self::assertStringContainsString('ReportProgress $progress', $materializer);
+            self::assertStringContainsString('advanceProportion(', $materializer);
+            self::assertStringContainsString('materialize($context, $query, $progress)', $provider);
+        }
+    }
+
+    #[Test]
     public function workforce_evidence_is_temporal_and_snapshot_rows_pin_an_exact_version(): void
     {
         $migration = file_get_contents(


### PR DESCRIPTION
Передаёт наблюдаемый прогресс в материализаторы отчётов по инцидентам и дефектам. Процент обновляется пропорционально обработанным событиям, итоговым состояниям и сохранённым строкам. Добавлен регрессионный контракт и обновлены fail-closed source pins.