### PR TITLE
fix[admin]: обработать границу истории параметров отчёта

### DIFF
--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsService.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Options/AcceptedProductionOptionsService.php
@@ -50,7 +50,20 @@ final readonly class AcceptedProductionOptionsService
             $asOf,
             'ru-RU',
         );
-        $snapshot = $this->source->snapshot($projectScope, $query);
+        try {
+            $snapshot = $this->source->snapshot($projectScope, $query);
+        } catch (ReportContractException $exception) {
+            if ($exception->errorCode !== ReportErrorCode::REPORT_FILTER_RANGE_INVALID) {
+                throw $exception;
+            }
+
+            return $this->unavailable(
+                $asOf,
+                $periodFrom,
+                $periodTo,
+                'source_history_incomplete',
+            );
+        }
         if (! $snapshot->available) {
             return $this->unavailable($asOf, $periodFrom, $periodTo, $snapshot->reason ?? 'source_unavailable');
         }

--- a/tests/Unit/CompletedWork/Reporting/AcceptedProductionOptionsServiceTest.php
+++ b/tests/Unit/CompletedWork/Reporting/AcceptedProductionOptionsServiceTest.php
@@ -160,6 +160,35 @@ final class AcceptedProductionOptionsServiceTest extends TestCase
         self::assertSame([], $options['statuses']);
     }
 
+    public function test_source_history_boundary_race_returns_unavailable_options(): void
+    {
+        $source = new class implements AcceptedProductionOptionsSource
+        {
+            public function snapshot(ReportScope $scope, ReportQuery $query): AcceptedProductionOptionsSourceSnapshot
+            {
+                throw ReportContractException::fromCode(ReportErrorCode::REPORT_FILTER_RANGE_INVALID);
+            }
+        };
+        $service = new AcceptedProductionOptionsService(
+            $source,
+            new AcceptedProductionBuiltinPublishedReport(new AcceptedProductionCandidateContract),
+            $this->connection,
+        );
+
+        $options = $service->options(
+            $this->scope(),
+            10,
+            new DateTimeImmutable('2026-08-06T14:15:00+03:00'),
+            new DateTimeImmutable('2026-08-01'),
+            new DateTimeImmutable('2026-08-06'),
+        );
+
+        self::assertFalse($options['available']);
+        self::assertSame('source_history_incomplete', $options['reason']);
+        self::assertSame([], $options['works']);
+        self::assertSame([], $options['statuses']);
+    }
+
     public function test_trusted_route_project_narrows_authorized_multi_project_scope(): void
     {
         $options = $this->service(AcceptedProductionOptionsSourceSnapshot::available(


### PR DESCRIPTION
Исправляет штатную гонку между текущим срезом и завершением снимка источника в параметрах отчёта принятой выработки. Endpoint параметров возвращает типизированное source_history_incomplete вместо внутренней ошибки; строгая проверка запуска отчёта сохранена. Добавлен регрессионный тест.\n\nПроверки: php -l изменённых файлов, git diff --check. PHPUnit локально недоступен: vendor отсутствует; CI обязателен.