### PR TITLE
fix[admin]: добавить живой прогресс принятой выработки

### DIFF
--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/AcceptedProductionCandidateContract.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/AcceptedProductionCandidateContract.php
@@ -49,7 +49,7 @@ final readonly class AcceptedProductionCandidateContract
     public const FORMULA_VERSION = 'accepted_production.v1';
     public const SOURCE_SCHEMA_VERSION = 'production_acceptance_events_v2';
     public const FORMULA_HASH = '839ea0b2787a0d73872bf5f7a63292437abaae05abb108ae92731abe3264f06b';
-    public const SOURCE_HASH = '620c23ba9f377b1b1b0b963a3b8dc39e5c3824920af37f715a429f0203981813';
+    public const SOURCE_HASH = 'f6f4f0259f1836978d5f929b91e26e9866b3d138113a98fbff32d710256c2ca5';
 
     public function filters(): array
     {

--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Providers/AcceptedProductionReportProvider.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Providers/AcceptedProductionReportProvider.php
@@ -32,8 +32,8 @@ final readonly class AcceptedProductionReportProvider implements ReportDataProvi
         ReportQuery $query,
         ReportProgress $progress,
     ): ReportSnapshotRef {
-        $progress->advance(10);
-        $snapshot = $this->snapshots->materialize($context->scope, $query);
+        $progress->advance(5);
+        $snapshot = $this->snapshots->materialize($context->scope, $query, $progress);
         $progress->advance(100);
 
         return $snapshot;

--- a/app/Services/CompletedWork/Reporting/AcceptedProduction/Services/AcceptedProductionSnapshotMaterializer.php
+++ b/app/Services/CompletedWork/Reporting/AcceptedProduction/Services/AcceptedProductionSnapshotMaterializer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\CompletedWork\Reporting\AcceptedProduction\Services;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
@@ -33,7 +34,11 @@ final readonly class AcceptedProductionSnapshotMaterializer
         $this->universe = $universe ?? new AcceptedProductionEventUniverse;
     }
 
-    public function materialize(ReportScope $scope, ReportQuery $query): ReportSnapshotRef
+    public function materialize(
+        ReportScope $scope,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): ReportSnapshotRef
     {
         if ($scope->canonicalIdentity() !== $query->scope->canonicalIdentity()
             || $query->definition->snapshotClassification !== ReportSnapshotClassification::OPERATIONAL
@@ -41,6 +46,7 @@ final readonly class AcceptedProductionSnapshotMaterializer
             throw new InvalidArgumentException('accepted_production_materialization_identity_invalid');
         }
 
+        $progress->advance(10);
         $stream = $this->universe->stream($scope, $query);
         if ($stream->gapCount() !== 0) {
             throw new InvalidArgumentException('accepted_production_owner_history_unproven');
@@ -53,23 +59,29 @@ final readonly class AcceptedProductionSnapshotMaterializer
         $stream->updateSourceHash($hashContext);
         hash_update($hashContext, '}');
         $sourceHash = new Sha256Hash(hash_final($hashContext));
+        $progress->advance(20);
         $existing = AcceptedProductionSnapshot::query()
             ->where('organization_id', $scope->organizationId)
             ->where('query_hash', $query->queryHash->value)
             ->where('source_hash', $sourceHash->value)
             ->first();
         if ($existing !== null) {
+            $progress->advance(100);
+
             return $this->reference($scope, $query, $existing);
         }
 
         $rowCount = 0;
         $totalsState = [];
+        $eligibleCount = $stream->eligibleCount();
         foreach ($stream->entries() as $entry) {
+            $progress->advanceProportion($rowCount, $eligibleCount, 20, 65);
             [, $metric] = $this->metric($entry);
             $this->accumulateTotal($totalsState, $metric);
             $rowCount++;
         }
         $totals = $this->finalizeTotals($totalsState);
+        $progress->advance(70);
 
         try {
             return DB::transaction(function () use (
@@ -82,6 +94,7 @@ final readonly class AcceptedProductionSnapshotMaterializer
                 $rowCount,
                 $totals,
                 $lineageFilter,
+                $progress,
             ): ReportSnapshotRef {
                 $snapshotId = (string) Str::ulid();
                 $sourceRefs = [[
@@ -126,7 +139,8 @@ final readonly class AcceptedProductionSnapshotMaterializer
                 ]);
 
                 $rowBatch = [];
-                foreach ($stream->entries() as $entry) {
+                foreach ($stream->entries() as $rowIndex => $entry) {
+                    $progress->advanceProportion($rowIndex, $rowCount, 75, 98);
                     [$item, $metric] = $this->metric($entry);
                     $event = $item['event'];
                     $recognizedOn = $this->grain->day($event, $scope->timezone);
@@ -218,6 +232,7 @@ final readonly class AcceptedProductionSnapshotMaterializer
                 if ($rowBatch !== []) {
                     DB::table('accepted_production_rows')->insert($rowBatch);
                 }
+                $progress->advance(99);
 
                 return $this->reference($scope, $query, $snapshot);
             });

--- a/tests/Feature/Reporting/Waves23/AcceptedProductionMaterializationPostgresTest.php
+++ b/tests/Feature/Reporting/Waves23/AcceptedProductionMaterializationPostgresTest.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractExceptio
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportScope;
 use App\Exceptions\BusinessLogicException;
 use App\Models\CompletedWork;
@@ -153,7 +154,7 @@ final class AcceptedProductionMaterializationPostgresTest extends TestCase
         $snapshot = (new AcceptedProductionSnapshotMaterializer(
             new AcceptedProductionFormula,
             new ProductionAcceptanceRecognitionGrain,
-        ))->materialize($scope, $query);
+        ))->materialize($scope, $query, new ReportProgress(0));
 
         $rows = DB::table('accepted_production_rows')
             ->where('organization_id', $organization->id)

--- a/tests/Unit/Reporting/Waves23/ProductionResourceBoundaryTest.php
+++ b/tests/Unit/Reporting/Waves23/ProductionResourceBoundaryTest.php
@@ -122,6 +122,8 @@ final class ProductionResourceBoundaryTest extends TestCase
             "DB::table('accepted_production_rows')->insert(\$rowBatch)",
             $materializer,
         );
+        self::assertStringContainsString('advanceProportion($rowCount, $eligibleCount, 20, 65)', $materializer);
+        self::assertStringContainsString('advanceProportion($rowIndex, $rowCount, 75, 98)', $materializer);
     }
 
     #[Test]


### PR DESCRIPTION
Материализатор принятой выработки публикует этапы подготовки, пропорциональный прогресс первого прохода по строкам и пропорциональный прогресс записи снимка. Канонический source hash обновлён, добавлен архитектурный контракт прогресса.\n\nПроверки: php -l всех изменённых PHP-файлов, git diff --check. PHPUnit локально недоступен из-за отсутствующего vendor; CI/deploy остаются обязательными.