### PR TITLE
feat[admin]: добавить живой прогресс сложных отчетов

### DIFF
--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardCandidateContract.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/ContractorScorecardCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class ContractorScorecardCandidateContract
     public const FORMULA_VERSION = 'contractor-scorecard.v1';
     public const SOURCE_SCHEMA_VERSION = 'contractor-scorecard.v1';
     public const FORMULA_HASH = 'a965552184893020d8da3da25875a0f6fe1ee7af6c8d5c373dd062b16a6d9d18';
-    public const SOURCE_HASH = 'f2f8e82344c4f11521a0bc16cd6fc992f8ac9b4e64a7ccd482416afc478d9e7b';
+    public const SOURCE_HASH = '8d47d0329ae257a7a5979ee3db0c5b3f04a1143ff77612966b742676fd5ab21a';
 
     public function filters(): array
     {

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Providers/ContractorScorecardReportProvider.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Providers/ContractorScorecardReportProvider.php
@@ -35,8 +35,7 @@ final readonly class ContractorScorecardReportProvider implements ReportDataProv
         ReportQuery $query,
         ReportProgress $progress,
     ): ReportSnapshotRef {
-        $progress->advance(10);
-        $snapshot = $this->materializer->materialize($context, $query);
+        $snapshot = $this->materializer->materialize($context, $query, $progress);
         $progress->advance(100);
 
         return $snapshot;

--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
@@ -11,6 +11,7 @@ use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Models\Contrac
 use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Models\ContractorScorecardRow;
 use App\BusinessModules\ContractorMarketplace\Reporting\Scorecard\Models\ContractorScorecardSnapshot;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportFilterSet;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
@@ -42,8 +43,13 @@ final readonly class ContractorScorecardSnapshotMaterializer
         private ContractorScorecardFormula $formula,
     ) {}
 
-    public function materialize(ReportExecutionContext $context, ReportQuery $query): ReportSnapshotRef
+    public function materialize(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): ReportSnapshotRef
     {
+        $progress->advance(5);
         $asOf = $query->filters->values['as_of'] ?? null;
         if (
             $query->definition->code !== 'contractor_scorecard'
@@ -87,6 +93,7 @@ final readonly class ContractorScorecardSnapshotMaterializer
         );
         [$periodFrom, $periodTo] = $this->cohortBounds($cohortKey, $cohortPeriod);
         $tuple = $this->sources->resolve($context, $query, $periodFrom, $periodTo);
+        $progress->advance(20);
         $components = $this->components($policy);
         $this->assertPinnedSources($tuple, $components);
         $objectiveObservations = $this->observations->load($tuple);
@@ -110,6 +117,7 @@ final readonly class ContractorScorecardSnapshotMaterializer
             $query->asOf,
             $cohortKey,
         );
+        $progress->advance(40);
         $sourceHash = hash('sha256', CanonicalJson::encode([
             'filters' => $query->filters->values,
             'policy_id' => (int) $policy->id,
@@ -141,6 +149,7 @@ final readonly class ContractorScorecardSnapshotMaterializer
             $staleAt,
             $snapshotId,
             $rowCount,
+            $progress,
         ): void {
             DB::table('organizations')
                 ->where('id', $query->scope->organizationId)
@@ -190,7 +199,8 @@ final readonly class ContractorScorecardSnapshotMaterializer
                 ]);
             }
 
-            foreach ($groups as $group) {
+            $groupCount = $groups->count();
+            foreach ($groups as $groupIndex => $group) {
                 $profileId = $group['profile_id'];
                 $categoryId = $group['category_id'];
                 $projectId = $group['project_id'];
@@ -236,8 +246,11 @@ final readonly class ContractorScorecardSnapshotMaterializer
                         'row_key' => $rowKey,
                     ]);
                 }
+                $progress->advanceProportion($groupIndex + 1, $groupCount, 45, 95);
             }
         }, 3);
+
+        $progress->advance(98);
 
         $snapshot = ContractorScorecardSnapshot::query()
             ->where('organization_id', $query->scope->organizationId)

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessCandidateContract.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/HandoverReadinessCandidateContract.php
@@ -20,7 +20,7 @@ final readonly class HandoverReadinessCandidateContract
     public const FORMULA_VERSION = 'handover.v1';
     public const SOURCE_SCHEMA_VERSION = 'handover-readiness.v1';
     public const FORMULA_HASH = '480796625d579f1b2887bc92674efe7dff6e178da9272f34d3da830dca9bb8c5';
-    public const SOURCE_HASH = 'abf160e4af08783cd7f1ad8c08103590efa3334ff84a60a14d66b1f5a781ed21';
+    public const SOURCE_HASH = 'ae87888c76f1f642d28e77969791ecf659851a8bd775a65e859196ae69701c50';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/HandoverReadinessReportProvider.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/HandoverReadinessReportProvider.php
@@ -38,14 +38,14 @@ final readonly class HandoverReadinessReportProvider implements ReportDataProvid
         ReportQuery $query,
         ReportProgress $progress,
     ): ReportSnapshotRef {
-        $progress->advance(10);
-        $provisional = $this->materializer->materialize($context, $query);
-        $progress->advance(100);
+        $provisional = $this->materializer->materialize($context, $query, $progress);
+        $progress->advance(99);
         $canonical = $this->identities->build(
             $query,
             $provisional,
             $this->result($context, $provisional),
         );
+        $progress->advance(100);
 
         return new ReportSnapshotRef(
             kind: $provisional->kind,

--- a/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Services/HandoverReadinessSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Services/HandoverReadinessSnapshotMaterializer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\HandoverAcceptance\Reporting\Readiness\Services;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportExecutionContext;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Domain\Enums\ReportSnapshotClassification;
@@ -29,9 +30,14 @@ final readonly class HandoverReadinessSnapshotMaterializer
 
     public function __construct(private HandoverReadinessFormula $formula) {}
 
-    public function materialize(ReportExecutionContext $context, ReportQuery $query): ReportSnapshotRef
+    public function materialize(
+        ReportExecutionContext $context,
+        ReportQuery $query,
+        ReportProgress $progress,
+    ): ReportSnapshotRef
     {
         $this->assertContext($context, $query);
+        $progress->advance(5);
         $gates = HandoverGateVersion::query()
             ->where('organization_id', $query->scope->organizationId)
             ->where('effective_from', '<=', $query->asOf)
@@ -49,6 +55,7 @@ final readonly class HandoverReadinessSnapshotMaterializer
             ->get()
             ->unique(static fn (HandoverGateVersion $gate): string => $gate->acceptance_scope_id.':'.$gate->gate_code)
             ->values();
+        $progress->advance(20);
 
         $events = HandoverEvidenceEvent::query()
             ->where('organization_id', $query->scope->organizationId)
@@ -57,6 +64,7 @@ final readonly class HandoverReadinessSnapshotMaterializer
             ->orderBy('occurred_at')
             ->orderBy('id')
             ->get();
+        $progress->advance(35);
         $sourceProjection = [
             'as_of' => $query->asOf->format(DATE_ATOM),
             'event_hashes' => $events->pluck('evidence_hash')->all(),
@@ -78,6 +86,7 @@ final readonly class HandoverReadinessSnapshotMaterializer
             $sourceHash,
             $generatedAt,
             $snapshotId,
+            $progress,
         ): void {
             DB::table('organizations')
                 ->where('id', $query->scope->organizationId)
@@ -113,7 +122,8 @@ final readonly class HandoverReadinessSnapshotMaterializer
                 'row_count' => $gates->count(),
             ]);
 
-            foreach ($gates as $gate) {
+            $gateCount = $gates->count();
+            foreach ($gates as $gateIndex => $gate) {
                 $scopeEvents = $events->where('acceptance_scope_id', (int) $gate->acceptance_scope_id);
                 $checklists = [];
                 $evidence = [];
@@ -173,8 +183,11 @@ final readonly class HandoverReadinessSnapshotMaterializer
                     ])->values()->all(),
                     'row_key' => $rowKey,
                 ]);
+                $progress->advanceProportion($gateIndex + 1, $gateCount, 40, 95);
             }
         }, 3);
+
+        $progress->advance(97);
 
         $snapshot = HandoverReadinessSnapshot::query()
             ->where('organization_id', $query->scope->organizationId)

--- a/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ReportingSourcePersistenceContractTest.php
@@ -125,6 +125,34 @@ final class ReportingSourcePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function handover_and_contractor_reports_publish_live_progress(): void
+    {
+        foreach ([
+            [
+                'app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Services/'
+                    .'HandoverReadinessSnapshotMaterializer.php',
+                'app/BusinessModules/Features/HandoverAcceptance/Reporting/Readiness/Providers/'
+                    .'HandoverReadinessReportProvider.php',
+            ],
+            [
+                'app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/'
+                    .'ContractorScorecardSnapshotMaterializer.php',
+                'app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Providers/'
+                    .'ContractorScorecardReportProvider.php',
+            ],
+        ] as [$materializerPath, $providerPath]) {
+            $materializer = file_get_contents(dirname(__DIR__, 4).'/'.$materializerPath);
+            $provider = file_get_contents(dirname(__DIR__, 4).'/'.$providerPath);
+
+            self::assertIsString($materializer);
+            self::assertIsString($provider);
+            self::assertStringContainsString('ReportProgress $progress', $materializer);
+            self::assertStringContainsString('advanceProportion(', $materializer);
+            self::assertStringContainsString('materialize($context, $query, $progress)', $provider);
+        }
+    }
+
+    #[Test]
     public function workforce_evidence_is_temporal_and_snapshot_rows_pin_an_exact_version(): void
     {
         $migration = file_get_contents(


### PR DESCRIPTION
## Что изменено
- материализаторы готовности передачи и карточки подрядчика публикуют этапы прогресса
- длинные циклы обновляют процент пропорционально обработанным группам
- обновлены канонические source hash и контрактный регрессионный тест

## Проверки
- PHP syntax для всех изменённых файлов
- git diff --check
- PHPUnit/PHPStan локально недоступны: vendor отсутствует; обязательная проверка в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated `SOURCE_HASH` constants in `ContractorScorecardCandidateContract` and `HandoverReadinessCandidateContract`.</li>
<li>Refactored `materialize` methods in `ContractorScorecardSnapshotMaterializer` and `HandoverReadinessSnapshotMaterializer` to accept and utilize `ReportProgress` for granular progress tracking.</li>
<li>Updated `ContractorScorecardReportProvider` and `HandoverReadinessReportProvider` to pass `ReportProgress` to the materializer and adjust progress advancement logic.</li>
<li>Implemented `advanceProportion` in `ContractorScorecardSnapshotMaterializer` to provide more accurate progress reporting during loop iterations.</li>
</ul></div>