### PR TITLE
fix[admin]: отделены служебные фильтры цикла закупки

### DIFF
--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/DTO/ProcurementCycleSnapshotRequest.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/DTO/ProcurementCycleSnapshotRequest.php
@@ -28,6 +28,7 @@ final readonly class ProcurementCycleSnapshotRequest
         if ($staleAt !== null && $staleAt < $asOf) {
             throw new InvalidArgumentException('procurement_cycle_snapshot_request_invalid');
         }
+        unset($filters['organization_id'], $filters['project_id']);
         foreach (array_keys($filters) as $key) {
             if (! is_string($key) || ! in_array($key, self::FILTERS, true)) {
                 throw new InvalidArgumentException('procurement_cycle_snapshot_filter_invalid');

--- a/tests/Unit/Procurement/Reporting/Cycle/ProcurementCycleRuntimeContractTest.php
+++ b/tests/Unit/Procurement/Reporting/Cycle/ProcurementCycleRuntimeContractTest.php
@@ -41,6 +41,28 @@ use Tests\Support\Reporting\ReportExecutionContextBuilder;
 
 final class ProcurementCycleRuntimeContractTest extends TestCase
 {
+    public function test_snapshot_request_ignores_canonical_scope_identity_filters(): void
+    {
+        $scope = (new ReportExecutionContextBuilder)->build()->scope;
+
+        $request = new ProcurementCycleSnapshotRequest(
+            $scope,
+            [
+                'organization_id' => (string) $scope->organizationId,
+                'project_id' => (string) $scope->projectIds[0],
+                'period_start' => '2026-07-10',
+                'period_end' => '2026-08-09',
+            ],
+            new DateTimeImmutable('2026-08-09T10:00:00+00:00'),
+            null,
+        );
+
+        self::assertSame([
+            'period_end' => '2026-08-09',
+            'period_start' => '2026-07-10',
+        ], $request->filters);
+    }
+
     public function test_snapshot_request_rejects_project_scope_escape(): void
     {
         $scope = (new ReportExecutionContextBuilder)->build()->scope;


### PR DESCRIPTION
## Что изменено
- служебные идентификаторы организации и проекта исключаются перед валидацией фильтров профильного снимка
- добавлен регрессионный тест на канонический набор фильтров запуска

## Проверки
- PHP syntax для изменённых файлов
- git diff --check
- PHPUnit локально недоступен: vendor отсутствует; тест обязателен в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Modified ProcurementCycleSnapshotRequest to explicitly ignore 'organization_id' and 'project_id' filters.</li>
<li>Added a unit test to verify that canonical scope identity filters are correctly ignored in snapshot requests.</li>
</ul></div>