### PR TITLE
feat[admin]: живой прогресс длительных отчётов

### DIFF
--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceSnapshotMaterializer.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/HoldingPerformanceSnapshotMaterializer.php
@@ -62,6 +62,7 @@ final readonly class HoldingPerformanceSnapshotMaterializer
         ReportProgress $progress,
     ): ReportSnapshotRef {
         $this->assertQuery($context, $query);
+        $progress->advance(5);
         try {
             $coverageStartedAt = $this->events->coverageStartedAt(
                 $this->sources->coverageStartedAt($query->asOf),
@@ -77,11 +78,14 @@ final readonly class HoldingPerformanceSnapshotMaterializer
             if ($batch->gaps !== []) {
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
             }
+            $sourceCount = count($batch->sources);
+            $completedSources = 0;
             foreach ($batch->sources as $source) {
                 if (! $source instanceof HoldingAllocationCheckpointSource) {
                     throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
                 }
                 $this->projector->persist($source->fact, $source->evidence);
+                $progress->advanceProportion(++$completedSources, max(1, $sourceCount), 5, 20);
             }
             $contractVersionIds = array_values(array_unique(array_map(
                 static fn (HoldingAllocationCheckpointSource $source): int => $source->fact->sourceVersion,
@@ -109,6 +113,7 @@ final readonly class HoldingPerformanceSnapshotMaterializer
             if (! $projectionCoverage->complete()) {
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
             }
+            $progress->advance(30);
         } catch (ReportContractException $exception) {
             throw $exception;
         } catch (InvalidArgumentException $exception) {
@@ -139,6 +144,8 @@ final readonly class HoldingPerformanceSnapshotMaterializer
             'projection_coverage_watermark' => $projectionCoverage->watermark,
         ]];
 
+        $factCount = $facts->count();
+        $completedFacts = 0;
         foreach ($facts as $factRecord) {
             $fact = $this->fact($factRecord);
             $metricRows[] = $this->formula->row(
@@ -152,6 +159,7 @@ final readonly class HoldingPerformanceSnapshotMaterializer
                 'source_hash' => (string) $factRecord->source_hash,
                 'source_key' => $fact->sourceKey(),
             ];
+            $progress->advanceProportion(++$completedFacts, max(1, $factCount), 30, 65);
         }
 
         $totals = $this->formula->totals($metricRows);
@@ -230,12 +238,14 @@ final readonly class HoldingPerformanceSnapshotMaterializer
             ->orderBy('id')
             ->get(['id', 'source_hash', 'missing_fields']);
         $projectionGapCount = $projectionGaps->count();
+        $completedGaps = 0;
         foreach ($projectionGaps as $gap) {
             $sourcePayload[] = [
                 'gap_id' => (int) $gap->getKey(),
                 'source_hash' => (string) $gap->source_hash,
                 'missing_fields' => $gap->missing_fields,
             ];
+            $progress->advanceProportion(++$completedGaps, max(1, $projectionGapCount), 65, 75);
         }
         $qualityGapPayload = $projectionGaps
             ->map(static fn (HoldingAllocationProjectionGap $gap): array => [
@@ -268,7 +278,7 @@ final readonly class HoldingPerformanceSnapshotMaterializer
             $sourceHash,
         );
 
-        DB::transaction(function () use ($context, $query, $snapshotId, $generatedAt, $sourceHash, $watermarks, $totals, $unknown, $hierarchyGapCount, $projectionGapCount, $sourceRef, $projectionRows, $hierarchy, $qualityGapWatermark, $recordedCutoff): void {
+        DB::transaction(function () use ($context, $query, $snapshotId, $generatedAt, $sourceHash, $watermarks, $totals, $unknown, $hierarchyGapCount, $projectionGapCount, $sourceRef, $projectionRows, $hierarchy, $qualityGapWatermark, $recordedCutoff, $progress): void {
             HoldingPerformanceSnapshot::query()->create([
                 'id' => $snapshotId,
                 'organization_id' => $context->scope->organizationId,
@@ -296,6 +306,8 @@ final readonly class HoldingPerformanceSnapshotMaterializer
                 'stale_at' => null,
             ]);
 
+            $rowCount = count($projectionRows);
+            $completedRows = 0;
             foreach ($projectionRows as $row) {
                 HoldingPerformanceRow::query()->create([
                     'organization_id' => $context->scope->organizationId,
@@ -311,6 +323,7 @@ final readonly class HoldingPerformanceSnapshotMaterializer
                     'row_key' => $row->rowKey,
                     'source_refs' => $row->sourceRefs,
                 ]);
+                $progress->advanceProportion(++$completedRows, max(1, $rowCount), 75, 95);
             }
         });
 

--- a/app/BusinessModules/Core/MultiOrganization/Reporting/Services/IntercompanyContractFlowSnapshotMaterializer.php
+++ b/app/BusinessModules/Core/MultiOrganization/Reporting/Services/IntercompanyContractFlowSnapshotMaterializer.php
@@ -53,15 +53,19 @@ final readonly class IntercompanyContractFlowSnapshotMaterializer
         ReportProgress $progress,
     ): ReportSnapshotRef {
         $this->assertQuery($context, $query);
+        $progress->advance(5);
         $batch = $this->sources->assemble($context->scope, $query);
         if ($batch->gaps !== []) {
             throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
         }
+        $sourceCount = count($batch->sources);
+        $completedSources = 0;
         foreach ($batch->sources as $source) {
             if (! $source instanceof HoldingAllocationCheckpointSource) {
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE);
             }
             $this->projector->persist($source->fact, $source->evidence);
+            $progress->advanceProportion(++$completedSources, max(1, $sourceCount), 5, 25);
         }
         $hierarchy = $batch->hierarchy;
         $coverageStartedAt = new DateTimeImmutable($batch->coverageStartedAt);
@@ -86,6 +90,8 @@ final readonly class IntercompanyContractFlowSnapshotMaterializer
         ]];
         $unknown = 0;
 
+        $factCount = $facts->count();
+        $completedFacts = 0;
         foreach ($facts as $fact) {
             $currency = $fact->currency === null ? null : (string) $fact->currency;
             $sourceRefs = is_array($fact->source_refs) ? $fact->source_refs : [];
@@ -128,6 +134,7 @@ final readonly class IntercompanyContractFlowSnapshotMaterializer
                 $sourceRefs,
             );
             $sourcePayload[] = ['id' => (int) $fact->getKey(), 'hash' => (string) $fact->source_hash];
+            $progress->advanceProportion(++$completedFacts, max(1, $factCount), 25, 65);
         }
 
         $rows = $this->projectionRows($groups);
@@ -197,12 +204,14 @@ final readonly class IntercompanyContractFlowSnapshotMaterializer
             ->orderBy('id')
             ->get(['id', 'source_hash', 'missing_fields']);
         $projectionGapCount = $projectionGaps->count();
+        $completedGaps = 0;
         foreach ($projectionGaps as $gap) {
             $sourcePayload[] = [
                 'gap_id' => (int) $gap->getKey(),
                 'source_hash' => (string) $gap->source_hash,
                 'missing_fields' => $gap->missing_fields,
             ];
+            $progress->advanceProportion(++$completedGaps, max(1, $projectionGapCount), 65, 75);
         }
         $qualityGapWatermark = hash('sha256', CanonicalJson::encode([
             'recorded_cutoff' => $recordedCutoff->format(DateTimeInterface::ATOM),
@@ -233,7 +242,7 @@ final readonly class IntercompanyContractFlowSnapshotMaterializer
             $sourceHash,
         );
 
-        DB::transaction(function () use ($context, $query, $rows, $totals, $sourceHash, $snapshotId, $watermark, $hierarchyWatermark, $sourceRef, $unknown, $hierarchyGapCount, $hierarchy, $qualityGapWatermark, $projectionGapCount, $recordedCutoff): void {
+        DB::transaction(function () use ($context, $query, $rows, $totals, $sourceHash, $snapshotId, $watermark, $hierarchyWatermark, $sourceRef, $unknown, $hierarchyGapCount, $hierarchy, $qualityGapWatermark, $projectionGapCount, $recordedCutoff, $progress): void {
             IntercompanyContractFlowSnapshot::query()->create([
                 'id' => $snapshotId,
                 'organization_id' => $context->scope->organizationId,
@@ -267,12 +276,15 @@ final readonly class IntercompanyContractFlowSnapshotMaterializer
                 'stale_at' => null,
             ]);
 
+            $rowCount = count($rows);
+            $completedRows = 0;
             foreach ($rows as $row) {
                 IntercompanyContractFlowRow::query()->create([
                     'organization_id' => $context->scope->organizationId,
                     'snapshot_id' => $snapshotId,
                     ...$row,
                 ]);
+                $progress->advanceProportion(++$completedRows, max(1, $rowCount), 75, 95);
             }
         });
 

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Contracts/ProcurementCycleSourceSnapshotWriter.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Contracts/ProcurementCycleSourceSnapshotWriter.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\Procurement\Reporting\Cycle\Contracts;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotHeader;
 
 interface ProcurementCycleSourceSnapshotWriter
 {
-    public function persist(ReportQuery $query): ReportSourceSnapshotHeader;
+    public function persist(ReportQuery $query, ReportProgress $progress): ReportSourceSnapshotHeader;
 }

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleCandidateContract.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/ProcurementCycleCandidateContract.php
@@ -18,7 +18,7 @@ final readonly class ProcurementCycleCandidateContract
 
     public const FORMULA_HASH = '7fa0c79e701d081930247ed67ebe233b5318b16127341898b586600a43463d71';
 
-    public const SOURCE_HASH = '4e123c67b13aac917751deab7c6e8be050d07043a70ba810f9219ebbe5993308';
+    public const SOURCE_HASH = '91e3d0394ba1464adb7c0e4bffdce7acdd391e0cd79728ae372d5e4da13229e0';
 
     public function filters(): array
     {

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/CanonicalProcurementCycleSourceSnapshotWriter.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/CanonicalProcurementCycleSourceSnapshotWriter.php
@@ -6,6 +6,7 @@ namespace App\BusinessModules\Features\Procurement\Reporting\Cycle\Services;
 
 use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStore;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotHeader;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Contracts\ProcurementCycleSourceReader;
 use App\BusinessModules\Features\Procurement\Reporting\Cycle\Contracts\ProcurementCycleSourceSnapshotWriter;
@@ -21,8 +22,9 @@ final readonly class CanonicalProcurementCycleSourceSnapshotWriter implements Pr
         private ReportSourceSnapshotStore $store,
     ) {}
 
-    public function persist(ReportQuery $query): ReportSourceSnapshotHeader
+    public function persist(ReportQuery $query, ReportProgress $progress): ReportSourceSnapshotHeader
     {
+        $progress->advance(10);
         $request = new ProcurementCycleSnapshotRequest(
             $query->scope,
             $query->filters->values,
@@ -39,6 +41,7 @@ final readonly class CanonicalProcurementCycleSourceSnapshotWriter implements Pr
                 $results[] = $this->formula->calculate($events, $policy, $query->asOf);
             },
         );
+        $progress->advance(40);
         $identity = $this->materializer->identity($request, $source, $query->identity);
         $ready = $this->store->findReady($identity);
         if ($ready !== null) {
@@ -52,6 +55,7 @@ final readonly class CanonicalProcurementCycleSourceSnapshotWriter implements Pr
             $results,
             $eventsByLine,
             $query,
+            $progress,
         );
 
         return $this->store->resolveReady($identity, $write);

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleReportAdapter.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleReportAdapter.php
@@ -77,7 +77,7 @@ final readonly class ProcurementCycleReportAdapter implements ReportDataProvider
         ReportProgress $progress,
     ): ReportSnapshotRef {
         $this->assertQuery($context, $query);
-        $header = $this->writer->persist($query);
+        $header = $this->writer->persist($query, $progress);
         $this->assertHeader($header, $query);
         $progress->advance(100);
 

--- a/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleSourceSnapshotMaterializer.php
+++ b/app/BusinessModules/Features/Procurement/Reporting/Cycle/Services/ProcurementCycleSourceSnapshotMaterializer.php
@@ -6,6 +6,7 @@ namespace App\BusinessModules\Features\Procurement\Reporting\Cycle\Services;
 
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQueryIdentity;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotDrillRow;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotHeader;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotIdentity;
@@ -54,16 +55,21 @@ final class ProcurementCycleSourceSnapshotMaterializer
         array $results,
         array $eventsByLine,
         ?ReportQuery $query = null,
+        ?ReportProgress $progress = null,
     ): ReportSourceSnapshotWrite {
+        $progress?->advance(45);
         $identity = $this->identity($request, $source, $query?->identity);
         $rows = [];
         $drillRows = [];
         $resultByLine = [];
+        $resultCount = count($results);
+        $completedResults = 0;
         foreach ($results as $result) {
             if (! $result instanceof ProcurementCycleLineResult) {
                 throw new InvalidArgumentException('procurement_cycle_snapshot_result_invalid');
             }
             $payload = $this->payload($result, $request->filters);
+            $progress?->advanceProportion(++$completedResults, max(1, $resultCount), 45, 60);
             if ($payload === null || ! $this->matches($payload, $request->filters)) {
                 continue;
             }
@@ -82,7 +88,9 @@ final class ProcurementCycleSourceSnapshotMaterializer
                     <=> ('procurement-line:'.$right[0]->purchaseRequestLineId);
         });
 
-        foreach (array_values($resultByLine) as $position => [$result, $payload]) {
+        $materializedRows = array_values($resultByLine);
+        $rowCount = count($materializedRows);
+        foreach ($materializedRows as $position => [$result, $payload]) {
             $row = new ReportSourceSnapshotRow(
                 $snapshotId,
                 $position + 1,
@@ -112,6 +120,7 @@ final class ProcurementCycleSourceSnapshotMaterializer
                     $this->hash($drill),
                 );
             }
+            $progress?->advanceProportion($position + 1, max(1, $rowCount), 60, 85);
         }
 
         $watermarks = $this->watermarks($rows, $source, $request->asOf);
@@ -162,6 +171,8 @@ final class ProcurementCycleSourceSnapshotMaterializer
             $header->reportQueryIdentity,
             $header->reportQueryHash,
         );
+
+        $progress?->advance(90);
 
         return new ReportSourceSnapshotWrite($header, $rows, $drillRows);
     }

--- a/tests/Unit/Procurement/Reporting/Cycle/ProcurementCycleRuntimeContractTest.php
+++ b/tests/Unit/Procurement/Reporting/Cycle/ProcurementCycleRuntimeContractTest.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\Reporting\Domain\Contracts\ReportSourceSnapshotStor
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownCell;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportDrillDownInput;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportQuery;
+use App\BusinessModules\Core\Reporting\Domain\DTO\ReportProgress;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportSnapshotRef;
 use App\BusinessModules\Core\Reporting\Domain\DTO\ReportWindowSort;
 use App\BusinessModules\Core\Reporting\Domain\DTO\SourceSnapshots\ReportSourceSnapshotCursor;
@@ -106,6 +107,34 @@ final class ProcurementCycleRuntimeContractTest extends TestCase
             $materializer->identity($request, $source)->queryHash->value,
             $write->header->queryHash->value,
         );
+    }
+
+    public function test_source_snapshot_reports_progress_while_materializing_rows(): void
+    {
+        $scope = (new ReportExecutionContextBuilder)->build()->scope;
+        $request = new ProcurementCycleSnapshotRequest(
+            $scope,
+            [],
+            new DateTimeImmutable('2026-08-01T10:00:00+00:00'),
+            null,
+        );
+        $reported = [];
+        $progress = new ReportProgress(40, static function (ReportProgress $current) use (&$reported): void {
+            $reported[] = $current->percent();
+        });
+
+        (new ProcurementCycleSourceSnapshotMaterializer)->materialize(
+            '01JZZZZZZZZZZZZZZZZZZZZZZZ',
+            $request,
+            new ProcurementCycleSourceRead([], 1, 1, 0, 0, null, 0, null),
+            [$this->publicResult()],
+            [],
+            null,
+            $progress,
+        );
+
+        self::assertSame(90, $progress->percent());
+        self::assertGreaterThanOrEqual(2, count($reported));
     }
 
     public function test_source_snapshot_identity_changes_with_the_immutable_report_query_identity(): void
@@ -310,7 +339,7 @@ final class ProcurementCycleRuntimeContractTest extends TestCase
     {
         return new class implements ProcurementCycleSourceSnapshotWriter
         {
-            public function persist(ReportQuery $query): ReportSourceSnapshotHeader
+            public function persist(ReportQuery $query, ReportProgress $progress): ReportSourceSnapshotHeader
             {
                 throw new LogicException('not used');
             }


### PR DESCRIPTION
## Что изменено
- прогресс холдинговых отчётов рассчитывается по реально обработанным источникам, фактам, пробелам качества и строкам
- цикл закупки передаёт единый progress через чтение и материализацию снимка
- добавлен регрессионный тест промежуточных обновлений цикла закупки
- обновлён integrity hash runtime-адаптера

## Проверки
- PHP syntax для всех изменённых файлов
- git diff --check
- PHPUnit/PHPStan локально недоступны из-за отсутствующего vendor; обязательны в CI

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Integrated ReportProgress tracking into snapshot materialization services to provide granular progress updates.</li>
<li>Updated ProcurementCycleSourceSnapshotWriter interface to accept ReportProgress in the persist method.</li>
<li>Updated ProcurementCycleCandidateContract with a new source hash.</li>
<li>Added progress tracking logic to HoldingPerformanceSnapshotMaterializer and IntercompanyContractFlowSnapshotMaterializer.</li>
</ul></div>