### PR TITLE
fix[admin]: возвращать сохранённую identity снимка

### DIFF
--- a/app/BusinessModules/Core/Reporting/Infrastructure/Persistence/EloquentReportSourceSnapshotStore.php
+++ b/app/BusinessModules/Core/Reporting/Infrastructure/Persistence/EloquentReportSourceSnapshotStore.php
@@ -133,7 +133,7 @@ final class EloquentReportSourceSnapshotStore implements ReportSourceSnapshotStr
     ): ReportSourceSnapshotHeader {
         return DB::transaction(function () use ($snapshot, $identity): ReportSourceSnapshotHeader {
             $header = $snapshot->header;
-            ReportSourceSnapshotRecord::query()->create($this->headerAttributes($header, $identity));
+            $record = ReportSourceSnapshotRecord::query()->create($this->headerAttributes($header, $identity));
             ReportSourceSnapshotRowRecord::query()->insert(array_map(fn (ReportSourceSnapshotRow $row): array => [
                 'snapshot_id' => $row->snapshotId, 'ordinal' => $row->ordinal, 'row_key' => $row->rowKey,
                 'payload' => json_encode($row->payload, JSON_THROW_ON_ERROR), 'payload_hash' => $row->payloadHash->value,
@@ -153,12 +153,9 @@ final class EloquentReportSourceSnapshotStore implements ReportSourceSnapshotStr
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR);
             }
 
-            return new ReportSourceSnapshotHeader(
-                $header->id, $header->sourceKind, $header->reportCode, $header->schemaVersion, $header->scope,
-                $header->queryHash, $header->asOf, $header->sourceHash, $header->watermarks, $header->generatedAt,
-                $header->staleAt, ReportSourceSnapshotStatus::READY, $header->rowCount, $header->drillRowCount,
-                $header->snapshotHash, $readyAt, null, $header->reportQueryIdentity, $header->reportQueryHash,
-            );
+            $record->refresh();
+
+            return $this->headerFromRecord($record);
         });
     }
 
@@ -304,12 +301,9 @@ final class EloquentReportSourceSnapshotStore implements ReportSourceSnapshotStr
                 throw ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR);
             }
 
-            return new ReportSourceSnapshotHeader(
-                $writing->id, $writing->sourceKind, $writing->reportCode, $writing->schemaVersion, $writing->scope,
-                $writing->queryHash, $writing->asOf, $writing->sourceHash, $writing->watermarks, $writing->generatedAt,
-                $writing->staleAt, ReportSourceSnapshotStatus::READY, $writing->rowCount, $writing->drillRowCount,
-                $writing->snapshotHash, $readyAt, null, $writing->reportQueryIdentity, $writing->reportQueryHash,
-            );
+            $record = ReportSourceSnapshotRecord::query()->findOrFail($writing->id);
+
+            return $this->headerFromRecord($record);
         });
     }
 

--- a/tests/Feature/Reporting/Persistence/EloquentReportSourceSnapshotStoreTest.php
+++ b/tests/Feature/Reporting/Persistence/EloquentReportSourceSnapshotStoreTest.php
@@ -76,6 +76,7 @@ final class EloquentReportSourceSnapshotStoreTest extends TestCase
         );
         self::assertSame($write->header->reportQueryHash?->value, $roundTrip->reportQueryHash?->value);
         self::assertSame($write->header->materializedSourceHash->value, $roundTrip->materializedSourceHash->value);
+        self::assertEquals($roundTrip, $ready);
 
         $first = $store->page($request, null, 1);
         self::assertSame(['project:1'], array_map(static fn (ReportSourceSnapshotRow $row): string => $row->rowKey, $first->rows));
@@ -311,7 +312,7 @@ final class EloquentReportSourceSnapshotStoreTest extends TestCase
             new DateTimeImmutable('2026-07-31T00:00:00+00:00'),
             $this->hash(['source' => $firstAmount]),
             ['portfolio_version' => 3],
-            new DateTimeImmutable('2026-07-31T00:00:00+00:00'), new DateTimeImmutable('2026-07-31T01:00:00+00:00'),
+            new DateTimeImmutable('2026-07-31T00:00:00.123456+00:00'), new DateTimeImmutable('2026-07-31T01:00:00.654321+00:00'),
             ReportSourceSnapshotStatus::WRITING, 2, 1, $this->hash(['placeholder' => 1]), null, null,
             $reportQueryIdentity, $reportQueryHash,
         );
@@ -320,7 +321,7 @@ final class EloquentReportSourceSnapshotStoreTest extends TestCase
             new DateTimeImmutable('2026-07-31T00:00:00+00:00'),
             $this->hash(['source' => $firstAmount]),
             ['portfolio_version' => 3],
-            new DateTimeImmutable('2026-07-31T00:00:00+00:00'), new DateTimeImmutable('2026-07-31T01:00:00+00:00'),
+            new DateTimeImmutable('2026-07-31T00:00:00.123456+00:00'), new DateTimeImmutable('2026-07-31T01:00:00.654321+00:00'),
             ReportSourceSnapshotStatus::WRITING, 2, 1, ReportSourceSnapshotIntegrity::hash($header, $rows, $drillRows), null, null,
             $header->reportQueryIdentity, $header->reportQueryHash,
         );


### PR DESCRIPTION
Исправляет общий дефект source-snapshot store: после INSERT/UPDATE возвращался исходный DTO с микросекундами, тогда как БД нормализовала timestamp. Немедленное повторное чтение видело другую identity, первая попытка падала на 90%, а вторая через backoff успешно использовала уже сохранённый снимок. Оба пути записи теперь возвращают rehydrated header из БД; тест проверяет точный round-trip на дробных timestamp.