### PR TITLE
fix[admin]: исправлены контракты запуска отчетов

### DIFF
--- a/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
+++ b/app/BusinessModules/ContractorMarketplace/Reporting/Scorecard/Services/ContractorScorecardSnapshotMaterializer.php
@@ -141,6 +141,7 @@ final readonly class ContractorScorecardSnapshotMaterializer
             $tuple,
             $policy,
             $cohortPeriod,
+            $cohortKey,
             $components,
             $groups,
             $objectiveObservations,

--- a/app/BusinessModules/Core/Reporting/Http/Admin/Requests/LookaheadReadinessReportOptionsRequest.php
+++ b/app/BusinessModules/Core/Reporting/Http/Admin/Requests/LookaheadReadinessReportOptionsRequest.php
@@ -6,7 +6,6 @@ namespace App\BusinessModules\Core\Reporting\Http\Admin\Requests;
 
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
 use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
-use App\BusinessModules\Core\Reporting\Http\Admin\Support\ReportAsOfParser;
 use DateTimeImmutable;
 
 final class LookaheadReadinessReportOptionsRequest extends ReportFormRequest
@@ -14,11 +13,7 @@ final class LookaheadReadinessReportOptionsRequest extends ReportFormRequest
     public function rules(): array
     {
         return [
-            'as_of' => ['required', 'string', static function (string $attribute, mixed $value, callable $fail): void {
-                if (ReportAsOfParser::parse($value) === null) {
-                    $fail(trans_message('reports.errors.report_request_invalid'));
-                }
-            }],
+            'as_of' => ['required', 'date_format:Y-m-d'],
             'horizon_days' => ['sometimes', 'integer', 'min:1', 'max:366'],
             ...$this->forbiddenClientFieldsRules(),
             'project_id' => ['prohibited'],
@@ -35,8 +30,14 @@ final class LookaheadReadinessReportOptionsRequest extends ReportFormRequest
 
     public function asOf(): DateTimeImmutable
     {
-        return ReportAsOfParser::parse($this->validated('as_of'))
-            ?? throw ReportContractException::fromCode(ReportErrorCode::REPORT_REQUEST_INVALID, ['fields' => ['as_of']]);
+        $asOf = DateTimeImmutable::createFromFormat('!Y-m-d', (string) $this->validated('as_of'));
+
+        return $asOf !== false
+            ? $asOf
+            : throw ReportContractException::fromCode(
+                ReportErrorCode::REPORT_REQUEST_INVALID,
+                ['fields' => ['as_of']],
+            );
     }
 
     public function horizonDays(): int

--- a/tests/Unit/Reporting/Http/LookaheadReadinessOptionsHttpContractTest.php
+++ b/tests/Unit/Reporting/Http/LookaheadReadinessOptionsHttpContractTest.php
@@ -32,6 +32,8 @@ final class LookaheadReadinessOptionsHttpContractTest extends TestCase
         self::assertIsString($request);
         self::assertStringContainsString("'as_of'", $request);
         self::assertStringContainsString("'horizon_days'", $request);
+        self::assertStringContainsString("'date_format:Y-m-d'", $request);
+        self::assertStringContainsString("DateTimeImmutable::createFromFormat('!Y-m-d'", $request);
         self::assertStringContainsString("'project_id' => ['prohibited']", $request);
         self::assertStringContainsString("'scope' => ['prohibited']", $request);
         self::assertStringContainsString("'actor_id' => ['prohibited']", $request);

--- a/tests/Unit/Reporting/Waves23/ContractorScorecardEvidenceContractTest.php
+++ b/tests/Unit/Reporting/Waves23/ContractorScorecardEvidenceContractTest.php
@@ -84,6 +84,10 @@ final class ContractorScorecardEvidenceContractTest extends TestCase
 
         self::assertStringContainsString('ContractorReviewSnapshotResolver', $sourceResolver);
         self::assertStringContainsString('contractor_scorecard_review_snapshot_rows', $materializer);
+        self::assertMatchesRegularExpression(
+            '/DB::transaction\(function \(\) use \([\s\S]*?\$cohortKey,[\s\S]*?\): void/',
+            $materializer,
+        );
         self::assertStringNotContainsString('MarketplaceHiringOfferReview::query()', $materializer);
         self::assertStringContainsString('contractor_scorecard_review_events', $backfill);
         self::assertStringNotContainsString('MarketplaceHiringOfferReview::query()', $backfill);


### PR DESCRIPTION
Исправляет date-only контракт параметров Lookahead и сохранение cohort в материализации карточки подрядчика. Добавлены регрессионные проверки. Локально: PHP syntax и diff check; PHPUnit недоступен без vendor.