### PR TITLE
fix[backend]: исключены ожидаемые ошибки отчетов из GlitchTip

### DIFF
--- a/app/Services/Monitoring/GlitchTipReportPolicy.php
+++ b/app/Services/Monitoring/GlitchTipReportPolicy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Monitoring;
 
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\Exceptions\BusinessLogicException;
 use App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob;
 use App\Support\LivewirePayloadExceptionClassifier;
@@ -36,6 +38,10 @@ class GlitchTipReportPolicy
         }
 
         if ($this->isRecoverableRagOrganizationEstimateMaxAttempts($exception)) {
+            return false;
+        }
+
+        if ($this->isExpectedReportContractFailure($exception)) {
             return false;
         }
 
@@ -159,6 +165,15 @@ class GlitchTipReportPolicy
         return str_contains($command, 's:9:"projectId";N;')
             && str_contains($command, 's:10:"sourceType";s:8:"estimate";')
             && str_contains($command, 's:5:"runId";i:');
+    }
+
+    private function isExpectedReportContractFailure(Throwable $exception): bool
+    {
+        return $exception instanceof ReportContractException
+            && ! in_array($exception->errorCode, [
+                ReportErrorCode::REPORT_DEPENDENCY_FAILED,
+                ReportErrorCode::REPORT_INTERNAL_ERROR,
+            ], true);
     }
 
     private function queueJobPayload(MaxAttemptsExceededException $exception): array

--- a/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
+++ b/tests/Unit/Monitoring/GlitchTipReportPolicyTest.php
@@ -9,6 +9,8 @@ use App\Exceptions\AI\AIParsingException;
 use App\Exceptions\AI\AIQuotaExceededException;
 use App\Exceptions\Billing\InsufficientBalanceException;
 use App\Exceptions\BusinessLogicException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportContractException;
+use App\BusinessModules\Core\Reporting\Application\Errors\ReportErrorCode;
 use App\BusinessModules\Features\AIAssistant\Jobs\IndexRagSourceJob;
 use App\Services\Monitoring\GlitchTipReportPolicy;
 use Filament\Actions\Exceptions\ActionNotResolvableException;
@@ -160,6 +162,18 @@ class GlitchTipReportPolicyTest extends TestCase
         );
 
         self::assertTrue($policy->shouldCapture($exception));
+    }
+
+    public function test_skips_expected_report_contract_failures_but_captures_internal_ones(): void
+    {
+        $policy = new GlitchTipReportPolicy($this->config());
+
+        self::assertFalse($policy->shouldCapture(
+            ReportContractException::fromCode(ReportErrorCode::REPORT_SOURCE_UNAVAILABLE),
+        ));
+        self::assertTrue($policy->shouldCapture(
+            ReportContractException::fromCode(ReportErrorCode::REPORT_INTERNAL_ERROR),
+        ));
     }
 
     public static function reportableExceptions(): array


### PR DESCRIPTION
## GlitchTip
- PROHELPER-BACKEND-GQ / issue 569: [REPORT_SOURCE_UNAVAILABLE](http://5.129.220.32:8000/prohelper-backend/issues/569)
- Сопутствующее событие: PROHELPER-BACKEND-GR / issue 570.

## Причина
`ReportContractException` является штатным контрактным ответом API отчётов, однако политика GlitchTip считала его неожиданным и отправляла в мониторинг.

## Изменения
- Ожидаемые контрактные ошибки отчётов исключены из GlitchTip.
- `REPORT_INTERNAL_ERROR` и `REPORT_DEPENDENCY_FAILED` остаются наблюдаемыми.
- Добавлен регрессионный тест политики.

## Проверки
- `php vendor/bin/phpunit tests/Unit/Monitoring/GlitchTipReportPolicyTest.php` — 25 tests, 38 assertions.
- `php vendor/bin/phpstan analyse app/Services/Monitoring/GlitchTipReportPolicy.php tests/Unit/Monitoring/GlitchTipReportPolicyTest.php --memory-limit=1G`.
- `php -l` для изменённых файлов и `git diff --check`.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated GlitchTipReportPolicy to ignore specific expected ReportContractException types.</li>
<li>Added logic to continue capturing ReportContractException instances that represent internal errors or dependency failures.</li>
<li>Added unit tests to verify that expected report contract failures are skipped while internal ones are still captured.</li>
</ul></div>