### PR TITLE
fix[backend]: добавить контекст ошибок просроченных платежей

### DIFF
--- a/app/BusinessModules/Core/Payments/Jobs/ProcessOverduePaymentsJob.php
+++ b/app/BusinessModules/Core/Payments/Jobs/ProcessOverduePaymentsJob.php
@@ -5,14 +5,17 @@ namespace App\BusinessModules\Core\Payments\Jobs;
 use App\BusinessModules\Core\Payments\Events\PaymentDocumentOverdue;
 use App\BusinessModules\Core\Payments\Models\PaymentDocument;
 use App\BusinessModules\Core\Payments\Notifications\PaymentOverdueNotification;
+use App\BusinessModules\Core\Payments\Support\OverduePaymentFailureContext;
 use App\Domain\Authorization\Models\AuthorizationContext;
 use App\Models\User;
+use App\Services\Monitoring\SentryScopeService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 /**
  * Job для обработки просроченных платежей
@@ -24,7 +27,7 @@ class ProcessOverduePaymentsJob implements ShouldQueue
 
     public function __construct() {}
 
-    public function handle(): void
+    public function handle(SentryScopeService $sentryScopeService): void
     {
         Log::info('processing_overdue_payments.started');
 
@@ -56,11 +59,13 @@ class ProcessOverduePaymentsJob implements ShouldQueue
                 $processedCount++;
                 $notifiedCount++;
 
-            } catch (\Exception $e) {
-                Log::error('processing_overdue_payments.document_failed', [
-                    'document_id' => $document->id,
-                    'error' => $e->getMessage(),
-                ]);
+            } catch (Throwable $exception) {
+                $sentryScopeService->captureException($exception);
+
+                Log::error(
+                    'processing_overdue_payments.document_failed',
+                    OverduePaymentFailureContext::from((int) $document->id, $exception),
+                );
             }
         }
 
@@ -110,4 +115,3 @@ class ProcessOverduePaymentsJob implements ShouldQueue
             ->values();
     }
 }
-

--- a/app/BusinessModules/Core/Payments/Support/OverduePaymentFailureContext.php
+++ b/app/BusinessModules/Core/Payments/Support/OverduePaymentFailureContext.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\Payments\Support;
+
+use Throwable;
+
+final class OverduePaymentFailureContext
+{
+    /**
+     * @return array{payment_document_id: int, exception_class: class-string<Throwable>, exception_code: int}
+     */
+    public static function from(int $documentId, Throwable $exception): array
+    {
+        return [
+            'payment_document_id' => $documentId,
+            'exception_class' => $exception::class,
+            'exception_code' => (int) $exception->getCode(),
+        ];
+    }
+}

--- a/tests/Unit/BusinessModules/Core/Payments/OverduePaymentFailureContextTest.php
+++ b/tests/Unit/BusinessModules/Core/Payments/OverduePaymentFailureContextTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BusinessModules\Core\Payments;
+
+use App\BusinessModules\Core\Payments\Support\OverduePaymentFailureContext;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class OverduePaymentFailureContextTest extends TestCase
+{
+    public function test_it_exposes_safe_exception_metadata_without_the_exception_message(): void
+    {
+        $context = OverduePaymentFailureContext::from(
+            documentId: 40,
+            exception: new RuntimeException('secret payment provider response', 503),
+        );
+
+        self::assertSame([
+            'payment_document_id' => 40,
+            'exception_class' => RuntimeException::class,
+            'exception_code' => 503,
+        ], $context);
+    }
+}


### PR DESCRIPTION
## GlitchTip

- PROHELPER-BACKEND-FQ / issue 537: processing_overdue_payments.document_failed
- http://5.129.220.32:8000/prohelper-backend/issues/537

## Причина

Исключение перехватывалось внутри задачи и отправлялось только как строковое поле лога. Глобальный redactor корректно скрывал содержимое, но GlitchTip не получал класс исключения и stack trace.

## Изменения

- задача передаёт перехваченное исключение в SentryScopeService;
- локальный error-лог содержит безопасные ID документа, класс и код исключения без текста причины;
- добавлен unit-тест безопасного контекста.

## Проверки

- phpunit --no-configuration tests/Unit/BusinessModules/Core/Payments/OverduePaymentFailureContextTest.php
- php -l изменённых PHP-файлов
- phpstan analyse изменённых файлов

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enhanced error handling in ProcessOverduePaymentsJob by integrating Sentry for exception tracking.</li>
<li>Introduced OverduePaymentFailureContext to standardize and sanitize error logging metadata.</li>
<li>Updated logging to exclude potentially sensitive exception messages, focusing on class and code instead.</li>
<li>Added unit tests for the new failure context helper.</li>
</ul></div>