### PR TITLE
fix[backend]: исправлен Stage 4 backfill модели проекта

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_10_000620_backfill_estimate_project_model_v2.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_10_000620_backfill_estimate_project_model_v2.php
@@ -90,7 +90,7 @@ SET fact_origin = CASE fact.payload->>'source' WHEN 'ai_candidate' THEN 'ai_infe
         ) THEN 'confirmed'
         ELSE 'candidate'
     END,
-    fact_value = CASE WHEN fact.payload ? 'value' THEN jsonb_build_object('value', fact.payload->'value') ELSE fact.payload - 'source' - 'unit' END,
+    fact_value = CASE WHEN fact.payload->'value' IS NOT NULL THEN jsonb_build_object('value', fact.payload->'value') ELSE fact.payload - 'source' - 'unit' END,
     fact_unit = NULLIF(fact.payload->>'unit', '')
 FROM batch WHERE fact.id = batch.id
 SQL);
@@ -158,7 +158,7 @@ SELECT building_model_id, organization_id, project_id, session_id, source_versio
        'fact:decision:' || substring(stable_key from 12 for 48), entity_id, assertion_type,
        jsonb_build_object('source','user_assumption','value',payload->'canonical_value'),
        1.0, 'user_assumption', 'confirmed', decision_version + 1, assertion_id,
-       CASE WHEN jsonb_typeof(payload->'canonical_value') = 'object' AND payload->'canonical_value' ? 'value'
+       CASE WHEN jsonb_typeof(payload->'canonical_value') = 'object' AND payload->'canonical_value'->'value' IS NOT NULL
             THEN jsonb_build_object('value', payload->'canonical_value'->'value')
             ELSE jsonb_build_object('value', payload->'canonical_value') END,
        NULLIF(payload->'canonical_value'->>'unit',''), created_at

--- a/tests/Unit/EstimateGeneration/ProjectModel/ProjectModelV2MigrationContractTest.php
+++ b/tests/Unit/EstimateGeneration/ProjectModel/ProjectModelV2MigrationContractTest.php
@@ -88,4 +88,16 @@ final class ProjectModelV2MigrationContractTest extends TestCase
             self::assertStringContainsString($required, $migration);
         }
     }
+
+    #[Test]
+    public function backfill_sql_does_not_expose_jsonb_question_operator_to_pdo_placeholders(): void
+    {
+        $migration = (string) file_get_contents(
+            dirname(__DIR__, 4).'/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_10_000620_backfill_estimate_project_model_v2.php'
+        );
+
+        self::assertStringNotContainsString(" ? 'value'", $migration);
+        self::assertStringContainsString("fact.payload->'value' IS NOT NULL", $migration);
+        self::assertStringContainsString("payload->'canonical_value'->'value' IS NOT NULL", $migration);
+    }
 }


### PR DESCRIPTION
## Причина

Штатный production deploy PR #374 остановился в `migrate:safe`: JSONB-оператор `?` внутри `DB::affectingStatement` был обработан PDO как positional placeholder и передан PostgreSQL как `$1`, что вызвало SQLSTATE 42601.

Forward-only защита сработала штатно: уже применённые миграции и схема сохранены, reversible tail отсутствовал, deployment был прерван с требованием fix-forward.

## Исправление

- Два existence-check в `000620_backfill_estimate_project_model_v2` переведены на эквивалентную проверку JSONB extraction через `-> ... IS NOT NULL`.
- Добавлен регрессионный контракт, запрещающий `? 'value'` в backfill SQL, проходящем через PDO.

## Проверки

- RED: новый тест воспроизвёл наличие опасного оператора.
- GREEN: 1 тест, 3 assertions.
- `php -l`: 2 файла — успешно.
- Pint: 2 файла — успешно.
- `git diff --check` — успешно.

Ручные миграции, rollback, SQL и production writes не выполнялись. После merge требуется только повторный стандартный workflow `Deploy Backend to Production`.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated SQL migration logic to replace the JSONB '?' operator with explicit 'IS NOT NULL' checks to avoid conflicts with PDO parameter placeholders.</li>
<li>Added a unit test to verify that the migration SQL does not contain the '?' operator and correctly uses the new null-check syntax.</li>
</ul></div>