### PR TITLE
feat: backfill and reconcile organization assets

### DIFF
--- a/app/BusinessModules/Core/AssetManagement/Services/LegacyAssetMapper.php
+++ b/app/BusinessModules/Core/AssetManagement/Services/LegacyAssetMapper.php
@@ -1,0 +1,498 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Core\AssetManagement\Services;
+
+use App\BusinessModules\Core\AssetManagement\DTO\AssetPlacementData;
+use App\BusinessModules\Core\AssetManagement\DTO\CreateOrganizationAssetData;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetOperationalMode;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final readonly class LegacyAssetMapper
+{
+    /** @var list<string> */
+    private const MACHINERY_OPERATION_TABLES = [
+        'machinery_assignments',
+        'machinery_shift_reports',
+        'machinery_downtimes',
+        'machinery_fuel_issues',
+        'machinery_production_records',
+        'machinery_maintenance_orders',
+    ];
+
+    public function __construct(private OrganizationAssetService $assets) {}
+
+    /**
+     * @return array{
+     *     dry_run: bool,
+     *     scanned: int,
+     *     would_create: int,
+     *     created: int,
+     *     links_updated: int,
+     *     already_linked: int,
+     *     conflicts: int,
+     *     conflict_records: list<array{source: string, reason: string}>
+     * }
+     */
+    public function backfill(bool $dryRun): array
+    {
+        $report = [
+            'dry_run' => $dryRun,
+            'scanned' => 0,
+            'would_create' => 0,
+            'created' => 0,
+            'links_updated' => 0,
+            'already_linked' => 0,
+            'conflicts' => 0,
+            'conflict_records' => [],
+        ];
+        $duplicateMachineryInventories = $this->duplicateMachineryInventoryKeys();
+        $duplicateWarehouseSerials = $this->duplicateWarehouseSerialKeys();
+
+        DB::table('machinery_assets')->orderBy('id')->eachById(function (object $legacy) use (
+            $dryRun,
+            $duplicateMachineryInventories,
+            &$report,
+        ): void {
+            $report['scanned']++;
+            $inventoryNumber = $this->machineryInventoryNumber($legacy);
+            $inventoryKey = $this->identityKey((int) $legacy->organization_id, $inventoryNumber);
+
+            if (isset($duplicateMachineryInventories[$inventoryKey])) {
+                $this->addConflict($report, $this->sourceKey('machinery_assets', (int) $legacy->id), 'duplicate_inventory_number');
+
+                return;
+            }
+
+            $this->backfillMachinerySource($legacy, $inventoryNumber, $dryRun, $report);
+        });
+
+        $this->serializedWarehouseBalances()->orderBy('warehouse_balances.id')->eachById(
+            function (object $legacy) use ($dryRun, $duplicateWarehouseSerials, &$report): void {
+                $report['scanned']++;
+                $source = $this->sourceKey('warehouse_balances', (int) $legacy->id);
+                $serialKey = $this->identityKey((int) $legacy->organization_id, trim((string) $legacy->serial_number));
+
+                if ((float) $legacy->total_quantity !== 1.0) {
+                    $this->addConflict($report, $source, 'serialized_quantity_must_equal_one');
+
+                    return;
+                }
+
+                if (isset($duplicateWarehouseSerials[$serialKey])) {
+                    $this->addConflict($report, $source, 'duplicate_serial_number');
+
+                    return;
+                }
+
+                $this->backfillWarehouseSource($legacy, $dryRun, $report);
+            },
+            column: 'warehouse_balances.id',
+            alias: 'id',
+        );
+
+        $report['conflicts'] = count($report['conflict_records']);
+
+        return $report;
+    }
+
+    /**
+     * @return array{legacy: int, linked: int, missing: int, duplicates: int, field_conflicts: int}
+     */
+    public function reconcile(): array
+    {
+        $report = [
+            'legacy' => 0,
+            'linked' => 0,
+            'missing' => 0,
+            'duplicates' => 0,
+            'field_conflicts' => 0,
+        ];
+
+        DB::table('machinery_assets')->orderBy('id')->eachById(function (object $legacy) use (&$report): void {
+            $report['legacy']++;
+            $matches = $this->canonicalMatches('machinery_assets', (int) $legacy->id, (int) $legacy->organization_id);
+
+            if ($matches->isEmpty()) {
+                $report['missing']++;
+
+                return;
+            }
+
+            if ($matches->count() > 1) {
+                $report['duplicates']++;
+            } elseif ((int) ($legacy->organization_asset_id ?? 0) === (int) $matches->first()->id) {
+                $report['linked']++;
+            } else {
+                $report['missing']++;
+            }
+
+            if ($matches->contains(fn (OrganizationAsset $asset): bool => ! $this->machineryFieldsMatch($legacy, $asset))) {
+                $report['field_conflicts']++;
+            }
+        });
+
+        $this->serializedWarehouseBalances()->orderBy('warehouse_balances.id')->eachById(
+            function (object $legacy) use (&$report): void {
+                $report['legacy']++;
+                $matches = $this->canonicalMatches('warehouse_balances', (int) $legacy->id, (int) $legacy->organization_id);
+
+                if ($matches->isEmpty()) {
+                    $report['missing']++;
+
+                    return;
+                }
+
+                if ($matches->count() > 1) {
+                    $report['duplicates']++;
+                } else {
+                    $report['linked']++;
+                }
+
+                if ($matches->contains(fn (OrganizationAsset $asset): bool => ! $this->warehouseFieldsMatch($legacy, $asset))) {
+                    $report['field_conflicts']++;
+                }
+            },
+            column: 'warehouse_balances.id',
+            alias: 'id',
+        );
+
+        return $report;
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function backfillMachinerySource(object $legacy, string $inventoryNumber, bool $dryRun, array &$report): void
+    {
+        $source = $this->sourceKey('machinery_assets', (int) $legacy->id);
+        $matches = $this->canonicalMatches('machinery_assets', (int) $legacy->id, (int) $legacy->organization_id);
+
+        if ($matches->count() > 1) {
+            $this->addConflict($report, $source, 'duplicate_legacy_source_mapping');
+
+            return;
+        }
+
+        $canonical = $matches->first();
+
+        if ($canonical?->trashed()) {
+            $this->addConflict($report, $source, 'canonical_mapping_deleted');
+
+            return;
+        }
+
+        if ($this->hasMachineryShadowLinkConflict($legacy, $canonical)) {
+            $this->addConflict($report, $source, 'shadow_link_mismatch');
+
+            return;
+        }
+
+        if ($canonical === null) {
+            if ($this->identityExists((int) $legacy->organization_id, $inventoryNumber, null)) {
+                $this->addConflict($report, $source, 'inventory_number_already_used');
+
+                return;
+            }
+
+            if ($dryRun) {
+                $report['would_create']++;
+
+                return;
+            }
+
+            $canonical = $this->assets->create(
+                (int) $legacy->organization_id,
+                new CreateOrganizationAssetData(
+                    name: (string) $legacy->name,
+                    inventoryNumber: $inventoryNumber,
+                    ownershipType: (string) $legacy->ownership_type,
+                    machineryId: $legacy->machinery_id !== null ? (int) $legacy->machinery_id : null,
+                    placement: $legacy->current_project_id !== null
+                        ? new AssetPlacementData(projectId: (int) $legacy->current_project_id)
+                        : null,
+                    metadata: ['legacy_source' => ['table' => 'machinery_assets', 'id' => (int) $legacy->id]],
+                    operationalMode: AssetOperationalMode::ShiftOperation,
+                    tracksMeter: true,
+                    tracksFuel: $legacy->fuel_type !== null || $legacy->fuel_consumption_rate !== null,
+                    tracksProduction: true,
+                    maintenanceEnabled: true,
+                    meterUnit: 'hour',
+                ),
+            );
+            $canonical->update([
+                'lifecycle_status' => $this->machineryLifecycleStatus($legacy),
+                'technical_status' => $this->machineryTechnicalStatus($legacy),
+            ]);
+            $report['created']++;
+        }
+
+        if ($dryRun) {
+            return;
+        }
+
+        $updated = DB::table('machinery_assets')
+            ->where('id', $legacy->id)
+            ->whereNull('organization_asset_id')
+            ->update(['organization_asset_id' => $canonical->id]);
+        $report['links_updated'] += $updated;
+
+        foreach (self::MACHINERY_OPERATION_TABLES as $table) {
+            $report['links_updated'] += DB::table($table)
+                ->where('asset_id', $legacy->id)
+                ->whereNull('organization_asset_id')
+                ->update(['organization_asset_id' => $canonical->id]);
+        }
+
+        if ($updated === 0 && (int) ($legacy->organization_asset_id ?? 0) === (int) $canonical->id) {
+            $report['already_linked']++;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function backfillWarehouseSource(object $legacy, bool $dryRun, array &$report): void
+    {
+        $source = $this->sourceKey('warehouse_balances', (int) $legacy->id);
+        $matches = $this->canonicalMatches('warehouse_balances', (int) $legacy->id, (int) $legacy->organization_id);
+
+        if ($matches->count() > 1) {
+            $this->addConflict($report, $source, 'duplicate_legacy_source_mapping');
+
+            return;
+        }
+
+        $canonical = $matches->first();
+        $inventoryNumber = 'WHB-'.$legacy->id;
+        $serialNumber = trim((string) $legacy->serial_number);
+
+        if ($canonical?->trashed()) {
+            $this->addConflict($report, $source, 'canonical_mapping_deleted');
+
+            return;
+        }
+
+        if ($this->hasWarehouseMovementLinkConflict($legacy, $canonical)) {
+            $this->addConflict($report, $source, 'shadow_link_mismatch');
+
+            return;
+        }
+
+        if ($canonical === null) {
+            if ($this->identityExists((int) $legacy->organization_id, $inventoryNumber, $serialNumber)) {
+                $this->addConflict($report, $source, 'warehouse_identity_already_used');
+
+                return;
+            }
+
+            if ($dryRun) {
+                $report['would_create']++;
+
+                return;
+            }
+
+            $canonical = $this->assets->create(
+                (int) $legacy->organization_id,
+                new CreateOrganizationAssetData(
+                    name: (string) $legacy->material_name,
+                    inventoryNumber: $inventoryNumber,
+                    serialNumber: $serialNumber,
+                    materialId: (int) $legacy->material_id,
+                    placement: new AssetPlacementData(warehouseId: (int) $legacy->warehouse_id),
+                    metadata: ['legacy_source' => ['table' => 'warehouse_balances', 'id' => (int) $legacy->id]],
+                ),
+            );
+            $report['created']++;
+        } elseif ($dryRun) {
+            return;
+        }
+
+        $report['links_updated'] += DB::table('warehouse_movements')
+            ->where('organization_id', $legacy->organization_id)
+            ->where('material_id', $legacy->material_id)
+            ->where('metadata->warehouse_balance_id', (int) $legacy->id)
+            ->whereNull('organization_asset_id')
+            ->update(['organization_asset_id' => $canonical->id]);
+
+        if ($matches->isNotEmpty()) {
+            $report['already_linked']++;
+        }
+    }
+
+    private function serializedWarehouseBalances(): Builder
+    {
+        return DB::table('warehouse_balances')
+            ->join('materials', 'materials.id', '=', 'warehouse_balances.material_id')
+            ->select([
+                'warehouse_balances.id',
+                'warehouse_balances.organization_id',
+                'warehouse_balances.warehouse_id',
+                'warehouse_balances.material_id',
+                'warehouse_balances.serial_number',
+                'materials.name as material_name',
+            ])
+            ->selectRaw('(warehouse_balances.available_quantity + warehouse_balances.reserved_quantity) AS total_quantity')
+            ->whereNotNull('warehouse_balances.serial_number')
+            ->where('warehouse_balances.serial_number', '<>', '');
+    }
+
+    /** @return Collection<int, OrganizationAsset> */
+    private function canonicalMatches(string $table, int $id, int $organizationId): Collection
+    {
+        return OrganizationAsset::query()
+            ->withTrashed()
+            ->forOrganization($organizationId)
+            ->where('metadata->legacy_source->table', $table)
+            ->where('metadata->legacy_source->id', $id)
+            ->get();
+    }
+
+    private function identityExists(int $organizationId, string $inventoryNumber, ?string $serialNumber): bool
+    {
+        return OrganizationAsset::query()
+            ->withTrashed()
+            ->forOrganization($organizationId)
+            ->where(function ($query) use ($inventoryNumber, $serialNumber): void {
+                $query->where('inventory_number', $inventoryNumber);
+
+                if ($serialNumber !== null && $serialNumber !== '') {
+                    $query->orWhere('serial_number', $serialNumber);
+                }
+            })
+            ->exists();
+    }
+
+    /** @return array<string, true> */
+    private function duplicateMachineryInventoryKeys(): array
+    {
+        return DB::table('machinery_assets')
+            ->selectRaw("organization_id, COALESCE(NULLIF(TRIM(inventory_number), ''), TRIM(asset_code)) AS effective_inventory")
+            ->groupByRaw("organization_id, COALESCE(NULLIF(TRIM(inventory_number), ''), TRIM(asset_code))")
+            ->havingRaw('COUNT(*) > 1')
+            ->get()
+            ->mapWithKeys(fn (object $row): array => [
+                $this->identityKey((int) $row->organization_id, (string) $row->effective_inventory) => true,
+            ])
+            ->all();
+    }
+
+    /** @return array<string, true> */
+    private function duplicateWarehouseSerialKeys(): array
+    {
+        return DB::table('warehouse_balances')
+            ->selectRaw('organization_id, TRIM(serial_number) AS normalized_serial')
+            ->whereNotNull('serial_number')
+            ->whereRaw("TRIM(serial_number) <> ''")
+            ->groupByRaw('organization_id, TRIM(serial_number)')
+            ->havingRaw('COUNT(*) > 1')
+            ->get()
+            ->mapWithKeys(fn (object $row): array => [
+                $this->identityKey((int) $row->organization_id, (string) $row->normalized_serial) => true,
+            ])
+            ->all();
+    }
+
+    private function machineryInventoryNumber(object $legacy): string
+    {
+        $inventoryNumber = trim((string) ($legacy->inventory_number ?? ''));
+
+        return $inventoryNumber !== '' ? $inventoryNumber : trim((string) $legacy->asset_code);
+    }
+
+    private function machineryFieldsMatch(object $legacy, OrganizationAsset $asset): bool
+    {
+        return ! $asset->trashed()
+            && (int) $asset->organization_id === (int) $legacy->organization_id
+            && $asset->name === (string) $legacy->name
+            && $asset->inventory_number === $this->machineryInventoryNumber($legacy)
+            && $asset->ownership_type === (string) $legacy->ownership_type
+            && (int) ($asset->machinery_id ?? 0) === (int) ($legacy->machinery_id ?? 0);
+    }
+
+    private function warehouseFieldsMatch(object $legacy, OrganizationAsset $asset): bool
+    {
+        return ! $asset->trashed()
+            && (int) $asset->organization_id === (int) $legacy->organization_id
+            && $asset->name === (string) $legacy->material_name
+            && $asset->inventory_number === 'WHB-'.$legacy->id
+            && $asset->serial_number === trim((string) $legacy->serial_number)
+            && (int) $asset->material_id === (int) $legacy->material_id
+            && (int) $asset->current_warehouse_id === (int) $legacy->warehouse_id;
+    }
+
+    private function hasMachineryShadowLinkConflict(object $legacy, ?OrganizationAsset $canonical): bool
+    {
+        $canonicalId = $canonical?->id;
+        $legacyLink = $legacy->organization_asset_id ?? null;
+
+        if ($legacyLink !== null && (int) $legacyLink !== (int) ($canonicalId ?? 0)) {
+            return true;
+        }
+
+        foreach (self::MACHINERY_OPERATION_TABLES as $table) {
+            $query = DB::table($table)
+                ->where('asset_id', $legacy->id)
+                ->whereNotNull('organization_asset_id');
+
+            if ($canonicalId === null ? $query->exists() : $query->where('organization_asset_id', '<>', $canonicalId)->exists()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasWarehouseMovementLinkConflict(object $legacy, ?OrganizationAsset $canonical): bool
+    {
+        $query = DB::table('warehouse_movements')
+            ->where('organization_id', $legacy->organization_id)
+            ->where('material_id', $legacy->material_id)
+            ->where('metadata->warehouse_balance_id', (int) $legacy->id)
+            ->whereNotNull('organization_asset_id');
+
+        return $canonical === null
+            ? $query->exists()
+            : $query->where('organization_asset_id', '<>', $canonical->id)->exists();
+    }
+
+    private function machineryLifecycleStatus(object $legacy): AssetLifecycleStatus
+    {
+        return $legacy->archived_at !== null || $legacy->status === 'archived'
+            ? AssetLifecycleStatus::Retired
+            : AssetLifecycleStatus::Active;
+    }
+
+    private function machineryTechnicalStatus(object $legacy): AssetTechnicalStatus
+    {
+        return match ($legacy->status) {
+            'maintenance' => AssetTechnicalStatus::Maintenance,
+            'unavailable' => AssetTechnicalStatus::Unavailable,
+            default => AssetTechnicalStatus::Serviceable,
+        };
+    }
+
+    private function identityKey(int $organizationId, string $identifier): string
+    {
+        return $organizationId.'|'.$identifier;
+    }
+
+    private function sourceKey(string $table, int $id): string
+    {
+        return $table.':'.$id;
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function addConflict(array &$report, string $source, string $reason): void
+    {
+        $report['conflict_records'][] = ['source' => $source, 'reason' => $reason];
+    }
+}

--- a/app/BusinessModules/Features/BasicWarehouse/Models/WarehouseMovement.php
+++ b/app/BusinessModules/Features/BasicWarehouse/Models/WarehouseMovement.php
@@ -28,6 +28,7 @@ class WarehouseMovement extends Model
 
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'warehouse_id',
         'cell_id',
         'material_id',
@@ -56,33 +57,50 @@ class WarehouseMovement extends Model
 
     // Типы движений
     const TYPE_RECEIPT = 'receipt';
+
     const TYPE_WRITE_OFF = 'write_off';
+
     const TYPE_TRANSFER_IN = 'transfer_in';
+
     const TYPE_TRANSFER_OUT = 'transfer_out';
+
     const TYPE_ADJUSTMENT = 'adjustment';
+
     const TYPE_RETURN = 'return';
 
     const CATEGORY_PROJECT_DELIVERY = 'project_delivery';
+
     const CATEGORY_RESPONSIBLE_ISSUE = 'responsible_issue';
+
     const CATEGORY_RESPONSIBLE_RETURN = 'responsible_return';
+
     const CATEGORY_PRODUCTION_USAGE = 'production_usage';
+
     const CATEGORY_LOSS = 'loss';
+
     const CATEGORY_DAMAGE = 'damage';
+
     const CATEGORY_DISPOSAL = 'disposal';
+
     const CATEGORY_INVENTORY_ADJUSTMENT = 'inventory_adjustment';
 
     public function operationCategoryLabel(): ?string
     {
-        if (!$this->operation_category) {
+        if (! $this->operation_category) {
             return null;
         }
 
-        return trans_message('basic_warehouse.operation_categories.' . $this->operation_category);
+        return trans_message('basic_warehouse.operation_categories.'.$this->operation_category);
     }
 
     public function organization(): BelongsTo
     {
         return $this->belongsTo(Organization::class);
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(\App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset::class);
     }
 
     public function warehouse(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryAsset.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryAsset.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Models;
 
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Machinery;
 use App\Models\Project;
 use App\Models\ScheduleTask;
@@ -38,6 +39,7 @@ final class MachineryAsset extends Model
 
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'machinery_id',
         'current_project_id',
         'current_schedule_task_id',
@@ -62,6 +64,11 @@ final class MachineryAsset extends Model
     public function machinery(): BelongsTo
     {
         return $this->belongsTo(Machinery::class);
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
     }
 
     public function currentProject(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryAssignment.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryAssignment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Models;
 
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Project;
 use App\Models\ScheduleTask;
 use App\Models\User;
@@ -18,6 +19,7 @@ final class MachineryAssignment extends Model
 
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'asset_id',
         'project_id',
         'schedule_task_id',
@@ -42,6 +44,11 @@ final class MachineryAssignment extends Model
     public function asset(): BelongsTo
     {
         return $this->belongsTo(MachineryAsset::class, 'asset_id');
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
     }
 
     public function project(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryDowntime.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryDowntime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Models;
 
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Project;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -13,6 +14,7 @@ final class MachineryDowntime extends Model
 {
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'asset_id',
         'project_id',
         'shift_report_id',
@@ -31,6 +33,11 @@ final class MachineryDowntime extends Model
     public function asset(): BelongsTo
     {
         return $this->belongsTo(MachineryAsset::class, 'asset_id');
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
     }
 
     public function project(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryFuelIssue.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryFuelIssue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Models;
 
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -14,6 +15,7 @@ final class MachineryFuelIssue extends Model
 {
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'asset_id',
         'project_id',
         'issued_by_user_id',
@@ -32,6 +34,11 @@ final class MachineryFuelIssue extends Model
     public function asset(): BelongsTo
     {
         return $this->belongsTo(MachineryAsset::class, 'asset_id');
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
     }
 
     public function project(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryMaintenanceOrder.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryMaintenanceOrder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Models;
 
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -17,6 +18,7 @@ final class MachineryMaintenanceOrder extends Model
 
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'asset_id',
         'project_id',
         'requested_by_user_id',
@@ -41,6 +43,11 @@ final class MachineryMaintenanceOrder extends Model
     public function asset(): BelongsTo
     {
         return $this->belongsTo(MachineryAsset::class, 'asset_id');
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
     }
 
     public function project(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryProductionRecord.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryProductionRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Models;
 
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -14,6 +15,7 @@ final class MachineryProductionRecord extends Model
 {
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'asset_id',
         'project_id',
         'shift_report_id',
@@ -31,6 +33,11 @@ final class MachineryProductionRecord extends Model
     public function asset(): BelongsTo
     {
         return $this->belongsTo(MachineryAsset::class, 'asset_id');
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
     }
 
     public function project(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryShiftReport.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryShiftReport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Models;
 
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -18,6 +19,7 @@ final class MachineryShiftReport extends Model
 
     protected $fillable = [
         'organization_id',
+        'organization_asset_id',
         'asset_id',
         'project_id',
         'assignment_id',
@@ -47,6 +49,11 @@ final class MachineryShiftReport extends Model
     public function asset(): BelongsTo
     {
         return $this->belongsTo(MachineryAsset::class, 'asset_id');
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
     }
 
     public function project(): BelongsTo

--- a/app/Console/Commands/Assets/BackfillOrganizationAssets.php
+++ b/app/Console/Commands/Assets/BackfillOrganizationAssets.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Assets;
+
+use App\BusinessModules\Core\AssetManagement\Services\LegacyAssetMapper;
+use Illuminate\Console\Command;
+
+final class BackfillOrganizationAssets extends Command
+{
+    protected $signature = 'assets:backfill {--dry-run : Рассчитать изменения без записи} {--format=table : table или json}';
+
+    protected $description = 'Детерминированно переносит legacy-технику и сериализованные складские записи в единый реестр';
+
+    public function handle(LegacyAssetMapper $mapper): int
+    {
+        $report = $mapper->backfill((bool) $this->option('dry-run'));
+        $this->renderReport($report);
+
+        return $report['conflicts'] === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function renderReport(array $report): void
+    {
+        if ($this->option('format') === 'json') {
+            $this->line((string) json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+
+            return;
+        }
+
+        $this->table(
+            ['dry_run', 'scanned', 'would_create', 'created', 'links_updated', 'already_linked', 'conflicts'],
+            [[
+                $report['dry_run'] ? 'yes' : 'no',
+                $report['scanned'],
+                $report['would_create'],
+                $report['created'],
+                $report['links_updated'],
+                $report['already_linked'],
+                $report['conflicts'],
+            ]],
+        );
+    }
+}

--- a/app/Console/Commands/Assets/ReconcileOrganizationAssets.php
+++ b/app/Console/Commands/Assets/ReconcileOrganizationAssets.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Assets;
+
+use App\BusinessModules\Core\AssetManagement\Services\LegacyAssetMapper;
+use Illuminate\Console\Command;
+
+final class ReconcileOrganizationAssets extends Command
+{
+    protected $signature = 'assets:reconcile {--format=table : table или json}';
+
+    protected $description = 'Сверяет legacy-источники с единым реестром имущества';
+
+    public function handle(LegacyAssetMapper $mapper): int
+    {
+        $report = $mapper->reconcile();
+
+        if ($this->option('format') === 'json') {
+            $this->line((string) json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        } else {
+            $this->table(array_keys($report), [array_values($report)]);
+        }
+
+        return $report['missing'] === 0 && $report['duplicates'] === 0
+            ? self::SUCCESS
+            : self::FAILURE;
+    }
+}

--- a/database/migrations/2026_08_10_000004_add_organization_asset_links.php
+++ b/database/migrations/2026_08_10_000004_add_organization_asset_links.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /** @var list<string> */
+    private array $tables = [
+        'machinery_assets',
+        'machinery_assignments',
+        'machinery_shift_reports',
+        'machinery_downtimes',
+        'machinery_fuel_issues',
+        'machinery_production_records',
+        'machinery_maintenance_orders',
+        'warehouse_movements',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $tableName) {
+            if (! Schema::hasTable($tableName) || Schema::hasColumn($tableName, 'organization_asset_id')) {
+                continue;
+            }
+
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->foreignId('organization_asset_id')
+                    ->nullable()
+                    ->constrained('organization_assets')
+                    ->nullOnDelete();
+            });
+        }
+
+        $this->installWarehouseMovementIdentityGuard(useJsonbComparison: true);
+    }
+
+    public function down(): void
+    {
+        $this->installWarehouseMovementIdentityGuard(useJsonbComparison: false);
+
+        foreach (array_reverse($this->tables) as $tableName) {
+            if (! Schema::hasTable($tableName) || ! Schema::hasColumn($tableName, 'organization_asset_id')) {
+                continue;
+            }
+
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->dropConstrainedForeignId('organization_asset_id');
+            });
+        }
+    }
+
+    private function installWarehouseMovementIdentityGuard(bool $useJsonbComparison): void
+    {
+        if (
+            DB::getDriverName() !== 'pgsql'
+            || ! Schema::hasTable('warehouse_inventory_events')
+            || ! Schema::hasTable('warehouse_movements')
+        ) {
+            return;
+        }
+
+        $metadataComparison = $useJsonbComparison
+            ? 'to_jsonb(NEW.metadata) IS DISTINCT FROM to_jsonb(OLD.metadata)'
+            : 'NEW.metadata IS DISTINCT FROM OLD.metadata';
+
+        DB::unprepared(<<<SQL
+            CREATE OR REPLACE FUNCTION most_warehouse_reporting_movement_identity_v1() RETURNS trigger
+            LANGUAGE plpgsql
+            AS \$\$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                      FROM warehouse_inventory_events
+                     WHERE source_movement_id = OLD.id
+                ) AND (
+                    NEW.organization_id <> OLD.organization_id
+                    OR NEW.warehouse_id <> OLD.warehouse_id
+                    OR NEW.material_id <> OLD.material_id
+                    OR NEW.movement_type <> OLD.movement_type
+                    OR NEW.quantity <> OLD.quantity
+                    OR NEW.movement_date <> OLD.movement_date
+                    OR NEW.from_warehouse_id IS DISTINCT FROM OLD.from_warehouse_id
+                    OR NEW.to_warehouse_id IS DISTINCT FROM OLD.to_warehouse_id
+                    OR NEW.operation_category IS DISTINCT FROM OLD.operation_category
+                    OR NEW.project_material_delivery_id IS DISTINCT FROM OLD.project_material_delivery_id
+                    OR NEW.price IS DISTINCT FROM OLD.price
+                    OR {$metadataComparison}
+                ) THEN
+                    RAISE EXCEPTION 'linked warehouse movement identity is immutable' USING ERRCODE = '55000';
+                END IF;
+                RETURN NEW;
+            END
+            \$\$;
+            SQL);
+    }
+};

--- a/tests/Feature/Console/BackfillOrganizationAssetsTest.php
+++ b/tests/Feature/Console/BackfillOrganizationAssetsTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetOperationalMode;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\BusinessModules\Features\BasicWarehouse\Models\OrganizationWarehouse;
+use App\BusinessModules\Features\BasicWarehouse\Models\WarehouseBalance;
+use App\BusinessModules\Features\BasicWarehouse\Models\WarehouseMovement;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAssignment;
+use App\Models\Material;
+use App\Models\Project;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\AdminApiTestContext;
+use Tests\TestCase;
+
+final class BackfillOrganizationAssetsTest extends TestCase
+{
+    public function test_dry_run_reports_work_without_writing_any_data(): void
+    {
+        $context = AdminApiTestContext::create();
+        $legacy = $this->createMachineryAsset((int) $context->organization->id, 'BF-DRY', 'INV-BF-DRY');
+
+        $exitCode = Artisan::call('assets:backfill', ['--dry-run' => true, '--format' => 'json']);
+        $report = $this->jsonOutput();
+
+        self::assertSame(0, $exitCode);
+        self::assertTrue($report['dry_run']);
+        self::assertSame(1, $report['scanned']);
+        self::assertSame(1, $report['would_create']);
+        self::assertSame(0, $report['created']);
+        self::assertSame(0, $report['conflicts']);
+        self::assertSame(0, OrganizationAsset::query()->count());
+        self::assertNull($legacy->fresh()->organization_asset_id);
+    }
+
+    public function test_two_apply_runs_create_one_asset_and_propagate_shadow_links(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $legacy = $this->createMachineryAsset((int) $context->organization->id, 'BF-IDEMPOTENT', 'INV-BF-IDEMPOTENT');
+        $assignment = MachineryAssignment::query()->create([
+            'organization_id' => $context->organization->id,
+            'asset_id' => $legacy->id,
+            'project_id' => $project->id,
+            'requested_by_user_id' => $context->user->id,
+            'status' => 'active',
+            'planned_start_at' => now(),
+        ]);
+
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+        $firstReport = $this->jsonOutput();
+        self::assertSame(1, $firstReport['created']);
+        self::assertSame(2, $firstReport['links_updated']);
+
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+        $secondReport = $this->jsonOutput();
+        self::assertSame(0, $secondReport['created']);
+        self::assertSame(0, $secondReport['links_updated']);
+        self::assertSame(1, $secondReport['already_linked']);
+
+        $canonical = OrganizationAsset::query()->sole();
+        self::assertSame($canonical->id, $legacy->fresh()->organization_asset_id);
+        self::assertSame($canonical->id, $assignment->fresh()->organization_asset_id);
+        self::assertSame(
+            ['id' => $legacy->id, 'table' => 'machinery_assets'],
+            $canonical->metadata['legacy_source'],
+        );
+        self::assertSame(AssetOperationalMode::ShiftOperation, $canonical->operationProfile->operational_mode);
+        self::assertTrue($canonical->operationProfile->tracks_meter);
+        self::assertTrue($canonical->operationProfile->tracks_fuel);
+        self::assertTrue($canonical->operationProfile->tracks_production);
+        self::assertTrue($canonical->operationProfile->maintenance_enabled);
+    }
+
+    public function test_duplicate_legacy_inventory_numbers_are_reported_and_not_auto_resolved(): void
+    {
+        $context = AdminApiTestContext::create();
+        $first = $this->createMachineryAsset((int) $context->organization->id, 'BF-CONFLICT-A', 'INV-CONFLICT');
+        $second = $this->createMachineryAsset((int) $context->organization->id, 'BF-CONFLICT-B', 'INV-CONFLICT');
+
+        $exitCode = Artisan::call('assets:backfill', ['--format' => 'json']);
+        $report = $this->jsonOutput();
+
+        self::assertSame(1, $exitCode);
+        self::assertSame(2, $report['conflicts']);
+        self::assertCount(2, $report['conflict_records']);
+        self::assertSame(0, OrganizationAsset::query()->count());
+        self::assertNull($first->fresh()->organization_asset_id);
+        self::assertNull($second->fresh()->organization_asset_id);
+    }
+
+    public function test_all_ownership_types_and_legacy_states_are_preserved_without_name_matching(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $owned = $this->createMachineryAsset((int) $context->organization->id, 'BF-OWNED', 'INV-BF-OWNED');
+        $owned->update(['name' => 'Одинаковое название']);
+        $leased = $this->createMachineryAsset((int) $context->organization->id, 'BF-LEASED', 'INV-BF-LEASED');
+        $leased->update([
+            'name' => 'Одинаковое название',
+            'ownership_type' => 'leased',
+            'status' => 'maintenance',
+            'current_project_id' => $project->id,
+        ]);
+        $subcontractor = $this->createMachineryAsset((int) $context->organization->id, 'BF-SUB', 'INV-BF-SUB');
+        $subcontractor->update([
+            'name' => 'Одинаковое название',
+            'ownership_type' => 'subcontractor',
+            'status' => 'archived',
+            'archived_at' => now(),
+        ]);
+
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+
+        $canonical = OrganizationAsset::query()->get()->keyBy(
+            static fn (OrganizationAsset $asset): int => (int) $asset->metadata['legacy_source']['id'],
+        );
+        self::assertSame('owned', $canonical[$owned->id]->ownership_type);
+        self::assertSame('leased', $canonical[$leased->id]->ownership_type);
+        self::assertSame($project->id, $canonical[$leased->id]->current_project_id);
+        self::assertSame(AssetTechnicalStatus::Maintenance, $canonical[$leased->id]->technical_status);
+        self::assertSame('subcontractor', $canonical[$subcontractor->id]->ownership_type);
+        self::assertSame(AssetLifecycleStatus::Retired, $canonical[$subcontractor->id]->lifecycle_status);
+    }
+
+    public function test_existing_mismatched_shadow_link_is_reported_and_never_overwritten(): void
+    {
+        $context = AdminApiTestContext::create();
+        $legacy = $this->createMachineryAsset((int) $context->organization->id, 'BF-MISMATCH', 'INV-BF-MISMATCH');
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+        $mapped = OrganizationAsset::query()->sole();
+        $wrong = OrganizationAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'name' => 'Другая карточка',
+            'inventory_number' => 'INV-WRONG-LINK',
+        ]);
+        $legacy->update(['organization_asset_id' => $wrong->id]);
+
+        self::assertSame(1, Artisan::call('assets:backfill', ['--format' => 'json']));
+        $report = $this->jsonOutput();
+
+        self::assertSame(1, $report['conflicts']);
+        self::assertSame('shadow_link_mismatch', $report['conflict_records'][0]['reason']);
+        self::assertSame($wrong->id, $legacy->fresh()->organization_asset_id);
+        self::assertDatabaseHas('organization_assets', ['id' => $mapped->id]);
+    }
+
+    public function test_serialized_warehouse_balance_is_imported_and_explicit_movements_are_linked(): void
+    {
+        $context = AdminApiTestContext::create();
+        $warehouse = $this->createWarehouse((int) $context->organization->id);
+        $material = Material::query()->create([
+            'organization_id' => $context->organization->id,
+            'name' => 'Шуруповерт Makita',
+            'code' => 'MAKITA-DDF485',
+            'additional_properties' => ['asset_type' => 'tool'],
+        ]);
+        $balance = WarehouseBalance::query()->create([
+            'organization_id' => $context->organization->id,
+            'warehouse_id' => $warehouse->id,
+            'material_id' => $material->id,
+            'available_quantity' => 1,
+            'reserved_quantity' => 0,
+            'average_price' => 15000,
+            'serial_number' => 'MAKITA-SERIAL-1',
+        ]);
+        $movement = WarehouseMovement::query()->create([
+            'organization_id' => $context->organization->id,
+            'warehouse_id' => $warehouse->id,
+            'material_id' => $material->id,
+            'movement_type' => WarehouseMovement::TYPE_RECEIPT,
+            'quantity' => 1,
+            'metadata' => [
+                'warehouse_balance_id' => $balance->id,
+                'reporting_source_version' => 1,
+                'unit_dimension' => 'item',
+                'unit_code' => 'pcs',
+                'unit_conversion_version' => 'v1',
+            ],
+            'movement_date' => now(),
+        ]);
+        DB::table('warehouse_inventory_events')->insert([
+            'organization_id' => $context->organization->id,
+            'warehouse_id' => $warehouse->id,
+            'project_id' => null,
+            'material_id' => $material->id,
+            'source_movement_id' => $movement->id,
+            'source_version' => 1,
+            'event_type' => 'receipt',
+            'on_hand_delta' => 1,
+            'reserved_delta' => 0,
+            'unit_dimension' => 'item',
+            'unit_code' => 'pcs',
+            'conversion_version' => 'v1',
+            'occurred_at' => $movement->movement_date,
+            'source_hash' => str_repeat('0', 64),
+            'source_refs' => '{}',
+        ]);
+
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+
+        $canonical = OrganizationAsset::query()->sole();
+        self::assertSame($material->id, $canonical->material_id);
+        self::assertSame($warehouse->id, $canonical->current_warehouse_id);
+        self::assertSame('WHB-'.$balance->id, $canonical->inventory_number);
+        self::assertSame('MAKITA-SERIAL-1', $canonical->serial_number);
+        self::assertSame(['id' => $balance->id, 'table' => 'warehouse_balances'], $canonical->metadata['legacy_source']);
+        self::assertSame($canonical->id, $movement->fresh()->organization_asset_id);
+
+        try {
+            DB::transaction(static function () use ($movement): void {
+                WarehouseMovement::query()->whereKey($movement->id)->update(['quantity' => 2]);
+            });
+            self::fail('Linked movement identity must remain immutable.');
+        } catch (QueryException) {
+            self::assertSame('1.000', $movement->fresh()->quantity);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function createMachineryAsset(int $organizationId, string $assetCode, ?string $inventoryNumber): MachineryAsset
+    {
+        return MachineryAsset::query()->create([
+            'organization_id' => $organizationId,
+            'asset_code' => $assetCode,
+            'name' => 'Техника '.$assetCode,
+            'inventory_number' => $inventoryNumber,
+            'ownership_type' => 'owned',
+            'status' => 'available',
+            'operating_cost_per_hour' => 1000,
+            'fuel_type' => 'diesel',
+            'meter_hours' => 12,
+        ]);
+    }
+
+    private function createWarehouse(int $organizationId): OrganizationWarehouse
+    {
+        return OrganizationWarehouse::query()->create([
+            'organization_id' => $organizationId,
+            'name' => 'Главный склад',
+            'code' => 'BF-MAIN',
+            'warehouse_type' => OrganizationWarehouse::TYPE_CENTRAL,
+            'is_main' => true,
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/Console/ReconcileOrganizationAssetsTest.php
+++ b/tests/Feature/Console/ReconcileOrganizationAssetsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Support\AdminApiTestContext;
+use Tests\TestCase;
+
+final class ReconcileOrganizationAssetsTest extends TestCase
+{
+    public function test_reconcile_returns_machine_readable_success_report_for_fully_linked_sources(): void
+    {
+        $context = AdminApiTestContext::create();
+        $this->createMachineryAsset((int) $context->organization->id, 'RC-LINKED', 'INV-RC-LINKED');
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+
+        $exitCode = Artisan::call('assets:reconcile', ['--format' => 'json']);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame([
+            'legacy' => 1,
+            'linked' => 1,
+            'missing' => 0,
+            'duplicates' => 0,
+            'field_conflicts' => 0,
+        ], $this->jsonOutput());
+    }
+
+    public function test_reconcile_fails_when_a_legacy_source_is_missing(): void
+    {
+        $context = AdminApiTestContext::create();
+        $this->createMachineryAsset((int) $context->organization->id, 'RC-MISSING', 'INV-RC-MISSING');
+
+        $exitCode = Artisan::call('assets:reconcile', ['--format' => 'json']);
+        $report = $this->jsonOutput();
+
+        self::assertSame(1, $exitCode);
+        self::assertSame(1, $report['legacy']);
+        self::assertSame(0, $report['linked']);
+        self::assertSame(1, $report['missing']);
+        self::assertSame(0, $report['duplicates']);
+    }
+
+    public function test_reconcile_detects_duplicate_source_mapping_and_field_conflicts(): void
+    {
+        $context = AdminApiTestContext::create();
+        $legacy = $this->createMachineryAsset((int) $context->organization->id, 'RC-DUP', 'INV-RC-DUP');
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+        $canonical = OrganizationAsset::query()->sole();
+        $canonical->update(['name' => 'Несовпадающее имя']);
+        OrganizationAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'name' => $legacy->name,
+            'inventory_number' => 'INV-RC-DUP-COPY',
+            'metadata' => ['legacy_source' => ['table' => 'machinery_assets', 'id' => $legacy->id]],
+        ]);
+
+        $exitCode = Artisan::call('assets:reconcile', ['--format' => 'json']);
+        $report = $this->jsonOutput();
+
+        self::assertSame(1, $exitCode);
+        self::assertSame(1, $report['legacy']);
+        self::assertSame(0, $report['linked']);
+        self::assertSame(0, $report['missing']);
+        self::assertSame(1, $report['duplicates']);
+        self::assertSame(1, $report['field_conflicts']);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function createMachineryAsset(int $organizationId, string $assetCode, string $inventoryNumber): MachineryAsset
+    {
+        return MachineryAsset::query()->create([
+            'organization_id' => $organizationId,
+            'asset_code' => $assetCode,
+            'name' => 'Техника '.$assetCode,
+            'inventory_number' => $inventoryNumber,
+            'ownership_type' => 'owned',
+            'status' => 'available',
+            'operating_cost_per_hour' => 1000,
+        ]);
+    }
+}


### PR DESCRIPTION
## Что сделано
- добавлены nullable-связи legacy-таблиц с единым реестром имущества
- реализован детерминированный idempotent backfill с dry-run и явным отчётом конфликтов
- реализована reconcile-команда с машинно-читаемым JSON
- добавлена безопасная связь сериализованных складских остатков без эвристики по имени
- исправлено PostgreSQL-сравнение JSON в штатном guard-триггере складских движений

## Проверки
- PHPUnit: 34 tests, 202 assertions
- PHPStan: no errors
- Laravel Pint: PASS
- migration rollback/reapply: 0 -> 8 columns
- git diff --check: PASS