### PR TITLE
Cut machinery workflows over to canonical assets

### DIFF
--- a/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryAssetResource.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryAssetResource.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\MachineryOperations\Http\Resources;
 
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use App\BusinessModules\Features\MachineryOperations\Services\MachineryAssetProjection;
+use App\BusinessModules\Features\MachineryOperations\Services\MachineryWorkflowPolicy;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -15,28 +18,23 @@ final class MachineryAssetResource extends JsonResource
     {
         /** @var MachineryAsset $asset */
         $asset = $this->resource;
-        $actions = $this->actions($asset->status);
+        $view = app(MachineryAssetProjection::class)->project($asset);
+        $actor = $request->user();
+        $actions = app(MachineryWorkflowPolicy::class)->availableActions(
+            $asset,
+            $actor instanceof User ? $actor : null,
+        );
+        $status = (string) $view['status'];
+        $machinery = $asset->organizationAsset?->machinery ?? $asset->machinery;
+        $currentProject = $asset->organizationAsset?->currentProject ?? $asset->currentProject;
 
         return [
-            'id' => $asset->id,
-            'organization_id' => $asset->organization_id,
-            'machinery_id' => $asset->machinery_id,
-            'current_project_id' => $asset->current_project_id,
-            'current_schedule_task_id' => $asset->current_schedule_task_id,
-            'asset_code' => $asset->asset_code,
-            'name' => $asset->name,
-            'inventory_number' => $asset->inventory_number,
-            'ownership_type' => $asset->ownership_type,
-            'status' => $asset->status,
-            'status_label' => trans_message("machinery_operations.asset_statuses.{$asset->status}"),
-            'operating_cost_per_hour' => $asset->operating_cost_per_hour,
-            'fuel_type' => $asset->fuel_type,
-            'fuel_consumption_rate' => $asset->fuel_consumption_rate,
-            'meter_hours' => $asset->meter_hours,
+            ...$view,
+            'status_label' => trans_message("machinery_operations.asset_statuses.{$status}"),
             'workflow_summary' => [
-                'stage' => $asset->status,
-                'status' => $asset->status,
-                'stage_label' => trans_message("machinery_operations.asset_statuses.{$asset->status}"),
+                'stage' => $status,
+                'status' => $status,
+                'stage_label' => trans_message("machinery_operations.asset_statuses.{$status}"),
                 'next_action' => $actions[0] ?? null,
                 'next_action_label' => $actions === [] ? null : trans_message("machinery_operations.actions.{$actions[0]}"),
                 'available_actions' => $actions,
@@ -46,46 +44,35 @@ final class MachineryAssetResource extends JsonResource
             'problem_flags' => $this->problemFlags($asset),
             'available_actions' => $actions,
             'linked_entities' => [
-                'machinery_id' => $asset->machinery_id,
-                'project_id' => $asset->current_project_id,
+                'machinery_id' => $view['machinery_id'],
+                'organization_asset_id' => $asset->organization_asset_id,
+                'project_id' => $view['current_project_id'],
                 'schedule_task_id' => $asset->current_schedule_task_id,
             ],
-            'machinery' => $this->whenLoaded('machinery', fn () => $asset->machinery ? [
-                'id' => $asset->machinery->id,
-                'name' => $asset->machinery->name,
-                'code' => $asset->machinery->code,
-                'category' => $asset->machinery->category,
-            ] : null),
-            'current_project' => $this->whenLoaded('currentProject', fn () => $asset->currentProject ? [
-                'id' => $asset->currentProject->id,
-                'name' => $asset->currentProject->name,
-            ] : null),
+            'machinery' => $machinery ? [
+                'id' => $machinery->id,
+                'name' => $machinery->name,
+                'code' => $machinery->code,
+                'category' => $machinery->category,
+            ] : null,
+            'current_project' => $currentProject ? [
+                'id' => $currentProject->id,
+                'name' => $currentProject->name,
+            ] : null,
             'current_schedule_task' => $this->whenLoaded('currentScheduleTask', fn () => $asset->currentScheduleTask ? [
                 'id' => $asset->currentScheduleTask->id,
                 'name' => $asset->currentScheduleTask->name,
             ] : null),
-            'metadata' => $asset->metadata,
             'archived_at' => $asset->archived_at?->toIso8601String(),
             'created_at' => $asset->created_at?->toIso8601String(),
             'updated_at' => $asset->updated_at?->toIso8601String(),
         ];
     }
 
-    private function actions(string $status): array
-    {
-        return match ($status) {
-            'available' => ['assign', 'maintenance', 'unavailable', 'archive'],
-            'assigned' => ['start_operation', 'return_available', 'maintenance'],
-            'in_operation' => ['return_available', 'maintenance', 'unavailable'],
-            'maintenance' => ['return_available'],
-            'unavailable' => ['return_available', 'maintenance', 'archive'],
-            default => [],
-        };
-    }
-
     private function problemFlags(MachineryAsset $asset): array
     {
-        if ($asset->status === 'unavailable') {
+        $status = app(MachineryWorkflowPolicy::class)->status($asset);
+        if ($status === 'unavailable') {
             return [[
                 'code' => 'asset_unavailable',
                 'severity' => 'warning',
@@ -93,7 +80,7 @@ final class MachineryAssetResource extends JsonResource
             ]];
         }
 
-        if ($asset->status === 'maintenance') {
+        if ($status === 'maintenance') {
             return [[
                 'code' => 'asset_in_maintenance',
                 'severity' => 'warning',

--- a/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryOperationRecordResource.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryOperationRecordResource.php
@@ -9,6 +9,8 @@ use App\BusinessModules\Features\MachineryOperations\Models\MachineryDowntime;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryFuelIssue;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryMaintenanceOrder;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryProductionRecord;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -21,7 +23,7 @@ final class MachineryOperationRecordResource extends JsonResource
             $this->resource instanceof MachineryDowntime => $this->downtime($this->resource),
             $this->resource instanceof MachineryFuelIssue => $this->fuelIssue($this->resource),
             $this->resource instanceof MachineryProductionRecord => $this->productionRecord($this->resource),
-            $this->resource instanceof MachineryMaintenanceOrder => $this->maintenanceOrder($this->resource),
+            $this->resource instanceof MachineryMaintenanceOrder => $this->maintenanceOrder($request, $this->resource),
             default => [],
         };
     }
@@ -31,6 +33,7 @@ final class MachineryOperationRecordResource extends JsonResource
         return [
             'id' => $assignment->id,
             'asset_id' => $assignment->asset_id,
+            'organization_asset_id' => $assignment->organization_asset_id,
             'project_id' => $assignment->project_id,
             'schedule_task_id' => $assignment->schedule_task_id,
             'requested_by_user_id' => $assignment->requested_by_user_id,
@@ -44,6 +47,7 @@ final class MachineryOperationRecordResource extends JsonResource
             'comment' => $assignment->comment,
             'linked_entities' => [
                 'asset_id' => $assignment->asset_id,
+                'organization_asset_id' => $assignment->organization_asset_id,
                 'project_id' => $assignment->project_id,
                 'schedule_task_id' => $assignment->schedule_task_id,
             ],
@@ -55,6 +59,7 @@ final class MachineryOperationRecordResource extends JsonResource
         return [
             'id' => $downtime->id,
             'asset_id' => $downtime->asset_id,
+            'organization_asset_id' => $downtime->organization_asset_id,
             'project_id' => $downtime->project_id,
             'shift_report_id' => $downtime->shift_report_id,
             'reason' => $downtime->reason,
@@ -70,6 +75,7 @@ final class MachineryOperationRecordResource extends JsonResource
         return [
             'id' => $fuelIssue->id,
             'asset_id' => $fuelIssue->asset_id,
+            'organization_asset_id' => $fuelIssue->organization_asset_id,
             'project_id' => $fuelIssue->project_id,
             'issued_by_user_id' => $fuelIssue->issued_by_user_id,
             'issued_at' => $fuelIssue->issued_at?->toIso8601String(),
@@ -86,6 +92,7 @@ final class MachineryOperationRecordResource extends JsonResource
         return [
             'id' => $record->id,
             'asset_id' => $record->asset_id,
+            'organization_asset_id' => $record->organization_asset_id,
             'project_id' => $record->project_id,
             'shift_report_id' => $record->shift_report_id,
             'recorded_by_user_id' => $record->recorded_by_user_id,
@@ -96,16 +103,23 @@ final class MachineryOperationRecordResource extends JsonResource
         ];
     }
 
-    private function maintenanceOrder(MachineryMaintenanceOrder $order): array
+    private function maintenanceOrder(Request $request, MachineryMaintenanceOrder $order): array
     {
-        $actions = match ($order->status) {
+        $candidateActions = match ($order->status) {
             'open', 'in_progress' => ['complete'],
             default => [],
         };
+        $actor = $request->user();
+        $actions = $actor instanceof User && app(AuthorizationService::class)->can(
+            $actor,
+            'machinery-operations.downtime.manage',
+            ['organization_id' => (int) $order->organization_id],
+        ) ? $candidateActions : [];
 
         return [
             'id' => $order->id,
             'asset_id' => $order->asset_id,
+            'organization_asset_id' => $order->organization_asset_id,
             'project_id' => $order->project_id,
             'requested_by_user_id' => $order->requested_by_user_id,
             'completed_by_user_id' => $order->completed_by_user_id,
@@ -134,6 +148,7 @@ final class MachineryOperationRecordResource extends JsonResource
             'available_actions' => $actions,
             'linked_entities' => [
                 'asset_id' => $order->asset_id,
+                'organization_asset_id' => $order->organization_asset_id,
                 'project_id' => $order->project_id,
             ],
         ];

--- a/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryShiftReportResource.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryShiftReportResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\MachineryOperations\Http\Resources;
 
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryShiftReport;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -15,16 +17,29 @@ final class MachineryShiftReportResource extends JsonResource
     {
         /** @var MachineryShiftReport $shift */
         $shift = $this->resource;
-        $actions = match ($shift->status) {
+        $candidateActions = match ($shift->status) {
             'draft' => ['submit'],
             'submitted' => ['approve', 'reject'],
             default => [],
         };
+        $actor = $request->user();
+        $actions = $actor instanceof User
+            ? array_values(array_filter($candidateActions, function (string $action) use ($actor, $shift): bool {
+                $permission = $action === 'submit'
+                    ? 'machinery-operations.shifts.create'
+                    : 'machinery-operations.shifts.approve';
+
+                return app(AuthorizationService::class)->can($actor, $permission, [
+                    'organization_id' => (int) $shift->organization_id,
+                ]);
+            }))
+            : [];
 
         return [
             'id' => $shift->id,
             'organization_id' => $shift->organization_id,
             'asset_id' => $shift->asset_id,
+            'organization_asset_id' => $shift->organization_asset_id,
             'project_id' => $shift->project_id,
             'assignment_id' => $shift->assignment_id,
             'reported_by_user_id' => $shift->reported_by_user_id,
@@ -56,6 +71,7 @@ final class MachineryShiftReportResource extends JsonResource
             'available_actions' => $actions,
             'linked_entities' => [
                 'asset_id' => $shift->asset_id,
+                'organization_asset_id' => $shift->organization_asset_id,
                 'project_id' => $shift->project_id,
                 'assignment_id' => $shift->assignment_id,
             ],

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetProjection.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetProjection.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\MachineryOperations\Services;
+
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+
+final readonly class MachineryAssetProjection
+{
+    public function __construct(private MachineryWorkflowPolicy $workflow) {}
+
+    /** @return array<string, mixed> */
+    public function project(MachineryAsset $legacy): array
+    {
+        $canonical = $legacy->organizationAsset;
+
+        return [
+            'id' => (int) $legacy->id,
+            'organization_asset_id' => $canonical?->id,
+            'organization_id' => (int) $legacy->organization_id,
+            'machinery_id' => $canonical?->machinery_id ?? $legacy->machinery_id,
+            'current_project_id' => $canonical?->current_project_id ?? $legacy->current_project_id,
+            'current_schedule_task_id' => $legacy->current_schedule_task_id,
+            'asset_code' => $legacy->asset_code,
+            'name' => $canonical?->name ?? $legacy->name,
+            'inventory_number' => $canonical?->inventory_number ?? $legacy->inventory_number,
+            'serial_number' => $canonical?->serial_number,
+            'qr_code' => $canonical?->qr_code,
+            'ownership_type' => $canonical?->ownership_type ?? $legacy->ownership_type,
+            'status' => $this->workflow->status($legacy),
+            'lifecycle_status' => $canonical?->lifecycle_status?->value,
+            'technical_status' => $canonical?->technical_status?->value,
+            'current_warehouse_id' => $canonical?->current_warehouse_id,
+            'responsible_user_id' => $canonical?->responsible_user_id,
+            'operating_cost_per_hour' => $legacy->operating_cost_per_hour,
+            'fuel_type' => $legacy->fuel_type,
+            'fuel_consumption_rate' => $legacy->fuel_consumption_rate,
+            'meter_hours' => $legacy->meter_hours,
+            'metadata' => $canonical?->metadata ?? $legacy->metadata,
+        ];
+    }
+}

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetReadRepository.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetReadRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\MachineryOperations\Services;
+
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+final class MachineryAssetReadRepository
+{
+    private const RELATIONS = [
+        'machinery:id,name,code,category',
+        'currentProject:id,name',
+        'currentScheduleTask:id,name',
+        'organizationAsset.operationProfile',
+        'organizationAsset.machinery:id,name,code,category',
+        'organizationAsset.currentProject:id,name',
+    ];
+
+    public function paginate(int $organizationId, int $perPage, array $filters = []): LengthAwarePaginator
+    {
+        return MachineryAsset::forOrganization($organizationId)
+            ->with(self::RELATIONS)
+            ->when(array_key_exists('project_ids', $filters), function ($query) use ($filters): void {
+                $query->where(function ($projectQuery) use ($filters): void {
+                    $projectQuery->whereNull('current_project_id')
+                        ->orWhereIn('current_project_id', $filters['project_ids'])
+                        ->orWhereHas('organizationAsset', fn ($canonical) => $canonical->whereIn('current_project_id', $filters['project_ids']));
+                });
+            })
+            ->when(! empty($filters['project_id']), function ($query) use ($filters): void {
+                $projectId = (int) $filters['project_id'];
+                $query->where(fn ($nested) => $nested->where('current_project_id', $projectId)
+                    ->orWhereHas('organizationAsset', fn ($canonical) => $canonical->where('current_project_id', $projectId)));
+            })
+            ->when(! empty($filters['status']), fn ($query) => $query->where('status', (string) $filters['status']))
+            ->orderBy('name')
+            ->paginate($perPage);
+    }
+
+    public function find(int $organizationId, int $id): ?MachineryAsset
+    {
+        return MachineryAsset::forOrganization($organizationId)->with(self::RELATIONS)->find($id);
+    }
+}

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace App\BusinessModules\Features\MachineryOperations\Services;
 
+use App\BusinessModules\Core\AssetManagement\DTO\AssetPlacementData;
+use App\BusinessModules\Core\AssetManagement\DTO\CreateOrganizationAssetData;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetOperationalMode;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\BusinessModules\Core\AssetManagement\Services\OrganizationAssetService;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAssignment;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryDowntime;
@@ -24,20 +31,15 @@ final class MachineryOperationsService
 
     private const SHIFT_RELATIONS = ['asset:id,name,asset_code,status', 'project:id,name', 'assignment:id,status'];
 
+    public function __construct(
+        private readonly MachineryAssetReadRepository $assets,
+        private readonly OrganizationAssetService $organizationAssets,
+        private readonly MachineryWorkflowPolicy $workflow,
+    ) {}
+
     public function paginateAssets(int $organizationId, int $perPage = 20, array $filters = []): LengthAwarePaginator
     {
-        return MachineryAsset::forOrganization($organizationId)
-            ->with(self::ASSET_RELATIONS)
-            ->when(array_key_exists('project_ids', $filters), function ($query) use ($filters): void {
-                $query->where(function ($projectQuery) use ($filters): void {
-                    $projectQuery->whereNull('current_project_id')
-                        ->orWhereIn('current_project_id', $filters['project_ids']);
-                });
-            })
-            ->when(! empty($filters['project_id']), fn ($query) => $query->where('current_project_id', (int) $filters['project_id']))
-            ->when(! empty($filters['status']), fn ($query) => $query->where('status', (string) $filters['status']))
-            ->orderBy('name')
-            ->paginate($perPage);
+        return $this->assets->paginate($organizationId, $perPage, $filters);
     }
 
     public function paginateShifts(int $organizationId, int $perPage = 20, array $filters = []): LengthAwarePaginator
@@ -69,29 +71,52 @@ final class MachineryOperationsService
         $this->assertOptionalProjectBelongsToOrganization($data['current_project_id'] ?? null, $organizationId);
         $this->assertOptionalScheduleTaskBelongsToOrganization($data['current_schedule_task_id'] ?? null, $organizationId);
 
-        return MachineryAsset::query()->create([
-            'organization_id' => $organizationId,
-            'machinery_id' => $data['machinery_id'] ?? null,
-            'current_project_id' => $data['current_project_id'] ?? null,
-            'current_schedule_task_id' => $data['current_schedule_task_id'] ?? null,
-            'asset_code' => $data['asset_code'],
-            'name' => $data['name'],
-            'inventory_number' => $data['inventory_number'] ?? null,
-            'ownership_type' => $data['ownership_type'] ?? 'owned',
-            'status' => 'available',
-            'operating_cost_per_hour' => $data['operating_cost_per_hour'] ?? 0,
-            'fuel_type' => $data['fuel_type'] ?? null,
-            'fuel_consumption_rate' => $data['fuel_consumption_rate'] ?? null,
-            'meter_hours' => $data['meter_hours'] ?? 0,
-            'metadata' => $data['metadata'] ?? null,
-        ])->fresh(self::ASSET_RELATIONS);
+        return DB::transaction(function () use ($organizationId, $data): MachineryAsset {
+            $initialStatus = isset($data['current_project_id']) ? 'assigned' : 'available';
+            $legacy = MachineryAsset::query()->create([
+                'organization_id' => $organizationId,
+                'machinery_id' => $data['machinery_id'] ?? null,
+                'current_project_id' => $data['current_project_id'] ?? null,
+                'current_schedule_task_id' => $data['current_schedule_task_id'] ?? null,
+                'asset_code' => $data['asset_code'],
+                'name' => $data['name'],
+                'inventory_number' => $data['inventory_number'] ?? null,
+                'ownership_type' => $data['ownership_type'] ?? 'owned',
+                'status' => $initialStatus,
+                'operating_cost_per_hour' => $data['operating_cost_per_hour'] ?? 0,
+                'fuel_type' => $data['fuel_type'] ?? null,
+                'fuel_consumption_rate' => $data['fuel_consumption_rate'] ?? null,
+                'meter_hours' => $data['meter_hours'] ?? 0,
+                'metadata' => $data['metadata'] ?? null,
+            ]);
+            $canonical = $this->organizationAssets->create($organizationId, new CreateOrganizationAssetData(
+                name: (string) $legacy->name,
+                inventoryNumber: (string) ($legacy->inventory_number ?: $legacy->asset_code),
+                ownershipType: (string) $legacy->ownership_type,
+                machineryId: $legacy->machinery_id !== null ? (int) $legacy->machinery_id : null,
+                placement: $legacy->current_project_id !== null
+                    ? new AssetPlacementData(projectId: (int) $legacy->current_project_id)
+                    : null,
+                metadata: [
+                    'legacy_source' => ['table' => 'machinery_assets', 'id' => (int) $legacy->id],
+                    'machinery_operation_status' => $initialStatus,
+                ],
+                operationalMode: AssetOperationalMode::ShiftOperation,
+                tracksMeter: true,
+                tracksFuel: $legacy->fuel_type !== null || $legacy->fuel_consumption_rate !== null,
+                tracksProduction: true,
+                maintenanceEnabled: true,
+                meterUnit: 'hour',
+            ));
+            $legacy->update(['organization_asset_id' => $canonical->id]);
+
+            return $this->assets->find($organizationId, (int) $legacy->id) ?? $legacy;
+        });
     }
 
     public function findAsset(int $organizationId, int $id): ?MachineryAsset
     {
-        return MachineryAsset::forOrganization($organizationId)
-            ->with(self::ASSET_RELATIONS)
-            ->find($id);
+        return $this->assets->find($organizationId, $id);
     }
 
     public function assignAsset(MachineryAsset $asset, int $userId, array $data): MachineryAssignment
@@ -99,7 +124,7 @@ final class MachineryOperationsService
         return DB::transaction(function () use ($asset, $userId, $data): MachineryAssignment {
             $lockedAsset = $this->requireLockedAsset((int) $asset->id, (int) $asset->organization_id);
 
-            if (! in_array($lockedAsset->status, ['available', 'assigned'], true)) {
+            if (! in_array($this->workflow->status($lockedAsset), ['available', 'assigned'], true)) {
                 throw new DomainException(trans_message('machinery_operations.errors.asset_assign_invalid_status'));
             }
 
@@ -119,6 +144,7 @@ final class MachineryOperationsService
 
             $assignment = MachineryAssignment::query()->create([
                 'organization_id' => $lockedAsset->organization_id,
+                'organization_asset_id' => $lockedAsset->organization_asset_id,
                 'asset_id' => $lockedAsset->id,
                 'project_id' => (int) $data['project_id'],
                 'schedule_task_id' => $data['schedule_task_id'] ?? null,
@@ -137,6 +163,7 @@ final class MachineryOperationsService
                 'current_project_id' => (int) $data['project_id'],
                 'current_schedule_task_id' => $data['schedule_task_id'] ?? null,
             ]);
+            $this->moveCanonicalToProject($lockedAsset, (int) $data['project_id'], $userId, 'assigned');
 
             return $assignment->fresh(['asset', 'project', 'scheduleTask']);
         });
@@ -144,40 +171,43 @@ final class MachineryOperationsService
 
     public function startOperation(MachineryAsset $asset): MachineryAsset
     {
-        if ($asset->status !== 'assigned') {
+        if ($this->workflow->status($asset) !== 'assigned') {
             throw new DomainException(trans_message('machinery_operations.errors.asset_start_invalid_status'));
         }
 
         $asset->update(['status' => 'in_operation']);
+        $this->updateCanonicalState($asset, operationStatus: 'in_operation');
 
         return $asset->fresh(self::ASSET_RELATIONS);
     }
 
     public function setMaintenance(MachineryAsset $asset): MachineryAsset
     {
-        if (! in_array($asset->status, ['available', 'assigned', 'in_operation', 'unavailable'], true)) {
+        if (! in_array($this->workflow->status($asset), ['available', 'assigned', 'in_operation', 'unavailable'], true)) {
             throw new DomainException(trans_message('machinery_operations.errors.asset_maintenance_invalid_status'));
         }
 
         $asset->update(['status' => 'maintenance']);
+        $this->updateCanonicalState($asset, technicalStatus: AssetTechnicalStatus::Maintenance);
 
         return $asset->fresh(self::ASSET_RELATIONS);
     }
 
     public function setUnavailable(MachineryAsset $asset): MachineryAsset
     {
-        if ($asset->status === 'archived') {
+        if ($this->workflow->status($asset) === 'archived') {
             throw new DomainException(trans_message('machinery_operations.errors.asset_unavailable_invalid_status'));
         }
 
         $asset->update(['status' => 'unavailable']);
+        $this->updateCanonicalState($asset, technicalStatus: AssetTechnicalStatus::Unavailable);
 
         return $asset->fresh(self::ASSET_RELATIONS);
     }
 
     public function returnAvailable(MachineryAsset $asset): MachineryAsset
     {
-        if (! in_array($asset->status, ['assigned', 'in_operation', 'maintenance', 'unavailable'], true)) {
+        if (! in_array($this->workflow->status($asset), ['assigned', 'in_operation', 'maintenance', 'unavailable'], true)) {
             throw new DomainException(trans_message('machinery_operations.errors.asset_available_invalid_status'));
         }
 
@@ -186,6 +216,12 @@ final class MachineryOperationsService
             'current_project_id' => null,
             'current_schedule_task_id' => null,
         ]);
+        $this->updateCanonicalState(
+            $asset,
+            operationStatus: 'available',
+            technicalStatus: AssetTechnicalStatus::Serviceable,
+            clearPlacement: true,
+        );
 
         MachineryAssignment::forOrganization((int) $asset->organization_id)
             ->where('asset_id', $asset->id)
@@ -197,7 +233,7 @@ final class MachineryOperationsService
 
     public function archiveAsset(MachineryAsset $asset): MachineryAsset
     {
-        if (in_array($asset->status, ['assigned', 'in_operation'], true)) {
+        if (in_array($this->workflow->status($asset), ['assigned', 'in_operation'], true)) {
             throw new DomainException(trans_message('machinery_operations.errors.asset_archive_invalid_status'));
         }
 
@@ -205,6 +241,7 @@ final class MachineryOperationsService
             'status' => 'archived',
             'archived_at' => now(),
         ]);
+        $this->updateCanonicalState($asset, lifecycleStatus: AssetLifecycleStatus::Retired);
 
         return $asset->fresh(self::ASSET_RELATIONS);
     }
@@ -223,12 +260,13 @@ final class MachineryOperationsService
                 $projectId,
             );
 
-            if (! in_array($asset->status, ['assigned', 'in_operation'], true)) {
+            if (! in_array($this->workflow->status($asset), ['assigned', 'in_operation'], true)) {
                 throw new DomainException(trans_message('machinery_operations.errors.shift_asset_not_operational'));
             }
 
             return MachineryShiftReport::query()->create([
                 'organization_id' => $organizationId,
+                'organization_asset_id' => $asset->organization_asset_id,
                 'asset_id' => $asset->id,
                 'project_id' => $projectId,
                 'assignment_id' => $data['assignment_id'] ?? null,
@@ -278,6 +316,15 @@ final class MachineryOperationsService
 
             if ($shift->meter_end !== null) {
                 $shift->asset()->update(['meter_hours' => $shift->meter_end]);
+                $asset = $shift->asset()->first();
+                if ($asset !== null) {
+                    $canonical = $this->canonicalAsset($asset, true);
+                    if ($canonical !== null) {
+                        $metadata = is_array($canonical->metadata) ? $canonical->metadata : [];
+                        $metadata['meter_hours'] = (float) $shift->meter_end;
+                        $canonical->update(['metadata' => $metadata]);
+                    }
+                }
             }
 
             return $shift->fresh(self::SHIFT_RELATIONS);
@@ -315,6 +362,7 @@ final class MachineryOperationsService
 
             return MachineryDowntime::query()->create([
                 'organization_id' => $organizationId,
+                'organization_asset_id' => $asset->organization_asset_id,
                 'asset_id' => $asset->id,
                 'project_id' => $projectId,
                 'shift_report_id' => $data['shift_report_id'] ?? null,
@@ -342,6 +390,7 @@ final class MachineryOperationsService
 
             return MachineryProductionRecord::query()->create([
                 'organization_id' => $organizationId,
+                'organization_asset_id' => $asset->organization_asset_id,
                 'asset_id' => $asset->id,
                 'project_id' => $projectId,
                 'shift_report_id' => $data['shift_report_id'] ?? null,
@@ -364,6 +413,7 @@ final class MachineryOperationsService
 
             return MachineryFuelIssue::query()->create([
                 'organization_id' => $organizationId,
+                'organization_asset_id' => $asset->organization_asset_id,
                 'asset_id' => $asset->id,
                 'project_id' => $projectId,
                 'issued_by_user_id' => $userId,
@@ -385,6 +435,7 @@ final class MachineryOperationsService
         return DB::transaction(function () use ($organizationId, $userId, $data, $asset): MachineryMaintenanceOrder {
             $order = MachineryMaintenanceOrder::query()->create([
                 'organization_id' => $organizationId,
+                'organization_asset_id' => $asset->organization_asset_id,
                 'asset_id' => $asset->id,
                 'project_id' => $data['project_id'] ?? $asset->current_project_id,
                 'requested_by_user_id' => $userId,
@@ -399,6 +450,7 @@ final class MachineryOperationsService
             ]);
 
             $asset->update(['status' => 'maintenance']);
+            $this->updateCanonicalState($asset, technicalStatus: AssetTechnicalStatus::Maintenance);
 
             return $order->fresh(['asset:id,name,asset_code,status', 'project:id,name']);
         });
@@ -419,6 +471,10 @@ final class MachineryOperationsService
             ]);
 
             $order->asset()->update(['status' => 'available']);
+            $asset = $order->asset()->first();
+            if ($asset !== null) {
+                $this->completeCanonicalMaintenance($asset, $order, $userId, $comment);
+            }
 
             return $order->fresh(['asset:id,name,asset_code,status', 'project:id,name']);
         });
@@ -642,5 +698,92 @@ final class MachineryOperationsService
     private function nextNumber(string $prefix, int $organizationId): string
     {
         return sprintf('%s-%d-%s', $prefix, $organizationId, now()->format('YmdHisv'));
+    }
+
+    private function moveCanonicalToProject(MachineryAsset $asset, int $projectId, int $actorId, string $operationStatus): void
+    {
+        $canonical = $this->canonicalAsset($asset);
+        if ($canonical === null) {
+            return;
+        }
+
+        $this->organizationAssets->move(
+            $canonical,
+            new AssetPlacementData(projectId: $projectId),
+            $actorId,
+            'machinery_assigned',
+        );
+        $this->updateCanonicalState($asset, operationStatus: $operationStatus);
+    }
+
+    private function updateCanonicalState(
+        MachineryAsset $asset,
+        ?string $operationStatus = null,
+        ?AssetTechnicalStatus $technicalStatus = null,
+        ?AssetLifecycleStatus $lifecycleStatus = null,
+        bool $clearPlacement = false,
+    ): void {
+        $canonical = $this->canonicalAsset($asset, true);
+        if ($canonical === null) {
+            return;
+        }
+
+        $metadata = is_array($canonical->metadata) ? $canonical->metadata : [];
+        if ($operationStatus !== null) {
+            $metadata['machinery_operation_status'] = $operationStatus;
+        }
+
+        $attributes = ['metadata' => $metadata];
+        if ($technicalStatus !== null) {
+            $attributes['technical_status'] = $technicalStatus;
+        }
+        if ($lifecycleStatus !== null) {
+            $attributes['lifecycle_status'] = $lifecycleStatus;
+        }
+        if ($clearPlacement) {
+            $attributes['current_project_id'] = null;
+            $attributes['current_warehouse_id'] = null;
+            $attributes['responsible_user_id'] = null;
+        }
+
+        $canonical->update($attributes);
+    }
+
+    private function completeCanonicalMaintenance(
+        MachineryAsset $asset,
+        MachineryMaintenanceOrder $order,
+        int $userId,
+        ?string $comment,
+    ): void {
+        $canonical = $this->canonicalAsset($asset, true);
+        if ($canonical === null) {
+            return;
+        }
+
+        $metadata = is_array($canonical->metadata) ? $canonical->metadata : [];
+        $metadata['machinery_operation_status'] = $canonical->current_project_id === null ? 'available' : 'assigned';
+        $metadata['last_control_inspection'] = [
+            'result' => 'serviceable',
+            'maintenance_order_id' => (int) $order->id,
+            'inspected_by_user_id' => $userId,
+            'comment' => $comment,
+            'occurred_at' => now()->toIso8601String(),
+        ];
+        $canonical->update([
+            'technical_status' => AssetTechnicalStatus::Serviceable,
+            'metadata' => $metadata,
+        ]);
+    }
+
+    private function canonicalAsset(MachineryAsset $asset, bool $lock = false): ?OrganizationAsset
+    {
+        if ($asset->organization_asset_id === null) {
+            return null;
+        }
+
+        return OrganizationAsset::forOrganization((int) $asset->organization_id)
+            ->whereKey((int) $asset->organization_asset_id)
+            ->when($lock, fn ($query) => $query->lockForUpdate())
+            ->first();
     }
 }

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryWorkflowPolicy.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryWorkflowPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\MachineryOperations\Services;
+
+use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Models\User;
+
+final readonly class MachineryWorkflowPolicy
+{
+    /** @var array<string, string> */
+    private const ACTION_PERMISSIONS = [
+        'assign' => 'machinery-operations.requests.approve',
+        'start_operation' => 'machinery-operations.shifts.create',
+        'return_available' => 'machinery-operations.edit',
+        'maintenance' => 'machinery-operations.downtime.manage',
+        'unavailable' => 'machinery-operations.downtime.manage',
+        'archive' => 'machinery-operations.delete',
+    ];
+
+    public function __construct(private AuthorizationService $authorization) {}
+
+    public function status(MachineryAsset $asset): string
+    {
+        $canonical = $asset->organizationAsset;
+
+        if ($canonical === null) {
+            return (string) $asset->status;
+        }
+
+        if ($canonical->lifecycle_status !== AssetLifecycleStatus::Active) {
+            return 'archived';
+        }
+
+        if ($canonical->technical_status === AssetTechnicalStatus::Maintenance) {
+            return 'maintenance';
+        }
+
+        if (in_array($canonical->technical_status, [AssetTechnicalStatus::Restricted, AssetTechnicalStatus::Unavailable], true)) {
+            return 'unavailable';
+        }
+
+        $metadata = is_array($canonical->metadata) ? $canonical->metadata : [];
+        $operationStatus = $metadata['machinery_operation_status'] ?? null;
+
+        if ($canonical->current_project_id !== null && in_array($operationStatus, ['assigned', 'in_operation'], true)) {
+            return $operationStatus;
+        }
+
+        return $canonical->current_project_id !== null ? 'assigned' : 'available';
+    }
+
+    /** @return list<string> */
+    public function availableActions(MachineryAsset $asset, ?User $actor): array
+    {
+        if ($actor === null) {
+            return [];
+        }
+
+        $actions = match ($this->status($asset)) {
+            'available' => ['assign', 'maintenance', 'unavailable', 'archive'],
+            'assigned' => ['start_operation', 'return_available', 'maintenance'],
+            'in_operation' => ['return_available', 'maintenance', 'unavailable'],
+            'maintenance' => ['return_available'],
+            'unavailable' => ['return_available', 'maintenance', 'archive'],
+            default => [],
+        };
+        $context = ['organization_id' => (int) $asset->organization_id];
+
+        return array_values(array_filter(
+            $actions,
+            fn (string $action): bool => $this->authorization->can($actor, self::ACTION_PERMISSIONS[$action], $context),
+        ));
+    }
+}

--- a/tests/Feature/Api/V1/Admin/MachineryOperationsCanonicalAssetTest.php
+++ b/tests/Feature/Api/V1/Admin/MachineryOperationsCanonicalAssetTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Admin;
+
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\Domain\Authorization\Models\AuthorizationContext;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Http\Middleware\WebInterfaceSecurityMiddleware;
+use App\Models\Project;
+use App\Models\User;
+use App\Modules\Core\AccessController;
+use Mockery\MockInterface;
+use Tests\Support\AdminApiTestContext;
+use Tests\TestCase;
+
+final class MachineryOperationsCanonicalAssetTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(WebInterfaceSecurityMiddleware::class);
+    }
+
+    public function test_admin_workflow_writes_authoritative_canonical_state_and_shadow_links(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $this->actingAs($context->user, 'api_admin');
+        $this->allowAccess();
+
+        $created = $this->withHeaders($context->authHeaders())->postJson('/api/v1/admin/machinery-operations/assets', [
+            'asset_code' => 'CAN-EXC-1',
+            'name' => 'Canonical excavator',
+            'inventory_number' => 'CAN-INV-1',
+            'ownership_type' => 'owned',
+            'fuel_type' => 'diesel',
+        ]);
+
+        $created->assertCreated()
+            ->assertJsonPath('data.name', 'Canonical excavator')
+            ->assertJsonPath('data.status', 'available');
+        $legacyId = (int) $created->json('data.id');
+        $canonicalId = (int) $created->json('data.organization_asset_id');
+        self::assertGreaterThan(0, $canonicalId);
+
+        $this->withHeaders($context->authHeaders())->postJson("/api/v1/admin/machinery-operations/assets/{$legacyId}/assign", [
+            'project_id' => $project->id,
+            'planned_start_at' => now()->toIso8601String(),
+        ])->assertOk();
+
+        $this->assertDatabaseHas('machinery_assignments', [
+            'asset_id' => $legacyId,
+            'organization_asset_id' => $canonicalId,
+        ]);
+        $canonical = OrganizationAsset::query()->findOrFail($canonicalId);
+        self::assertSame((int) $project->id, (int) $canonical->current_project_id);
+        self::assertSame('assigned', $canonical->metadata['machinery_operation_status']);
+
+        $maintenance = $this->withHeaders($context->authHeaders())->postJson('/api/v1/admin/machinery-operations/maintenance-orders', [
+            'asset_id' => $legacyId,
+            'title' => 'Control service',
+        ])->assertCreated();
+        self::assertSame(AssetTechnicalStatus::Maintenance, $canonical->refresh()->technical_status);
+
+        $this->withHeaders($context->authHeaders())->postJson(
+            '/api/v1/admin/machinery-operations/maintenance-orders/'.$maintenance->json('data.id').'/complete',
+            ['completion_comment' => 'Контрольный осмотр пройден'],
+        )->assertOk();
+
+        $canonical->refresh();
+        self::assertSame(AssetTechnicalStatus::Serviceable, $canonical->technical_status);
+        self::assertSame('serviceable', $canonical->metadata['last_control_inspection']['result']);
+    }
+
+    private function allowAccess(): void
+    {
+        $this->mock(AccessController::class, fn (MockInterface $mock) => $mock->shouldReceive('hasModuleAccess')->andReturn(true));
+        $this->mock(AuthorizationService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('canAccessInterface')->andReturn(true);
+            $mock->shouldReceive('can')->andReturn(true);
+            $mock->shouldReceive('hasRole')->andReturn(true);
+            $mock->shouldReceive('getUserRoleSlugs')->andReturn(['web_admin']);
+            $mock->shouldReceive('getUserRoles')->andReturnUsing(
+                static fn (User $user, ?AuthorizationContext $context = null) => $user->roleAssignments()->where('is_active', true)->get(),
+            );
+        });
+    }
+}

--- a/tests/Feature/Api/V1/Mobile/MachineryOperationsCanonicalAssetTest.php
+++ b/tests/Feature/Api/V1/Mobile/MachineryOperationsCanonicalAssetTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Mobile;
+
+use App\BusinessModules\Core\AssetManagement\Enums\AssetAccountingMode;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAssignment;
+use App\Domain\Authorization\Models\AuthorizationContext;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Models\Project;
+use App\Models\User;
+use App\Modules\Core\AccessController;
+use Mockery\MockInterface;
+use Tests\Support\AdminApiTestContext;
+use Tests\TestCase;
+
+final class MachineryOperationsCanonicalAssetTest extends TestCase
+{
+    public function test_mobile_payload_reads_canonical_fields_and_writes_canonical_shift_link(): void
+    {
+        $context = AdminApiTestContext::create(roleSlug: 'foreman');
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $canonical = OrganizationAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'name' => 'Canonical mobile roller',
+            'inventory_number' => 'MOB-CAN-1',
+            'accounting_mode' => AssetAccountingMode::Serialized,
+            'ownership_type' => 'owned',
+            'lifecycle_status' => AssetLifecycleStatus::Active,
+            'technical_status' => AssetTechnicalStatus::Serviceable,
+            'current_project_id' => $project->id,
+            'metadata' => ['machinery_operation_status' => 'in_operation'],
+        ]);
+        $legacy = MachineryAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'organization_asset_id' => $canonical->id,
+            'current_project_id' => $project->id,
+            'asset_code' => 'MOB-LEG-1',
+            'name' => 'Stale legacy name',
+            'status' => 'available',
+            'ownership_type' => 'owned',
+            'operating_cost_per_hour' => 1000,
+        ]);
+        MachineryAssignment::query()->create([
+            'organization_id' => $context->organization->id,
+            'organization_asset_id' => $canonical->id,
+            'asset_id' => $legacy->id,
+            'project_id' => $project->id,
+            'requested_by_user_id' => $context->user->id,
+            'approved_by_user_id' => $context->user->id,
+            'status' => 'active',
+            'planned_start_at' => now()->subHour(),
+            'actual_start_at' => now()->subHour(),
+        ]);
+        $this->allowAccess();
+
+        $this->withHeaders($context->authHeaders())
+            ->getJson("/api/v1/mobile/machinery-operations/assets?project_id={$project->id}")
+            ->assertOk()
+            ->assertJsonPath('data.data.0.id', $legacy->id)
+            ->assertJsonPath('data.data.0.organization_asset_id', $canonical->id)
+            ->assertJsonPath('data.data.0.name', 'Canonical mobile roller')
+            ->assertJsonPath('data.data.0.status', 'in_operation');
+
+        $shift = $this->withHeaders($context->authHeaders())->postJson('/api/v1/mobile/machinery-operations/shift-reports', [
+            'asset_id' => $legacy->id,
+            'project_id' => $project->id,
+            'report_date' => now()->toDateString(),
+            'actual_hours' => 4,
+            'fuel_consumed' => 20,
+        ]);
+        $shift->assertCreated()->assertJsonPath('data.organization_asset_id', $canonical->id);
+    }
+
+    private function allowAccess(): void
+    {
+        $this->mock(AccessController::class, fn (MockInterface $mock) => $mock->shouldReceive('hasModuleAccess')->andReturn(true));
+        $this->mock(AuthorizationService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('canAccessInterface')->andReturn(true);
+            $mock->shouldReceive('can')->andReturn(true);
+            $mock->shouldReceive('hasRole')->andReturn(true);
+            $mock->shouldReceive('getUserRoleSlugs')->andReturn(['foreman']);
+            $mock->shouldReceive('getUserRoles')->andReturnUsing(
+                static fn (User $user, ?AuthorizationContext $context = null) => $user->roleAssignments()->where('is_active', true)->get(),
+            );
+        });
+    }
+}

--- a/tests/Unit/MachineryOperations/MachineryWorkflowPolicyTest.php
+++ b/tests/Unit/MachineryOperations/MachineryWorkflowPolicyTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MachineryOperations;
+
+use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use App\BusinessModules\Features\MachineryOperations\Services\MachineryAssetProjection;
+use App\BusinessModules\Features\MachineryOperations\Services\MachineryWorkflowPolicy;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Models\User;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+final class MachineryWorkflowPolicyTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_canonical_lifecycle_technical_placement_and_operation_state_override_legacy_status(): void
+    {
+        $policy = $this->policyAllowingAll();
+        $asset = $this->linkedAsset([
+            'current_project_id' => 51,
+            'technical_status' => AssetTechnicalStatus::Serviceable,
+            'metadata' => ['machinery_operation_status' => 'in_operation'],
+        ]);
+
+        self::assertSame('in_operation', $policy->status($asset));
+
+        $asset->organizationAsset->technical_status = AssetTechnicalStatus::Maintenance;
+        self::assertSame('maintenance', $policy->status($asset));
+
+        $asset->organizationAsset->lifecycle_status = AssetLifecycleStatus::Retired;
+        self::assertSame('archived', $policy->status($asset));
+    }
+
+    public function test_available_actions_are_filtered_by_actor_permissions(): void
+    {
+        $authorization = Mockery::mock(AuthorizationService::class);
+        $authorization->shouldReceive('can')->andReturnUsing(
+            static fn (User $user, string $permission): bool => in_array($permission, [
+                'machinery-operations.requests.approve',
+                'machinery-operations.delete',
+            ], true),
+        );
+        $policy = new MachineryWorkflowPolicy($authorization);
+
+        self::assertSame(['assign', 'archive'], $policy->availableActions($this->linkedAsset(), new User));
+    }
+
+    public function test_projection_has_identical_business_shape_for_canonical_and_legacy_records(): void
+    {
+        $policy = $this->policyAllowingAll();
+        $projection = new MachineryAssetProjection($policy);
+        $legacy = $this->legacyAsset();
+        $linked = $this->linkedAsset();
+
+        self::assertSame(array_keys($projection->project($legacy)), array_keys($projection->project($linked)));
+        self::assertSame(900, $projection->project($linked)['organization_asset_id']);
+        self::assertSame('Canonical excavator', $projection->project($linked)['name']);
+        self::assertNull($projection->project($legacy)['organization_asset_id']);
+        self::assertSame('Legacy excavator', $projection->project($legacy)['name']);
+    }
+
+    private function policyAllowingAll(): MachineryWorkflowPolicy
+    {
+        $authorization = Mockery::mock(AuthorizationService::class);
+        $authorization->shouldReceive('can')->andReturn(true);
+
+        return new MachineryWorkflowPolicy($authorization);
+    }
+
+    /** @param array<string, mixed> $canonicalOverrides */
+    private function linkedAsset(array $canonicalOverrides = []): MachineryAsset
+    {
+        $asset = $this->legacyAsset();
+        $asset->organization_asset_id = 900;
+        $canonical = new OrganizationAsset(array_merge([
+            'organization_id' => 10,
+            'name' => 'Canonical excavator',
+            'inventory_number' => 'INV-900',
+            'ownership_type' => 'owned',
+            'lifecycle_status' => AssetLifecycleStatus::Active,
+            'technical_status' => AssetTechnicalStatus::Serviceable,
+            'metadata' => ['machinery_operation_status' => 'available'],
+        ], $canonicalOverrides));
+        $canonical->id = 900;
+        $asset->setRelation('organizationAsset', $canonical);
+
+        return $asset;
+    }
+
+    private function legacyAsset(): MachineryAsset
+    {
+        $asset = new MachineryAsset([
+            'organization_id' => 10,
+            'asset_code' => 'LEG-1',
+            'name' => 'Legacy excavator',
+            'inventory_number' => 'INV-LEG',
+            'ownership_type' => 'owned',
+            'status' => 'available',
+            'operating_cost_per_hour' => 1000,
+        ]);
+        $asset->id = 70;
+        $asset->setRelation('organizationAsset', null);
+
+        return $asset;
+    }
+}


### PR DESCRIPTION
## Summary
- read linked machinery through canonical organization assets with legacy fallback
- split lifecycle, technical, placement and operation state transitions
- propagate authoritative organization_asset_id to all operation records
- permission-filter workflow actions in API resources
- record control inspection before returning maintenance to serviceable

## Verification
- 21 PHPUnit tests, 122 assertions
- PHPStan: no errors
- Pint: pass on changed files
- reconciliation: missing=0, duplicates=0, field_conflicts=0

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced MachineryWorkflowPolicy to centralize asset status calculation and available action logic.</li>
<li>Refactored MachineryAssetResource and related resources to use the new policy for determining status and available actions.</li>
<li>Updated MachineryAssetProjection to handle asset status projections.</li>
<li>Added new feature tests for canonical asset operations in both Admin and Mobile API namespaces.</li>
<li>Added unit tests for the new MachineryWorkflowPolicy.</li>
</ul></div>