### PR TITLE
feat(machinery): expose admin workspace data

### DIFF
--- a/app/BusinessModules/Features/MachineryOperations/Http/Controllers/MachineryOperationsController.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Controllers/MachineryOperationsController.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Features\MachineryOperations\DTO\AssetRequestData;
 use App\BusinessModules\Features\MachineryOperations\DTO\AssignmentData;
 use App\BusinessModules\Features\MachineryOperations\Http\Requests\AssignAssetRequest;
 use App\BusinessModules\Features\MachineryOperations\Http\Requests\CreateAssetRequest;
+use App\BusinessModules\Features\MachineryOperations\Http\Resources\AssetRequestResource;
 use App\BusinessModules\Features\MachineryOperations\Http\Resources\MachineryAssetResource;
 use App\BusinessModules\Features\MachineryOperations\Http\Resources\MachineryOperationRecordResource;
 use App\BusinessModules\Features\MachineryOperations\Http\Resources\MachineryShiftReportResource;
@@ -52,6 +53,36 @@ final class MachineryOperationsController extends Controller
         } catch (DomainException $exception) {
             return AdminResponse::error($exception->getMessage(), 422);
         }
+    }
+
+    public function requests(Request $request): JsonResponse
+    {
+        return $this->paginated($this->dispatch->paginateRequests(
+            (int) $request->attributes->get('current_organization_id'),
+            (int) $request->input('per_page', 20),
+            $request->only(['status', 'project_id']),
+        ), AssetRequestResource::class);
+    }
+
+    public function overview(Request $request): JsonResponse
+    {
+        return AdminResponse::success($this->dispatch->overview(
+            (int) $request->attributes->get('current_organization_id'),
+        ));
+    }
+
+    public function assetWorkspace(Request $request, int $id): JsonResponse
+    {
+        $workspace = $this->service->assetWorkspace(
+            (int) $request->attributes->get('current_organization_id'),
+            $id,
+        );
+        if ($workspace === null) {
+            return AdminResponse::error(trans_message('machinery_operations.errors.asset_not_found'), 404);
+        }
+        $workspace['asset'] = new MachineryAssetResource($workspace['asset']);
+
+        return AdminResponse::success($workspace);
     }
 
     public function requestCandidates(Request $request, int $id): JsonResponse

--- a/app/BusinessModules/Features/MachineryOperations/Http/Resources/AssetRequestResource.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Resources/AssetRequestResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\MachineryOperations\Http\Resources;
+
+use App\BusinessModules\Features\MachineryOperations\Models\AssetRequest;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin AssetRequest */
+final class AssetRequestResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'organization_id' => $this->organization_id,
+            'project_id' => $this->project_id,
+            'schedule_task_id' => $this->schedule_task_id,
+            'requested_by_user_id' => $this->requested_by_user_id,
+            'approved_by_user_id' => $this->approved_by_user_id,
+            'organization_asset_id' => $this->organization_asset_id,
+            'status' => $this->status,
+            'priority' => $this->priority,
+            'planned_start_at' => $this->planned_start_at?->toIso8601String(),
+            'planned_end_at' => $this->planned_end_at?->toIso8601String(),
+            'required_profile' => $this->required_profile,
+            'purpose' => $this->purpose,
+            'decision_comment' => $this->decision_comment,
+            'events_count' => $this->events_count ?? null,
+            'project' => $this->whenLoaded('project'),
+            'organization_asset' => $this->whenLoaded('organizationAsset'),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/BusinessModules/Features/MachineryOperations/Services/AssetDispatchService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/AssetDispatchService.php
@@ -17,6 +17,7 @@ use App\Models\Project;
 use App\Models\ScheduleTask;
 use App\Models\User;
 use DomainException;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
@@ -53,6 +54,29 @@ final readonly class AssetDispatchService
 
             return $request->load('events');
         });
+    }
+
+    public function paginateRequests(int $organizationId, int $perPage, array $filters = []): LengthAwarePaginator
+    {
+        return AssetRequest::forOrganization($organizationId)
+            ->with(['project:id,name', 'organizationAsset:id,name,inventory_number,technical_status'])
+            ->withCount('events')
+            ->when(! empty($filters['status']), fn ($query) => $query->where('status', $filters['status']))
+            ->when(! empty($filters['project_id']), fn ($query) => $query->where('project_id', (int) $filters['project_id']))
+            ->orderByRaw("CASE priority WHEN 'urgent' THEN 1 WHEN 'high' THEN 2 WHEN 'normal' THEN 3 ELSE 4 END")
+            ->orderBy('planned_start_at')
+            ->paginate(min(max($perPage, 1), 100));
+    }
+
+    /** @return array<string, int> */
+    public function overview(int $organizationId): array
+    {
+        return [
+            'open_downtimes' => DB::table('machinery_downtimes')->where('organization_id', $organizationId)->whereNull('ended_at')->count(),
+            'pending_requests' => DB::table('asset_requests')->where('organization_id', $organizationId)->whereIn('status', ['pending', 'approved'])->whereNull('deleted_at')->count(),
+            'shift_variances' => DB::table('machinery_shift_reports')->where('organization_id', $organizationId)->where('status', 'submitted')->whereColumn('actual_hours', '<>', 'planned_hours')->whereNull('deleted_at')->count(),
+            'overdue_maintenance' => DB::table('machinery_maintenance_orders')->where('organization_id', $organizationId)->whereIn('status', ['open', 'in_progress'])->where('planned_at', '<', now())->whereNull('deleted_at')->count(),
+        ];
     }
 
     public function assign(int $organizationId, int $actorId, AssignmentData $data): MachineryAssignment

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
@@ -119,6 +119,29 @@ final class MachineryOperationsService
         return $this->assets->find($organizationId, $id);
     }
 
+    /** @return array<string, mixed>|null */
+    public function assetWorkspace(int $organizationId, int $id): ?array
+    {
+        $asset = $this->findAsset($organizationId, $id);
+        if ($asset === null) {
+            return null;
+        }
+
+        return [
+            'asset' => $asset,
+            'assignments' => MachineryAssignment::forOrganization($organizationId)->where('asset_id', $id)->with('project:id,name')->latest()->limit(50)->get(),
+            'shifts' => MachineryShiftReport::forOrganization($organizationId)->where('asset_id', $id)->with('project:id,name')->latest('report_date')->limit(50)->get(),
+            'fuel_issues' => MachineryFuelIssue::forOrganization($organizationId)->where('asset_id', $id)->latest('issued_at')->limit(50)->get(),
+            'maintenance_orders' => MachineryMaintenanceOrder::forOrganization($organizationId)->where('asset_id', $id)->latest()->limit(50)->get(),
+            'custody_history' => $asset->organizationAsset?->custodyEvents()->latest('occurred_at')->limit(100)->get() ?? [],
+            'documents' => [],
+            'costs' => [
+                'fuel' => (float) MachineryFuelIssue::forOrganization($organizationId)->where('asset_id', $id)->sum('cost'),
+                'maintenance' => (float) MachineryMaintenanceOrder::forOrganization($organizationId)->where('asset_id', $id)->sum('cost'),
+            ],
+        ];
+    }
+
     public function assignAsset(MachineryAsset $asset, int $userId, array $data): MachineryAssignment
     {
         return DB::transaction(function () use ($asset, $userId, $data): MachineryAssignment {

--- a/app/BusinessModules/Features/MachineryOperations/routes.php
+++ b/app/BusinessModules/Features/MachineryOperations/routes.php
@@ -17,6 +17,16 @@ Route::prefix('api/v1/admin/machinery-operations')
         Route::post('/asset-requests', [MachineryOperationsController::class, 'storeRequest'])
             ->middleware('authorize:machinery-operations.requests.create')
             ->name('asset_requests.store');
+        Route::get('/asset-requests', [MachineryOperationsController::class, 'requests'])
+            ->middleware('authorize:machinery-operations.view')
+            ->name('asset_requests.index');
+        Route::get('/overview', [MachineryOperationsController::class, 'overview'])
+            ->middleware('authorize:machinery-operations.view')
+            ->name('overview');
+        Route::get('/assets/{id}/workspace', [MachineryOperationsController::class, 'assetWorkspace'])
+            ->whereNumber('id')
+            ->middleware('authorize:machinery-operations.view')
+            ->name('assets.workspace');
         Route::get('/asset-requests/{id}/candidates', [MachineryOperationsController::class, 'requestCandidates'])
             ->whereNumber('id')
             ->middleware('authorize:machinery-operations.requests.approve')

--- a/tests/Feature/Api/V1/Admin/AssetDispatchWorkflowTest.php
+++ b/tests/Feature/Api/V1/Admin/AssetDispatchWorkflowTest.php
@@ -53,6 +53,20 @@ final class AssetDispatchWorkflowTest extends TestCase
         $requestId = (int) $request->json('data.id');
 
         $this->withHeaders($context->authHeaders())
+            ->getJson('/api/v1/admin/machinery-operations/asset-requests?status=pending')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $requestId);
+        $this->withHeaders($context->authHeaders())
+            ->getJson('/api/v1/admin/machinery-operations/overview')
+            ->assertOk()
+            ->assertJsonPath('data.pending_requests', 1);
+        $this->withHeaders($context->authHeaders())
+            ->getJson("/api/v1/admin/machinery-operations/assets/{$asset->id}/workspace")
+            ->assertOk()
+            ->assertJsonPath('data.asset.id', $asset->id)
+            ->assertJsonPath('data.costs.fuel', 0);
+
+        $this->withHeaders($context->authHeaders())
             ->getJson("/api/v1/admin/machinery-operations/asset-requests/{$requestId}/candidates")
             ->assertOk()
             ->assertJsonPath('data.0.asset.organization_asset_id', $asset->organization_asset_id)


### PR DESCRIPTION
## Summary
- expose operational overview counts and paginated asset request queue
- expose selected asset workspace with assignments, shifts, fuel, maintenance, custody and costs
- cover the new admin endpoints in the dispatch workflow

## Verification
- PHPUnit: 15 tests, 138 assertions
- PHPStan: no errors
- Pint: pass
- git diff --check: pass