### PR TITLE
fix(machinery): apply registry search server-side

### DIFF
--- a/app/BusinessModules/Features/MachineryOperations/Http/Controllers/MachineryOperationsController.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Controllers/MachineryOperationsController.php
@@ -119,7 +119,7 @@ final class MachineryOperationsController extends Controller
             return $this->paginated($this->service->paginateAssets(
                 (int) $request->attributes->get('current_organization_id'),
                 min((int) $request->input('per_page', 20), 100),
-                $request->only(['project_id', 'status'])
+                $request->only(['project_id', 'status', 'search'])
             ), MachineryAssetResource::class);
         } catch (\Throwable $exception) {
             return $this->failed($request, $exception, 'assets.index');

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetReadRepository.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetReadRepository.php
@@ -35,6 +35,18 @@ final class MachineryAssetReadRepository
                     ->orWhereHas('organizationAsset', fn ($canonical) => $canonical->where('current_project_id', $projectId)));
             })
             ->when(! empty($filters['status']), fn ($query) => $query->where('status', (string) $filters['status']))
+            ->when(trim((string) ($filters['search'] ?? '')) !== '', function ($query) use ($filters): void {
+                $search = '%'.str_replace(['%', '_'], ['\\%', '\\_'], trim((string) $filters['search'])).'%';
+                $query->where(function ($searchQuery) use ($search): void {
+                    $searchQuery->where('name', 'ilike', $search)
+                        ->orWhere('asset_code', 'ilike', $search)
+                        ->orWhere('inventory_number', 'ilike', $search)
+                        ->orWhereHas('organizationAsset', fn ($canonical) => $canonical
+                            ->where('name', 'ilike', $search)
+                            ->orWhere('inventory_number', 'ilike', $search)
+                            ->orWhere('serial_number', 'ilike', $search));
+                });
+            })
             ->orderBy('name')
             ->paginate($perPage);
     }

--- a/tests/Feature/Api/V1/Admin/MachineryOperationsCanonicalAssetTest.php
+++ b/tests/Feature/Api/V1/Admin/MachineryOperationsCanonicalAssetTest.php
@@ -46,6 +46,17 @@ final class MachineryOperationsCanonicalAssetTest extends TestCase
         $canonicalId = (int) $created->json('data.organization_asset_id');
         self::assertGreaterThan(0, $canonicalId);
 
+        $this->withHeaders($context->authHeaders())->postJson('/api/v1/admin/machinery-operations/assets', [
+            'asset_code' => 'CAN-OTHER-2',
+            'name' => 'Other asset',
+            'inventory_number' => 'OTHER-INV-2',
+        ])->assertCreated();
+        $this->withHeaders($context->authHeaders())
+            ->getJson('/api/v1/admin/machinery-operations/assets?search=can-inv-1')
+            ->assertOk()
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.0.id', $legacyId);
+
         $this->withHeaders($context->authHeaders())->postJson("/api/v1/admin/machinery-operations/assets/{$legacyId}/assign", [
             'project_id' => $project->id,
             'planned_start_at' => now()->toIso8601String(),


### PR DESCRIPTION
## Summary
- apply scoped case-insensitive search to the machinery asset registry
- search legacy and canonical names, codes, inventory and serial numbers
- verify search narrows the paginated API response

## Verification
- PHPUnit: 1 test, 17 assertions
- PHPStan: no errors
- Pint: pass
- git diff --check: pass