### PR TITLE
feat: add approved machinery costs and inspections

### DIFF
--- a/app/BusinessModules/Features/MachineryOperations/Http/Controllers/MachineryOperationsController.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Controllers/MachineryOperationsController.php
@@ -359,7 +359,11 @@ final class MachineryOperationsController extends Controller
     public function completeMaintenanceOrder(Request $request, int $id): JsonResponse
     {
         try {
-            $validated = $request->validate(['completion_comment' => ['nullable', 'string', 'max:2000']]);
+            $validated = $request->validate([
+                'completion_comment' => ['nullable', 'string', 'max:2000'],
+                'inspection_result' => ['nullable', Rule::in(['serviceable', 'restricted', 'unavailable'])],
+                'inspection_evidence' => ['nullable', 'array'],
+            ]);
             $order = $this->service->findMaintenanceOrder((int) $request->attributes->get('current_organization_id'), $id);
 
             if ($order === null) {
@@ -369,7 +373,9 @@ final class MachineryOperationsController extends Controller
             return AdminResponse::success(new MachineryOperationRecordResource($this->service->completeMaintenanceOrder(
                 $order,
                 (int) $request->user()?->id,
-                $validated['completion_comment'] ?? null
+                $validated['completion_comment'] ?? null,
+                (string) ($validated['inspection_result'] ?? 'serviceable'),
+                $validated['inspection_evidence'] ?? [],
             )));
         } catch (ValidationException $exception) {
             return AdminResponse::error($exception->getMessage(), 422, $exception->errors());
@@ -377,6 +383,56 @@ final class MachineryOperationsController extends Controller
             return AdminResponse::error($exception->getMessage(), 422);
         } catch (\Throwable $exception) {
             return $this->failed($request, $exception, 'maintenance.complete');
+        }
+    }
+
+    public function storeDefect(Request $request): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'asset_id' => ['required', 'integer'],
+                'project_id' => ['nullable', 'integer'],
+                'defect_code' => ['required', 'string', 'max:80'],
+                'severity' => ['required', Rule::in(['low', 'medium', 'high', 'critical'])],
+                'description' => ['required', 'string', 'max:5000'],
+                'reported_at' => ['nullable', 'date', 'before_or_equal:now'],
+            ]);
+
+            return AdminResponse::success(
+                new MachineryOperationRecordResource($this->service->reportDefect(
+                    (int) $request->attributes->get('current_organization_id'),
+                    (int) $request->user()?->id,
+                    $validated,
+                )),
+                trans_message('machinery_operations.messages.defect_created'),
+                201,
+            );
+        } catch (ValidationException $exception) {
+            return AdminResponse::error($exception->getMessage(), 422, $exception->errors());
+        } catch (DomainException $exception) {
+            return AdminResponse::error($exception->getMessage(), 422);
+        }
+    }
+
+    public function costReport(Request $request): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'date_from' => ['required', 'date'],
+                'date_to' => ['required', 'date', 'after_or_equal:date_from'],
+                'project_id' => ['nullable', 'integer'],
+            ]);
+
+            return AdminResponse::success($this->service->costReport(
+                (int) $request->attributes->get('current_organization_id'),
+                (string) $validated['date_from'],
+                (string) $validated['date_to'],
+                isset($validated['project_id']) ? (int) $validated['project_id'] : null,
+            ));
+        } catch (ValidationException $exception) {
+            return AdminResponse::error($exception->getMessage(), 422, $exception->errors());
+        } catch (DomainException $exception) {
+            return AdminResponse::error($exception->getMessage(), 422);
         }
     }
 

--- a/app/BusinessModules/Features/MachineryOperations/Http/Controllers/Mobile/MachineryOperationsController.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Controllers/Mobile/MachineryOperationsController.php
@@ -375,7 +375,11 @@ final class MachineryOperationsController extends Controller
     public function completeMaintenanceOrder(Request $request, int $id): JsonResponse
     {
         try {
-            $validated = $this->validated($request, ['completion_comment' => ['nullable', 'string', 'max:2000']]);
+            $validated = $this->validated($request, [
+                'completion_comment' => ['nullable', 'string', 'max:2000'],
+                'inspection_result' => ['nullable', 'in:serviceable,restricted,unavailable'],
+                'inspection_evidence' => ['nullable', 'array'],
+            ]);
             $order = $this->service->findMaintenanceOrder((int) $request->attributes->get('current_organization_id'), $id);
             if ($order === null) {
                 return MobileResponse::error(trans_message('machinery_operations.errors.maintenance_not_found'), 404);
@@ -392,6 +396,8 @@ final class MachineryOperationsController extends Controller
                     $order,
                     (int) $request->user()?->id,
                     $validated['completion_comment'] ?? null,
+                    (string) ($validated['inspection_result'] ?? 'serviceable'),
+                    $validated['inspection_evidence'] ?? [],
                 ),
             );
 

--- a/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryOperationRecordResource.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryOperationRecordResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Features\MachineryOperations\Http\Resources;
 
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAssignment;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryDefect;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryDowntime;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryFuelIssue;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryMaintenanceOrder;
@@ -24,6 +25,7 @@ final class MachineryOperationRecordResource extends JsonResource
             $this->resource instanceof MachineryFuelIssue => $this->fuelIssue($this->resource),
             $this->resource instanceof MachineryProductionRecord => $this->productionRecord($this->resource),
             $this->resource instanceof MachineryMaintenanceOrder => $this->maintenanceOrder($request, $this->resource),
+            $this->resource instanceof MachineryDefect => $this->defect($this->resource),
             default => [],
         };
     }
@@ -63,6 +65,9 @@ final class MachineryOperationRecordResource extends JsonResource
             'project_id' => $downtime->project_id,
             'shift_report_id' => $downtime->shift_report_id,
             'reason' => $downtime->reason,
+            'reason_code' => $downtime->reason_code ?? $downtime->reason,
+            'reason_label' => trans_message('machinery_operations.downtime_reasons.'.($downtime->reason_code ?? $downtime->reason)),
+            'reason_original' => $downtime->reason_original,
             'started_at' => $downtime->started_at?->toIso8601String(),
             'ended_at' => $downtime->ended_at?->toIso8601String(),
             'duration_minutes' => $downtime->duration_minutes,
@@ -80,8 +85,12 @@ final class MachineryOperationRecordResource extends JsonResource
             'issued_by_user_id' => $fuelIssue->issued_by_user_id,
             'issued_at' => $fuelIssue->issued_at?->toIso8601String(),
             'fuel_type' => $fuelIssue->fuel_type,
+            'fuel_type_code' => $fuelIssue->fuel_type_code ?? $fuelIssue->fuel_type,
+            'fuel_type_label' => trans_message('machinery_operations.fuel_types.'.($fuelIssue->fuel_type_code ?? $fuelIssue->fuel_type)),
             'quantity' => $fuelIssue->quantity,
             'unit' => $fuelIssue->unit,
+            'unit_code' => $fuelIssue->unit_code ?? $fuelIssue->unit,
+            'unit_label' => trans_message('machinery_operations.fuel_units.'.($fuelIssue->unit_code ?? $fuelIssue->unit)),
             'cost' => $fuelIssue->cost,
             'comment' => $fuelIssue->comment,
         ];
@@ -134,6 +143,12 @@ final class MachineryOperationRecordResource extends JsonResource
             'completed_at' => $order->completed_at?->toIso8601String(),
             'cost' => $order->cost,
             'completion_comment' => $order->completion_comment,
+            'inspection' => $order->relationLoaded('inspection') && $order->inspection ? [
+                'id' => $order->inspection->id,
+                'result' => $order->inspection->result,
+                'notes' => $order->inspection->notes,
+                'inspected_at' => $order->inspection->inspected_at?->toIso8601String(),
+            ] : null,
             'workflow_summary' => [
                 'stage' => $order->status,
                 'status' => $order->status,
@@ -151,6 +166,23 @@ final class MachineryOperationRecordResource extends JsonResource
                 'organization_asset_id' => $order->organization_asset_id,
                 'project_id' => $order->project_id,
             ],
+        ];
+    }
+
+    private function defect(MachineryDefect $defect): array
+    {
+        return [
+            'id' => $defect->id,
+            'asset_id' => $defect->asset_id,
+            'organization_asset_id' => $defect->organization_asset_id,
+            'project_id' => $defect->project_id,
+            'defect_code' => $defect->defect_code,
+            'severity' => $defect->severity,
+            'status' => $defect->status,
+            'description' => $defect->description,
+            'reported_at' => $defect->reported_at?->toIso8601String(),
+            'resolved_at' => $defect->resolved_at?->toIso8601String(),
+            'available_actions' => [],
         ];
     }
 }

--- a/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryShiftReportResource.php
+++ b/app/BusinessModules/Features/MachineryOperations/Http/Resources/MachineryShiftReportResource.php
@@ -49,6 +49,8 @@ final class MachineryShiftReportResource extends JsonResource
             'status_label' => trans_message("machinery_operations.shift_statuses.{$shift->status}"),
             'planned_hours' => $shift->planned_hours,
             'actual_hours' => $shift->actual_hours,
+            'hourly_rate_snapshot' => $shift->hourly_rate_snapshot,
+            'cost_evidence' => $shift->cost_evidence,
             'fuel_consumed' => $shift->fuel_consumed,
             'meter_start' => $shift->meter_start,
             'meter_end' => $shift->meter_end,

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryDefect.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryDefect.php
@@ -6,31 +6,20 @@ namespace App\BusinessModules\Features\MachineryOperations\Models;
 
 use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Models\Project;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-final class MachineryDowntime extends Model
+final class MachineryDefect extends Model
 {
     protected $fillable = [
-        'organization_id',
-        'organization_asset_id',
-        'asset_id',
-        'project_id',
-        'shift_report_id',
-        'reason',
-        'reason_code',
-        'reason_original',
-        'started_at',
-        'ended_at',
-        'duration_minutes',
-        'comment',
+        'organization_id', 'organization_asset_id', 'asset_id', 'project_id',
+        'reported_by_user_id', 'defect_code', 'severity', 'status', 'description',
+        'reported_at', 'resolved_at',
     ];
 
-    protected $casts = [
-        'started_at' => 'datetime',
-        'ended_at' => 'datetime',
-    ];
+    protected $casts = ['reported_at' => 'datetime', 'resolved_at' => 'datetime'];
 
     public function asset(): BelongsTo
     {
@@ -47,9 +36,9 @@ final class MachineryDowntime extends Model
         return $this->belongsTo(Project::class);
     }
 
-    public function shiftReport(): BelongsTo
+    public function reportedBy(): BelongsTo
     {
-        return $this->belongsTo(MachineryShiftReport::class, 'shift_report_id');
+        return $this->belongsTo(User::class, 'reported_by_user_id');
     }
 
     public function scopeForOrganization(Builder $query, int $organizationId): Builder

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryFuelIssue.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryFuelIssue.php
@@ -21,8 +21,12 @@ final class MachineryFuelIssue extends Model
         'issued_by_user_id',
         'issued_at',
         'fuel_type',
+        'fuel_type_code',
+        'fuel_type_original',
         'quantity',
         'unit',
+        'unit_code',
+        'unit_original',
         'cost',
         'comment',
     ];

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryMaintenanceOrder.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryMaintenanceOrder.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 final class MachineryMaintenanceOrder extends Model
@@ -58,6 +59,11 @@ final class MachineryMaintenanceOrder extends Model
     public function requestedBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'requested_by_user_id');
+    }
+
+    public function inspection(): HasOne
+    {
+        return $this->hasOne(MaintenanceInspection::class, 'maintenance_order_id');
     }
 
     public function scopeForOrganization(Builder $query, int $organizationId): Builder

--- a/app/BusinessModules/Features/MachineryOperations/Models/MachineryShiftReport.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MachineryShiftReport.php
@@ -29,6 +29,8 @@ final class MachineryShiftReport extends Model
         'status',
         'planned_hours',
         'actual_hours',
+        'hourly_rate_snapshot',
+        'cost_evidence',
         'fuel_consumed',
         'meter_start',
         'meter_end',
@@ -44,6 +46,7 @@ final class MachineryShiftReport extends Model
         'submitted_at' => 'datetime',
         'approved_at' => 'datetime',
         'rejected_at' => 'datetime',
+        'cost_evidence' => 'array',
     ];
 
     public function asset(): BelongsTo

--- a/app/BusinessModules/Features/MachineryOperations/Models/MaintenanceInspection.php
+++ b/app/BusinessModules/Features/MachineryOperations/Models/MaintenanceInspection.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\MachineryOperations\Models;
+
+use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class MaintenanceInspection extends Model
+{
+    protected $fillable = [
+        'organization_id', 'maintenance_order_id', 'organization_asset_id',
+        'asset_id', 'inspected_by_user_id', 'result', 'notes', 'evidence', 'inspected_at',
+    ];
+
+    protected $casts = ['evidence' => 'array', 'inspected_at' => 'datetime'];
+
+    public function maintenanceOrder(): BelongsTo
+    {
+        return $this->belongsTo(MachineryMaintenanceOrder::class);
+    }
+
+    public function asset(): BelongsTo
+    {
+        return $this->belongsTo(MachineryAsset::class, 'asset_id');
+    }
+
+    public function organizationAsset(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationAsset::class);
+    }
+
+    public function inspectedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'inspected_by_user_id');
+    }
+}

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryCostService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryCostService.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Features\MachineryOperations\Services;
+
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryFuelIssue;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryMaintenanceOrder;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryShiftReport;
+use Carbon\CarbonImmutable;
+
+final class MachineryCostService
+{
+    /** @return array<string, mixed> */
+    public function calculate(
+        int $organizationId,
+        CarbonImmutable $dateFrom,
+        CarbonImmutable $dateTo,
+        ?int $projectId = null,
+    ): array {
+        $effectiveDateTo = $dateTo->lessThan(CarbonImmutable::today()) ? $dateTo : CarbonImmutable::today();
+        $shifts = MachineryShiftReport::forOrganization($organizationId)
+            ->with('asset:id,operating_cost_per_hour,ownership_type,metadata')
+            ->where('status', 'approved')
+            ->whereBetween('report_date', [$dateFrom->toDateString(), $effectiveDateTo->toDateString()])
+            ->when($projectId !== null, fn ($query) => $query->where('project_id', $projectId))
+            ->orderBy('report_date')
+            ->get();
+        $fuel = MachineryFuelIssue::forOrganization($organizationId)
+            ->whereBetween('issued_at', [$dateFrom->startOfDay(), $dateTo->endOfDay()])
+            ->when($projectId !== null, fn ($query) => $query->where('project_id', $projectId))
+            ->get();
+        $maintenance = MachineryMaintenanceOrder::forOrganization($organizationId)
+            ->where('status', 'completed')
+            ->whereBetween('completed_at', [$dateFrom->startOfDay(), $dateTo->endOfDay()])
+            ->when($projectId !== null, fn ($query) => $query->where('project_id', $projectId))
+            ->get();
+
+        $shiftEvidence = $shifts->map(function (MachineryShiftReport $shift): array {
+            $snapshot = $shift->hourly_rate_snapshot;
+            $rate = (float) ($snapshot ?? $shift->asset?->operating_cost_per_hour ?? 0);
+
+            return [
+                'shift_report_id' => (int) $shift->id,
+                'project_id' => (int) $shift->project_id,
+                'report_date' => $shift->report_date?->toDateString(),
+                'approved_at' => $shift->approved_at?->toIso8601String(),
+                'actual_hours' => (float) $shift->actual_hours,
+                'hourly_rate' => $rate,
+                'rate_source' => $snapshot !== null ? 'approval_snapshot' : 'legacy_current_rate',
+                'rate_evidence' => $shift->cost_evidence,
+                'cost' => round((float) $shift->actual_hours * $rate, 2),
+            ];
+        });
+        $rentalEvidence = $this->rentalEvidence($shifts->all(), $dateFrom, $dateTo, $projectId);
+
+        $operationCost = round((float) $shiftEvidence->sum('cost'), 2);
+        $fuelCost = round((float) $fuel->sum(fn (MachineryFuelIssue $item) => (float) $item->cost), 2);
+        $maintenanceCost = round((float) $maintenance->sum(fn (MachineryMaintenanceOrder $item) => (float) $item->cost), 2);
+        $rentalCost = round((float) collect($rentalEvidence)->sum('cost'), 2);
+
+        return [
+            'period' => ['date_from' => $dateFrom->toDateString(), 'date_to' => $dateTo->toDateString()],
+            'project_id' => $projectId,
+            'source_status' => 'approved_only',
+            'totals' => [
+                'operation_cost' => $operationCost,
+                'fuel_cost' => $fuelCost,
+                'maintenance_cost' => $maintenanceCost,
+                'rental_cost' => $rentalCost,
+                'total_cost' => round($operationCost + $fuelCost + $maintenanceCost + $rentalCost, 2),
+            ],
+            'evidence' => [
+                'shifts' => $shiftEvidence->values()->all(),
+                'fuel_issue_ids' => $fuel->pluck('id')->map(fn ($id) => (int) $id)->all(),
+                'maintenance_order_ids' => $maintenance->pluck('id')->map(fn ($id) => (int) $id)->all(),
+                'rental' => $rentalEvidence,
+            ],
+        ];
+    }
+
+    /** @param array<int, MachineryShiftReport> $shifts @return array<int, array<string, mixed>> */
+    private function rentalEvidence(array $shifts, CarbonImmutable $dateFrom, CarbonImmutable $dateTo, ?int $projectId): array
+    {
+        $assets = collect($shifts)->map(fn (MachineryShiftReport $shift) => $shift->asset)->filter()->unique('id');
+        $evidence = [];
+        foreach ($assets as $asset) {
+            if ($asset->ownership_type !== 'rented') {
+                continue;
+            }
+            $terms = is_array($asset->metadata) ? ($asset->metadata['rental_terms'] ?? null) : null;
+            if (! is_array($terms) || ! is_numeric($terms['daily_rate'] ?? null)) {
+                continue;
+            }
+            if ($projectId !== null && isset($terms['project_id']) && (int) $terms['project_id'] !== $projectId) {
+                continue;
+            }
+            $from = isset($terms['valid_from']) ? CarbonImmutable::parse($terms['valid_from'])->startOfDay() : $dateFrom->startOfDay();
+            $to = isset($terms['valid_to']) ? CarbonImmutable::parse($terms['valid_to'])->startOfDay() : $dateTo->startOfDay();
+            $start = $from->greaterThan($dateFrom) ? $from : $dateFrom;
+            $end = $to->lessThan($dateTo) ? $to : $dateTo;
+            if ($end->lessThan($start)) {
+                continue;
+            }
+            $days = $start->diffInDays($end) + 1;
+            $rate = (float) $terms['daily_rate'];
+            $evidence[] = [
+                'asset_id' => (int) $asset->id,
+                'date_from' => $start->toDateString(),
+                'date_to' => $end->toDateString(),
+                'days' => $days,
+                'daily_rate' => $rate,
+                'terms_version' => (string) ($terms['version'] ?? 'metadata-v1'),
+                'cost' => round($days * $rate, 2),
+            ];
+        }
+
+        return $evidence;
+    }
+}

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
@@ -13,11 +13,13 @@ use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\BusinessModules\Core\AssetManagement\Services\OrganizationAssetService;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAssignment;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryDefect;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryDowntime;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryFuelIssue;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryMaintenanceOrder;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryProductionRecord;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryShiftReport;
+use App\BusinessModules\Features\MachineryOperations\Models\MaintenanceInspection;
 use App\Models\Machinery;
 use App\Models\Project;
 use App\Models\ScheduleTask;
@@ -29,12 +31,17 @@ final class MachineryOperationsService
 {
     private const ASSET_RELATIONS = ['machinery:id,name,code,category', 'currentProject:id,name', 'currentScheduleTask:id,name'];
 
-    private const SHIFT_RELATIONS = ['asset:id,name,asset_code,status', 'project:id,name', 'assignment:id,status'];
+    private const SHIFT_RELATIONS = [
+        'asset:id,name,asset_code,status,operating_cost_per_hour,ownership_type,metadata',
+        'project:id,name',
+        'assignment:id,status',
+    ];
 
     public function __construct(
         private readonly MachineryAssetReadRepository $assets,
         private readonly OrganizationAssetService $organizationAssets,
         private readonly MachineryWorkflowPolicy $workflow,
+        private readonly MachineryCostService $costs,
     ) {}
 
     public function paginateAssets(int $organizationId, int $perPage = 20, array $filters = []): LengthAwarePaginator
@@ -57,7 +64,7 @@ final class MachineryOperationsService
     public function paginateMaintenanceOrders(int $organizationId, int $perPage = 20, array $filters = []): LengthAwarePaginator
     {
         return MachineryMaintenanceOrder::forOrganization($organizationId)
-            ->with(['asset:id,name,asset_code,status', 'project:id,name'])
+            ->with(['asset:id,name,asset_code,status', 'project:id,name', 'inspection'])
             ->when(! empty($filters['project_id']), fn ($query) => $query->where('project_id', (int) $filters['project_id']))
             ->when(! empty($filters['asset_id']), fn ($query) => $query->where('asset_id', (int) $filters['asset_id']))
             ->when(! empty($filters['status']), fn ($query) => $query->where('status', (string) $filters['status']))
@@ -350,10 +357,19 @@ final class MachineryOperationsService
         }
 
         return DB::transaction(function () use ($shift, $userId): MachineryShiftReport {
+            $hourlyRate = (float) ($shift->asset?->operating_cost_per_hour ?? 0);
             $shift->update([
                 'status' => 'approved',
                 'approved_by_user_id' => $userId,
                 'approved_at' => now(),
+                'hourly_rate_snapshot' => $hourlyRate,
+                'cost_evidence' => [
+                    'version' => 1,
+                    'source' => 'asset_operating_cost_per_hour',
+                    'asset_id' => (int) $shift->asset_id,
+                    'hourly_rate' => $hourlyRate,
+                    'captured_at' => now()->toIso8601String(),
+                ],
             ]);
 
             if ($shift->meter_end !== null) {
@@ -409,6 +425,8 @@ final class MachineryOperationsService
                 'project_id' => $projectId,
                 'shift_report_id' => $data['shift_report_id'] ?? null,
                 'reason' => $data['reason'],
+                'reason_code' => $this->dictionaryCode((string) $data['reason'], self::DOWNTIME_CODES),
+                'reason_original' => $this->dictionaryOriginal((string) $data['reason'], self::DOWNTIME_CODES),
                 'started_at' => $data['started_at'],
                 'ended_at' => $data['ended_at'] ?? null,
                 'duration_minutes' => $data['duration_minutes'],
@@ -461,8 +479,12 @@ final class MachineryOperationsService
                 'issued_by_user_id' => $userId,
                 'issued_at' => $data['issued_at'],
                 'fuel_type' => $data['fuel_type'],
+                'fuel_type_code' => $this->dictionaryCode((string) $data['fuel_type'], self::FUEL_CODES),
+                'fuel_type_original' => $this->dictionaryOriginal((string) $data['fuel_type'], self::FUEL_CODES),
                 'quantity' => $data['quantity'],
                 'unit' => $data['unit'],
+                'unit_code' => $this->dictionaryCode((string) $data['unit'], self::FUEL_UNIT_CODES),
+                'unit_original' => $this->dictionaryOriginal((string) $data['unit'], self::FUEL_UNIT_CODES),
                 'cost' => $data['cost'] ?? 0,
                 'comment' => $data['comment'] ?? null,
             ])->fresh(['asset:id,name,asset_code', 'project:id,name']);
@@ -494,17 +516,26 @@ final class MachineryOperationsService
             $asset->update(['status' => 'maintenance']);
             $this->updateCanonicalState($asset, technicalStatus: AssetTechnicalStatus::Maintenance);
 
-            return $order->fresh(['asset:id,name,asset_code,status', 'project:id,name']);
+            return $order->fresh(['asset:id,name,asset_code,status', 'project:id,name', 'inspection']);
         });
     }
 
-    public function completeMaintenanceOrder(MachineryMaintenanceOrder $order, int $userId, ?string $comment): MachineryMaintenanceOrder
-    {
+    public function completeMaintenanceOrder(
+        MachineryMaintenanceOrder $order,
+        int $userId,
+        ?string $comment,
+        string $inspectionResult = 'serviceable',
+        array $inspectionEvidence = [],
+    ): MachineryMaintenanceOrder {
         if (! in_array($order->status, ['open', 'in_progress'], true)) {
             throw new DomainException(trans_message('machinery_operations.errors.maintenance_complete_invalid_status'));
         }
 
-        return DB::transaction(function () use ($order, $userId, $comment): MachineryMaintenanceOrder {
+        if (! in_array($inspectionResult, ['serviceable', 'restricted', 'unavailable'], true)) {
+            throw new DomainException(trans_message('machinery_operations.errors.inspection_result_invalid'));
+        }
+
+        return DB::transaction(function () use ($order, $userId, $comment, $inspectionResult, $inspectionEvidence): MachineryMaintenanceOrder {
             $order->update([
                 'status' => 'completed',
                 'completed_by_user_id' => $userId,
@@ -512,20 +543,77 @@ final class MachineryOperationsService
                 'completion_comment' => $comment,
             ]);
 
-            $order->asset()->update(['status' => 'available']);
+            MaintenanceInspection::query()->create([
+                'organization_id' => $order->organization_id,
+                'maintenance_order_id' => $order->id,
+                'organization_asset_id' => $order->organization_asset_id,
+                'asset_id' => $order->asset_id,
+                'inspected_by_user_id' => $userId,
+                'result' => $inspectionResult,
+                'notes' => $comment,
+                'evidence' => $inspectionEvidence,
+                'inspected_at' => now(),
+            ]);
+
+            $legacyStatus = $inspectionResult === 'serviceable' ? 'available' : 'unavailable';
+            $order->asset()->update(['status' => $legacyStatus]);
             $asset = $order->asset()->first();
             if ($asset !== null) {
-                $this->completeCanonicalMaintenance($asset, $order, $userId, $comment);
+                $this->completeCanonicalMaintenance($asset, $order, $userId, $comment, $inspectionResult);
             }
 
-            return $order->fresh(['asset:id,name,asset_code,status', 'project:id,name']);
+            return $order->fresh(['asset:id,name,asset_code,status', 'project:id,name', 'inspection']);
         });
+    }
+
+    public function reportDefect(int $organizationId, int $userId, array $data): MachineryDefect
+    {
+        return DB::transaction(function () use ($organizationId, $userId, $data): MachineryDefect {
+            $asset = $this->requireLockedAsset((int) $data['asset_id'], $organizationId);
+            $this->assertOptionalProjectBelongsToOrganization($data['project_id'] ?? null, $organizationId);
+            $severity = (string) $data['severity'];
+            if (! in_array($severity, ['low', 'medium', 'high', 'critical'], true)) {
+                throw new DomainException(trans_message('machinery_operations.errors.defect_severity_invalid'));
+            }
+            $defect = MachineryDefect::query()->create([
+                'organization_id' => $organizationId,
+                'organization_asset_id' => $asset->organization_asset_id,
+                'asset_id' => $asset->id,
+                'project_id' => $data['project_id'] ?? $asset->current_project_id,
+                'reported_by_user_id' => $userId,
+                'defect_code' => (string) $data['defect_code'],
+                'severity' => $severity,
+                'status' => 'open',
+                'description' => (string) $data['description'],
+                'reported_at' => $data['reported_at'] ?? now(),
+            ]);
+            if ($severity === 'critical') {
+                $asset->update(['status' => 'unavailable']);
+                $this->updateCanonicalState($asset, technicalStatus: AssetTechnicalStatus::Unavailable);
+            }
+
+            return $defect->fresh(['asset:id,name,asset_code,status', 'project:id,name']);
+        });
+    }
+
+    public function costReport(int $organizationId, string $dateFrom, string $dateTo, ?int $projectId = null): array
+    {
+        if ($projectId !== null) {
+            $this->assertProjectBelongsToOrganization($projectId, $organizationId);
+        }
+
+        return $this->costs->calculate(
+            $organizationId,
+            \Carbon\CarbonImmutable::parse($dateFrom),
+            \Carbon\CarbonImmutable::parse($dateTo),
+            $projectId,
+        );
     }
 
     public function findMaintenanceOrder(int $organizationId, int $id): ?MachineryMaintenanceOrder
     {
         return MachineryMaintenanceOrder::forOrganization($organizationId)
-            ->with(['asset:id,name,asset_code,status', 'project:id,name'])
+            ->with(['asset:id,name,asset_code,status', 'project:id,name', 'inspection'])
             ->find($id);
     }
 
@@ -543,24 +631,28 @@ final class MachineryOperationsService
         return [
             'utilization_by_project' => MachineryShiftReport::forOrganization($organizationId)
                 ->selectRaw('project_id, sum(actual_hours) as actual_hours, sum(planned_hours) as planned_hours')
+                ->where('status', 'approved')
+                ->where('report_date', '<=', now()->toDateString())
                 ->when($projectId !== null, fn ($query) => $query->where('project_id', $projectId))
                 ->groupBy('project_id')
                 ->get()
                 ->all(),
             'downtime_by_reason' => $downtimes
-                ->selectRaw('reason, sum(duration_minutes) as duration_minutes, count(*) as count')
-                ->groupBy('reason')
+                ->selectRaw('coalesce(reason_code, reason) as reason, sum(duration_minutes) as duration_minutes, count(*) as count')
+                ->groupByRaw('coalesce(reason_code, reason)')
                 ->get()
                 ->all(),
             'fuel_consumption' => $fuel
-                ->selectRaw('fuel_type, sum(quantity) as quantity, sum(cost) as cost')
-                ->groupBy('fuel_type')
+                ->selectRaw('coalesce(fuel_type_code, fuel_type) as fuel_type, sum(quantity) as quantity, sum(cost) as cost')
+                ->groupByRaw('coalesce(fuel_type_code, fuel_type)')
                 ->get()
                 ->all(),
             'operating_cost_by_project' => MachineryShiftReport::query()
                 ->join('machinery_assets', 'machinery_shift_reports.asset_id', '=', 'machinery_assets.id')
                 ->selectRaw('machinery_shift_reports.project_id, sum(machinery_shift_reports.actual_hours * machinery_assets.operating_cost_per_hour) as cost')
                 ->where('machinery_shift_reports.organization_id', $organizationId)
+                ->where('machinery_shift_reports.status', 'approved')
+                ->where('machinery_shift_reports.report_date', '<=', now()->toDateString())
                 ->when($projectId !== null, fn ($query) => $query->where('machinery_shift_reports.project_id', $projectId))
                 ->whereNull('machinery_shift_reports.deleted_at')
                 ->groupBy('machinery_shift_reports.project_id')
@@ -568,6 +660,8 @@ final class MachineryOperationsService
                 ->all(),
             'plan_fact_variance' => MachineryShiftReport::forOrganization($organizationId)
                 ->selectRaw('project_id, sum(planned_hours) as planned_hours, sum(actual_hours) as actual_hours, sum(actual_hours - planned_hours) as variance_hours')
+                ->where('status', 'approved')
+                ->where('report_date', '<=', now()->toDateString())
                 ->when($projectId !== null, fn ($query) => $query->where('project_id', $projectId))
                 ->groupBy('project_id')
                 ->get()
@@ -796,6 +890,7 @@ final class MachineryOperationsService
         MachineryMaintenanceOrder $order,
         int $userId,
         ?string $comment,
+        string $inspectionResult,
     ): void {
         $canonical = $this->canonicalAsset($asset, true);
         if ($canonical === null) {
@@ -803,18 +898,44 @@ final class MachineryOperationsService
         }
 
         $metadata = is_array($canonical->metadata) ? $canonical->metadata : [];
-        $metadata['machinery_operation_status'] = $canonical->current_project_id === null ? 'available' : 'assigned';
+        $metadata['machinery_operation_status'] = $inspectionResult === 'serviceable'
+            ? ($canonical->current_project_id === null ? 'available' : 'assigned')
+            : 'unavailable';
         $metadata['last_control_inspection'] = [
-            'result' => 'serviceable',
+            'result' => $inspectionResult,
             'maintenance_order_id' => (int) $order->id,
             'inspected_by_user_id' => $userId,
             'comment' => $comment,
             'occurred_at' => now()->toIso8601String(),
         ];
         $canonical->update([
-            'technical_status' => AssetTechnicalStatus::Serviceable,
+            'technical_status' => match ($inspectionResult) {
+                'serviceable' => AssetTechnicalStatus::Serviceable,
+                'restricted' => AssetTechnicalStatus::Restricted,
+                default => AssetTechnicalStatus::Unavailable,
+            },
             'metadata' => $metadata,
         ]);
+    }
+
+    private const DOWNTIME_CODES = ['waiting_material', 'weather', 'breakdown', 'organizational', 'other'];
+
+    private const FUEL_CODES = ['diesel', 'gasoline', 'electricity', 'gas', 'other'];
+
+    private const FUEL_UNIT_CODES = ['l', 'kg', 'kwh', 'm3', 'other'];
+
+    private function dictionaryCode(string $value, array $codes): string
+    {
+        $normalized = mb_strtolower(trim($value));
+
+        return in_array($normalized, $codes, true) ? $normalized : 'other';
+    }
+
+    private function dictionaryOriginal(string $value, array $codes): ?string
+    {
+        return $this->dictionaryCode($value, $codes) === 'other' && mb_strtolower(trim($value)) !== 'other'
+            ? trim($value)
+            : null;
     }
 
     private function canonicalAsset(MachineryAsset $asset, bool $lock = false): ?OrganizationAsset

--- a/app/BusinessModules/Features/MachineryOperations/routes.php
+++ b/app/BusinessModules/Features/MachineryOperations/routes.php
@@ -102,6 +102,14 @@ Route::prefix('api/v1/admin/machinery-operations')
             ->middleware('authorize:machinery-operations.downtime.manage')
             ->name('maintenance_orders.complete');
 
+        Route::post('/defects', [MachineryOperationsController::class, 'storeDefect'])
+            ->middleware('authorize:machinery-operations.downtime.manage')
+            ->name('defects.store');
+
+        Route::get('/reports/costs', [MachineryOperationsController::class, 'costReport'])
+            ->middleware('authorize:machinery-operations.view')
+            ->name('reports.costs');
+
         Route::get('/reports', [MachineryOperationsController::class, 'reports'])
             ->middleware('authorize:machinery-operations.view')
             ->name('reports.index');

--- a/database/migrations/2026_08_11_000002_add_machinery_cost_and_inspection_evidence.php
+++ b/database/migrations/2026_08_11_000002_add_machinery_cost_and_inspection_evidence.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('machinery_shift_reports', function (Blueprint $table): void {
+            $table->decimal('hourly_rate_snapshot', 15, 2)->nullable()->after('actual_hours');
+            $table->jsonb('cost_evidence')->nullable()->after('hourly_rate_snapshot');
+        });
+        Schema::table('machinery_downtimes', function (Blueprint $table): void {
+            $table->string('reason_code', 80)->nullable()->after('reason');
+            $table->string('reason_original', 255)->nullable()->after('reason_code');
+        });
+        Schema::table('machinery_fuel_issues', function (Blueprint $table): void {
+            $table->string('fuel_type_code', 80)->nullable()->after('fuel_type');
+            $table->string('fuel_type_original', 255)->nullable()->after('fuel_type_code');
+            $table->string('unit_code', 20)->nullable()->after('unit');
+            $table->string('unit_original', 80)->nullable()->after('unit_code');
+        });
+
+        Schema::create('machinery_defects', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('organization_id')->constrained('organizations')->cascadeOnDelete();
+            $table->foreignId('organization_asset_id')->nullable()->constrained('organization_assets')->nullOnDelete();
+            $table->foreignId('asset_id')->constrained('machinery_assets')->cascadeOnDelete();
+            $table->foreignId('project_id')->nullable()->constrained('projects')->nullOnDelete();
+            $table->foreignId('reported_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('defect_code', 80);
+            $table->string('severity', 32);
+            $table->string('status', 32)->default('open');
+            $table->text('description');
+            $table->timestamp('reported_at');
+            $table->timestamp('resolved_at')->nullable();
+            $table->timestamps();
+            $table->index(['organization_id', 'asset_id', 'status']);
+        });
+
+        Schema::create('maintenance_inspections', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('organization_id')->constrained('organizations')->cascadeOnDelete();
+            $table->foreignId('maintenance_order_id')->constrained('machinery_maintenance_orders')->cascadeOnDelete();
+            $table->foreignId('organization_asset_id')->nullable()->constrained('organization_assets')->nullOnDelete();
+            $table->foreignId('asset_id')->constrained('machinery_assets')->cascadeOnDelete();
+            $table->foreignId('inspected_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('result', 32);
+            $table->text('notes')->nullable();
+            $table->jsonb('evidence')->nullable();
+            $table->timestamp('inspected_at');
+            $table->timestamps();
+            $table->unique('maintenance_order_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_inspections');
+        Schema::dropIfExists('machinery_defects');
+        Schema::table('machinery_fuel_issues', function (Blueprint $table): void {
+            $table->dropColumn(['fuel_type_code', 'fuel_type_original', 'unit_code', 'unit_original']);
+        });
+        Schema::table('machinery_downtimes', function (Blueprint $table): void {
+            $table->dropColumn(['reason_code', 'reason_original']);
+        });
+        Schema::table('machinery_shift_reports', function (Blueprint $table): void {
+            $table->dropColumn(['hourly_rate_snapshot', 'cost_evidence']);
+        });
+    }
+};

--- a/lang/ru/machinery_operations.php
+++ b/lang/ru/machinery_operations.php
@@ -23,6 +23,27 @@ return [
         'completed' => 'Завершена',
         'cancelled' => 'Отменена',
     ],
+    'downtime_reasons' => [
+        'waiting_material' => 'Ожидание материалов',
+        'weather' => 'Погодные условия',
+        'breakdown' => 'Поломка',
+        'organizational' => 'Организационная причина',
+        'other' => 'Другое',
+    ],
+    'fuel_types' => [
+        'diesel' => 'Дизельное топливо',
+        'gasoline' => 'Бензин',
+        'electricity' => 'Электроэнергия',
+        'gas' => 'Газ',
+        'other' => 'Другое',
+    ],
+    'fuel_units' => [
+        'l' => 'л',
+        'kg' => 'кг',
+        'kwh' => 'кВт·ч',
+        'm3' => 'м³',
+        'other' => 'другая',
+    ],
     'actions' => [
         'assign' => 'Назначить',
         'start_operation' => 'Начать работу',
@@ -46,6 +67,7 @@ return [
         'fuel_created' => 'Выдача ГСМ зафиксирована.',
         'production_created' => 'Выработка техники зафиксирована.',
         'maintenance_created' => 'Заявка на обслуживание создана.',
+        'defect_created' => 'Дефект техники зарегистрирован.',
     ],
     'errors' => [
         'organization_missing' => 'Организация не определена.',
@@ -86,6 +108,8 @@ return [
         'shift_approve_invalid_status' => 'Утвердить можно только отправленный сменный рапорт.',
         'shift_reject_invalid_status' => 'Вернуть можно только отправленный сменный рапорт.',
         'maintenance_complete_invalid_status' => 'Завершить можно только открытую заявку на обслуживание.',
+        'inspection_result_invalid' => 'Укажите корректный результат контрольного осмотра.',
+        'defect_severity_invalid' => 'Укажите корректную критичность дефекта.',
         'validation_failed' => 'Проверьте данные операции по технике.',
     ],
     'validation' => [

--- a/tests/Feature/Api/V1/Admin/MachineryAnalyticsTest.php
+++ b/tests/Feature/Api/V1/Admin/MachineryAnalyticsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Admin;
+
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryShiftReport;
+use App\Domain\Authorization\Models\AuthorizationContext;
+use App\Domain\Authorization\Services\AuthorizationService;
+use App\Http\Middleware\WebInterfaceSecurityMiddleware;
+use App\Models\Project;
+use App\Models\User;
+use App\Modules\Core\AccessController;
+use Mockery\MockInterface;
+use Tests\Support\AdminApiTestContext;
+use Tests\TestCase;
+
+final class MachineryAnalyticsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(WebInterfaceSecurityMiddleware::class);
+    }
+
+    public function test_cost_report_requires_period_and_excludes_unapproved_and_future_shifts(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $asset = MachineryAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'current_project_id' => $project->id,
+            'asset_code' => 'API-COST-1',
+            'name' => 'Кран',
+            'status' => 'in_operation',
+            'ownership_type' => 'owned',
+            'operating_cost_per_hour' => 2000,
+        ]);
+        foreach ([['approved', now()->toDateString()], ['draft', now()->toDateString()], ['approved', now()->addMonth()->toDateString()]] as [$status, $date]) {
+            MachineryShiftReport::query()->create([
+                'organization_id' => $context->organization->id,
+                'asset_id' => $asset->id,
+                'project_id' => $project->id,
+                'report_date' => $date,
+                'status' => $status,
+                'actual_hours' => 2,
+                'planned_hours' => 2,
+                'fuel_consumed' => 0,
+                'hourly_rate_snapshot' => 2000,
+                'approved_at' => $status === 'approved' ? now() : null,
+            ]);
+        }
+        $this->actingAs($context->user, 'api_admin');
+        $this->allowAccess();
+
+        $this->withHeaders($context->authHeaders())
+            ->getJson('/api/v1/admin/machinery-operations/reports/costs')
+            ->assertStatus(422);
+        $this->withHeaders($context->authHeaders())
+            ->getJson('/api/v1/admin/machinery-operations/reports/costs?'.http_build_query([
+                'date_from' => now()->startOfMonth()->toDateString(),
+                'date_to' => now()->endOfMonth()->toDateString(),
+                'project_id' => $project->id,
+            ]))
+            ->assertOk()
+            ->assertJsonPath('data.source_status', 'approved_only')
+            ->assertJsonPath('data.totals.operation_cost', 4000)
+            ->assertJsonCount(1, 'data.evidence.shifts');
+    }
+
+    private function allowAccess(): void
+    {
+        $this->mock(AccessController::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('hasModuleAccess')->andReturn(true);
+        });
+        $this->mock(AuthorizationService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('canAccessInterface')->andReturn(true);
+            $mock->shouldReceive('can')->andReturn(true);
+            $mock->shouldReceive('hasRole')->andReturn(true);
+            $mock->shouldReceive('getUserRoleSlugs')->andReturn(['web_admin']);
+            $mock->shouldReceive('getUserRoles')->andReturnUsing(
+                static fn (User $user, ?AuthorizationContext $context = null) => $user->roleAssignments()
+                    ->where('is_active', true)
+                    ->when($context !== null, static fn ($query) => $query->where('context_id', $context->id))
+                    ->get(),
+            );
+        });
+    }
+}

--- a/tests/Feature/Api/V1/Admin/MachineryMaintenanceWorkflowTest.php
+++ b/tests/Feature/Api/V1/Admin/MachineryMaintenanceWorkflowTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Admin;
+
+use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Features\MachineryOperations\Models\MaintenanceInspection;
+use App\BusinessModules\Features\MachineryOperations\Services\MachineryOperationsService;
+use App\Models\Project;
+use Tests\Support\AdminApiTestContext;
+use Tests\TestCase;
+
+final class MachineryMaintenanceWorkflowTest extends TestCase
+{
+    public function test_critical_defect_blocks_asset_and_only_serviceable_inspection_releases_it(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $service = $this->app->make(MachineryOperationsService::class);
+        $asset = $service->createAsset((int) $context->organization->id, [
+            'asset_code' => 'DEFECT-1',
+            'name' => 'Виброплита',
+            'current_project_id' => $project->id,
+        ]);
+        $service->reportDefect((int) $context->organization->id, (int) $context->user->id, [
+            'asset_id' => $asset->id,
+            'project_id' => $project->id,
+            'defect_code' => 'engine_failure',
+            'severity' => 'critical',
+            'description' => 'Двигатель не запускается',
+        ]);
+
+        self::assertSame('unavailable', $asset->fresh()->status);
+        self::assertSame(AssetTechnicalStatus::Unavailable, $asset->organizationAsset->fresh()->technical_status);
+
+        $first = $service->createMaintenanceOrder((int) $context->organization->id, (int) $context->user->id, [
+            'asset_id' => $asset->id,
+            'project_id' => $project->id,
+            'title' => 'Диагностика',
+        ]);
+        $service->completeMaintenanceOrder($first, (int) $context->user->id, 'Требуется ремонт', 'unavailable');
+        self::assertSame('unavailable', $asset->fresh()->status);
+        self::assertSame('unavailable', MaintenanceInspection::query()->where('maintenance_order_id', $first->id)->value('result'));
+
+        $second = $service->createMaintenanceOrder((int) $context->organization->id, (int) $context->user->id, [
+            'asset_id' => $asset->id,
+            'project_id' => $project->id,
+            'title' => 'Ремонт двигателя',
+        ]);
+        $service->completeMaintenanceOrder($second, (int) $context->user->id, 'Исправна', 'serviceable');
+        self::assertSame('available', $asset->fresh()->status);
+        self::assertSame(AssetTechnicalStatus::Serviceable, $asset->organizationAsset->fresh()->technical_status);
+    }
+}

--- a/tests/Feature/Api/V1/Admin/MachineryOperationsWorkflowTest.php
+++ b/tests/Feature/Api/V1/Admin/MachineryOperationsWorkflowTest.php
@@ -177,7 +177,8 @@ final class MachineryOperationsWorkflowTest extends TestCase
             ->postJson("/api/v1/admin/machinery-operations/shift-reports/{$shiftId}/approve");
         $approvedShift->assertOk()
             ->assertJsonPath('data.status', 'approved')
-            ->assertJsonPath('data.approved_by_user_id', $context->user->id);
+            ->assertJsonPath('data.approved_by_user_id', $context->user->id)
+            ->assertJsonPath('data.hourly_rate_snapshot', '4500.00');
 
         $downtimeResponse = $this->withHeaders($context->authHeaders())
             ->postJson('/api/v1/admin/machinery-operations/downtimes', [

--- a/tests/Unit/MachineryOperations/MachineryCostServiceTest.php
+++ b/tests/Unit/MachineryOperations/MachineryCostServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\MachineryOperations;
+
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryFuelIssue;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryMaintenanceOrder;
+use App\BusinessModules\Features\MachineryOperations\Models\MachineryShiftReport;
+use App\BusinessModules\Features\MachineryOperations\Services\MachineryCostService;
+use App\Models\Project;
+use Carbon\CarbonImmutable;
+use Tests\Support\AdminApiTestContext;
+use Tests\TestCase;
+
+final class MachineryCostServiceTest extends TestCase
+{
+    public function test_cost_is_period_bound_approved_only_and_uses_rate_snapshot(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $asset = MachineryAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'current_project_id' => $project->id,
+            'asset_code' => 'COST-1',
+            'name' => 'Экскаватор',
+            'status' => 'in_operation',
+            'ownership_type' => 'owned',
+            'operating_cost_per_hour' => 9999,
+        ]);
+        $this->shift($asset, $project, 'approved', '2026-08-10', 8, 1500);
+        $this->shift($asset, $project, 'draft', '2026-08-10', 20, 5000);
+        $this->shift($asset, $project, 'approved', '2026-09-01', 20, 5000);
+        MachineryFuelIssue::query()->create([
+            'organization_id' => $context->organization->id,
+            'asset_id' => $asset->id,
+            'project_id' => $project->id,
+            'issued_at' => '2026-08-10 12:00:00',
+            'fuel_type' => 'diesel',
+            'quantity' => 20,
+            'unit' => 'l',
+            'cost' => 2000,
+        ]);
+        MachineryMaintenanceOrder::query()->create([
+            'organization_id' => $context->organization->id,
+            'asset_id' => $asset->id,
+            'project_id' => $project->id,
+            'order_number' => 'MO-COST-1',
+            'title' => 'Ремонт',
+            'status' => 'completed',
+            'completed_at' => '2026-08-11 12:00:00',
+            'cost' => 3000,
+        ]);
+
+        $report = $this->app->make(MachineryCostService::class)->calculate(
+            (int) $context->organization->id,
+            CarbonImmutable::parse('2026-08-01'),
+            CarbonImmutable::parse('2026-08-31'),
+            (int) $project->id,
+        );
+
+        self::assertSame('approved_only', $report['source_status']);
+        self::assertSame(12000.0, $report['totals']['operation_cost']);
+        self::assertSame(2000.0, $report['totals']['fuel_cost']);
+        self::assertSame(3000.0, $report['totals']['maintenance_cost']);
+        self::assertSame(17000.0, $report['totals']['total_cost']);
+        self::assertCount(1, $report['evidence']['shifts']);
+        self::assertSame('approval_snapshot', $report['evidence']['shifts'][0]['rate_source']);
+    }
+
+    private function shift(
+        MachineryAsset $asset,
+        Project $project,
+        string $status,
+        string $date,
+        float $hours,
+        float $rate,
+    ): void {
+        MachineryShiftReport::query()->create([
+            'organization_id' => $asset->organization_id,
+            'asset_id' => $asset->id,
+            'project_id' => $project->id,
+            'report_date' => $date,
+            'status' => $status,
+            'actual_hours' => $hours,
+            'planned_hours' => $hours,
+            'fuel_consumed' => 0,
+            'hourly_rate_snapshot' => $rate,
+            'approved_at' => $status === 'approved' ? $date.' 20:00:00' : null,
+            'cost_evidence' => ['version' => 1],
+        ]);
+    }
+}


### PR DESCRIPTION
Task 9: approved-only period cost reports with rate evidence; fuel, repair and rental components; critical defect blocking; maintenance inspections; stable analytics dictionaries with legacy values preserved.\n\nVerification: 12 focused tests / 119 assertions, PHPStan clean, migration rollback/reapply, Pint on all changed files, diff check.