### PR TITLE
chore: expose asset cutover evidence in standard deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -485,6 +485,18 @@ jobs:
                 && docker compose exec -T websockets php -r 'exit(@fsockopen("127.0.0.1", 8080) ? 0 : 1);' \
                 && docker compose exec -T clamav clamdscan --ping 1 \
                 && docker compose exec -T geometry-worker /usr/local/bin/geometry-runtime-smoke; then
+                if asset_cutover_report="$(docker compose exec -T api php artisan assets:verify-cutover --format=json 2>&1)"; then
+                  echo "Asset registry cutover observation (GO): ${asset_cutover_report}"
+                else
+                  echo "Asset registry cutover observation (NO-GO): ${asset_cutover_report}"
+                fi
+                asset_cutover_log='storage/logs/asset-registry-cutover.log'
+                if [ -f "${asset_cutover_log}" ]; then
+                  asset_cutover_samples="$(tail -n 24 "${asset_cutover_log}" | grep -c '"ready":true' || true)"
+                  echo "Asset registry successful hourly samples in latest log window: ${asset_cutover_samples}/24"
+                else
+                  echo 'Asset registry hourly observation log has no samples yet.'
+                fi
                 systemctl start nginx
                 systemctl is-active --quiet nginx
                 trap - ERR

--- a/docs/runbooks/asset-registry-cutover.md
+++ b/docs/runbooks/asset-registry-cutover.md
@@ -43,6 +43,8 @@ ASSET_REGISTRY_LEGACY_WRITES_ENABLED=true
 5. В production оставить dual-write и compatibility-read минимум на `ASSET_REGISTRY_OBSERVATION_HOURS` (не менее 24 часов и не менее одного фактического цикла приёмки → назначения/выдачи → смены/возврата → утверждения).
 6. Зафиксировать для начала и конца интервала: release SHA, UTC-время, JSON команды, число scheduler-запусков и отсутствие ошибок записи.
 
+Штатный backend workflow печатает текущий JSON go/no-go и число успешных почасовых образцов в последнем 24-строчном окне. Для финального снимка повторно запускается тот же workflow на `main`; отдельный workflow или SSH-контур не создаётся.
+
 Production readiness нельзя подтверждать только тестами или единичным запуском команды.
 
 ## Фаза B — read cutover и запрет legacy create


### PR DESCRIPTION
## Summary
- print non-blocking asset-registry go/no-go evidence in the existing backend deployment
- report the latest 24 hourly successful observation samples
- document the standard-workflow evidence path; no new deployment contour

## Verification
- workflow YAML parse PASS
- git diff --check PASS