### PR TITLE
fix: close strict canonical read boundary

### DIFF
--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetReadRepository.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetReadRepository.php
@@ -23,7 +23,7 @@ final class MachineryAssetReadRepository
     {
         return MachineryAsset::forOrganization($organizationId)
             ->with(self::RELATIONS)
-            ->when((bool) config('asset_registry.strict_canonical_reads'), fn ($query) => $query->whereNotNull('organization_asset_id'))
+            ->when((bool) config('asset_registry.strict_canonical_reads'), fn ($query) => $query->whereHas('organizationAsset'))
             ->when(array_key_exists('project_ids', $filters), function ($query) use ($filters): void {
                 $query->where(function ($projectQuery) use ($filters): void {
                     $projectQuery->whereNull('current_project_id')
@@ -55,6 +55,9 @@ final class MachineryAssetReadRepository
 
     public function find(int $organizationId, int $id): ?MachineryAsset
     {
-        return MachineryAsset::forOrganization($organizationId)->with(self::RELATIONS)->find($id);
+        return MachineryAsset::forOrganization($organizationId)
+            ->with(self::RELATIONS)
+            ->when((bool) config('asset_registry.strict_canonical_reads'), fn ($query) => $query->whereHas('organizationAsset'))
+            ->find($id);
     }
 }

--- a/tests/Feature/Api/V1/Admin/MachineryOperationsCanonicalAssetTest.php
+++ b/tests/Feature/Api/V1/Admin/MachineryOperationsCanonicalAssetTest.php
@@ -8,6 +8,7 @@ use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
 use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
 use App\BusinessModules\Features\MachineryOperations\Services\MachineryAssetReadRepository;
+use App\BusinessModules\Features\MachineryOperations\Services\MachineryOperationsService;
 use App\Domain\Authorization\Models\AuthorizationContext;
 use App\Domain\Authorization\Services\AuthorizationService;
 use App\Http\Middleware\WebInterfaceSecurityMiddleware;
@@ -116,6 +117,31 @@ final class MachineryOperationsCanonicalAssetTest extends TestCase
             ])
             ->assertStatus(422)
             ->assertJsonPath('message', 'Создание физической единицы перенесено в единый складской реестр.');
+    }
+
+    public function test_strict_canonical_reads_reject_direct_access_without_a_live_canonical_asset(): void
+    {
+        $context = AdminApiTestContext::create();
+        $organizationId = (int) $context->organization->id;
+        $unlinked = MachineryAsset::query()->create([
+            'organization_id' => $organizationId,
+            'asset_code' => 'STRICT-UNLINKED',
+            'name' => 'Legacy only',
+            'ownership_type' => 'owned',
+            'status' => 'available',
+            'operating_cost_per_hour' => 0,
+            'meter_hours' => 0,
+        ]);
+        $retired = app(MachineryOperationsService::class)->createAsset($organizationId, [
+            'asset_code' => 'STRICT-RETIRED',
+            'name' => 'Retired canonical asset',
+        ]);
+        $retired->organizationAsset()->firstOrFail()->delete();
+        config()->set('asset_registry.strict_canonical_reads', true);
+        $repository = app(MachineryAssetReadRepository::class);
+
+        self::assertNull($repository->find($organizationId, (int) $unlinked->id));
+        self::assertNull($repository->find($organizationId, (int) $retired->id));
     }
 
     private function allowAccess(): void


### PR DESCRIPTION
## Summary
- make strict canonical reads require a live canonical relation for both paginated and direct asset access
- fail closed for unlinked and soft-deleted canonical rows before Phase B
- keep production behavior unchanged while the strict flag remains disabled

## Verification
- machinery/cutover regression: 31 tests, 195 assertions
- PHPStan changed scope: pass
- Pint changed scope: pass
- git diff check: pass