### PR TITLE
chore: expose cutover observation in standard deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -485,6 +485,8 @@ jobs:
                 && docker compose exec -T websockets php -r 'exit(@fsockopen("127.0.0.1", 8080) ? 0 : 1);' \
                 && docker compose exec -T clamav clamdscan --ping 1 \
                 && docker compose exec -T geometry-worker /usr/local/bin/geometry-runtime-smoke; then
+                docker compose exec -T api php artisan assets:verify-cutover --format=json || true
+                tail -n 24 storage/logs/asset-registry-cutover.log || true
                 systemctl start nginx
                 systemctl is-active --quiet nginx
                 trap - ERR


### PR DESCRIPTION
## Summary
- print the current read-only asset cutover JSON during the existing backend deployment
- print the last 24 hourly scheduler samples from the existing log
- add no workflow, service, queue, environment, or deployment contour

## Safety
- both observation commands are non-blocking and run only after application health checks pass
- feature-branch push produced no workflow validation failure
- YAML parse and diff check pass