### PR TITLE
chore: expose asset cutover diagnostics

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -485,6 +485,8 @@ jobs:
                 && docker compose exec -T websockets php -r 'exit(@fsockopen("127.0.0.1", 8080) ? 0 : 1);' \
                 && docker compose exec -T clamav clamdscan --ping 1 \
                 && docker compose exec -T geometry-worker /usr/local/bin/geometry-runtime-smoke; then
+                docker compose exec -T api php artisan assets:backfill --dry-run --format=json || true
+                docker compose exec -T api php artisan assets:reconcile --format=json || true
                 docker compose exec -T api php artisan assets:verify-cutover --format=json || true
                 tail -n 24 storage/logs/asset-registry-cutover.log || true
                 systemctl start nginx


### PR DESCRIPTION
## Summary
- print the existing asset backfill dry-run report during the standard deployment
- print the existing reconciliation report alongside the cutover gates
- keep both diagnostics read-only and non-blocking

## Verification
- workflow YAML parse
- `git diff --check`