### PR TITLE
feat: detail asset cutover diagnostics

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -487,7 +487,7 @@ jobs:
                 && docker compose exec -T geometry-worker /usr/local/bin/geometry-runtime-smoke; then
                 docker compose exec -T api php artisan assets:backfill --dry-run --format=json || true
                 docker compose exec -T api php artisan assets:reconcile --format=json || true
-                docker compose exec -T api php artisan assets:verify-cutover --format=json || true
+                docker compose exec -T api php artisan assets:verify-cutover --format=json --details || true
                 tail -n 24 storage/logs/asset-registry-cutover.log || true
                 systemctl start nginx
                 systemctl is-active --quiet nginx

--- a/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
+++ b/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
@@ -23,7 +23,7 @@ final class VerifyAssetRegistryCutover extends Command
         'maintenance_inspections',
     ];
 
-    protected $signature = 'assets:verify-cutover {--format=table : table или json}';
+    protected $signature = 'assets:verify-cutover {--format=table : table или json} {--details : Добавить агрегированную диагностику}';
 
     protected $description = 'Проверяет go/no-go условия перехода на единый реестр имущества';
 
@@ -37,6 +37,13 @@ final class VerifyAssetRegistryCutover extends Command
             'open_assignments_with_inconsistent_placement' => $this->inconsistentOpenAssignments(),
         ];
         $report['ready'] = array_sum($report) === 0;
+        if ((bool) $this->option('details')) {
+            $report['details'] = [
+                'missing_links' => $this->missingLinksBreakdown(),
+                'operations_without_canonical_id' => $this->operationsWithoutCanonicalIdBreakdown(),
+                'assignments' => $this->assignmentRiskBreakdown(),
+            ];
+        }
 
         if ($this->option('format') === 'json') {
             $this->line((string) json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
@@ -54,17 +61,21 @@ final class VerifyAssetRegistryCutover extends Command
 
     private function missingLinks(): int
     {
-        $missing = (int) DB::table('machinery_assets')->whereNull('organization_asset_id')->count();
+        return array_sum($this->missingLinksBreakdown());
+    }
 
-        $missing += (int) DB::table('organization_assets')
+    /** @return array{machinery_assets: int, operation_profiles: int, serialized_projections: int} */
+    private function missingLinksBreakdown(): array
+    {
+        $machineryAssets = (int) DB::table('machinery_assets')->whereNull('organization_asset_id')->count();
+        $operationProfiles = (int) DB::table('organization_assets')
             ->whereNull('deleted_at')
             ->whereNotExists(static fn (Builder $query) => $query
                 ->selectRaw('1')
                 ->from('asset_operation_profiles')
                 ->whereColumn('asset_operation_profiles.organization_asset_id', 'organization_assets.id'))
             ->count();
-
-        return $missing + (int) DB::table('organization_assets')
+        $serializedProjections = (int) DB::table('organization_assets')
             ->where('accounting_mode', 'serialized')
             ->whereNotNull('material_id')
             ->whereNull('deleted_at')
@@ -73,6 +84,12 @@ final class VerifyAssetRegistryCutover extends Command
                 ->from('machinery_assets')
                 ->whereColumn('machinery_assets.organization_asset_id', 'organization_assets.id'))
             ->count();
+
+        return [
+            'machinery_assets' => $machineryAssets,
+            'operation_profiles' => $operationProfiles,
+            'serialized_projections' => $serializedProjections,
+        ];
     }
 
     private function duplicateCanonicalAssets(): int
@@ -138,14 +155,60 @@ final class VerifyAssetRegistryCutover extends Command
 
     private function operationsWithoutCanonicalId(): int
     {
-        $count = 0;
+        return array_sum($this->operationsWithoutCanonicalIdBreakdown());
+    }
+
+    /** @return array<string, int> */
+    private function operationsWithoutCanonicalIdBreakdown(): array
+    {
+        $counts = [];
         foreach (self::OPERATION_TABLES as $table) {
-            if (Schema::hasTable($table) && Schema::hasColumn($table, 'organization_asset_id')) {
-                $count += (int) DB::table($table)->whereNull('organization_asset_id')->count();
-            }
+            $counts[$table] = Schema::hasTable($table) && Schema::hasColumn($table, 'organization_asset_id')
+                ? (int) DB::table($table)->whereNull('organization_asset_id')->count()
+                : 0;
         }
 
-        return $count;
+        return $counts;
+    }
+
+    /** @return array{active: int, currently_effective: int, overlapping_pairs: int, distinct_projects: int} */
+    private function assignmentRiskBreakdown(): array
+    {
+        if (! Schema::hasTable('machinery_assignments')) {
+            return ['active' => 0, 'currently_effective' => 0, 'overlapping_pairs' => 0, 'distinct_projects' => 0];
+        }
+
+        $active = DB::table('machinery_assignments')
+            ->where('status', 'active')
+            ->whereNull('deleted_at');
+        $currentlyEffective = (clone $active)
+            ->where('planned_start_at', '<=', now())
+            ->where(static fn (Builder $query) => $query
+                ->whereNull('planned_end_at')
+                ->orWhere('planned_end_at', '>', now()))
+            ->count();
+        $overlappingPairs = DB::table('machinery_assignments as earlier')
+            ->join('machinery_assignments as later', static fn ($join) => $join
+                ->on('later.asset_id', '=', 'earlier.asset_id')
+                ->on('later.id', '>', 'earlier.id'))
+            ->where('earlier.status', 'active')
+            ->where('later.status', 'active')
+            ->whereNull('earlier.deleted_at')
+            ->whereNull('later.deleted_at')
+            ->where(static fn (Builder $query) => $query
+                ->whereNull('later.planned_end_at')
+                ->orWhereColumn('earlier.planned_start_at', '<', 'later.planned_end_at'))
+            ->where(static fn (Builder $query) => $query
+                ->whereNull('earlier.planned_end_at')
+                ->orWhereColumn('later.planned_start_at', '<', 'earlier.planned_end_at'))
+            ->count();
+
+        return [
+            'active' => (int) (clone $active)->count(),
+            'currently_effective' => (int) $currentlyEffective,
+            'overlapping_pairs' => (int) $overlappingPairs,
+            'distinct_projects' => (int) (clone $active)->distinct()->count('project_id'),
+        ];
     }
 
     private function inconsistentOpenAssignments(): int

--- a/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
+++ b/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
@@ -11,6 +11,7 @@ use App\BusinessModules\Features\MachineryOperations\Models\MachineryAssignment;
 use App\BusinessModules\Features\MachineryOperations\Services\MachineryOperationsService;
 use App\Models\Project;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Tests\Support\AdminApiTestContext;
 use Tests\TestCase;
 
@@ -99,7 +100,48 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
         self::assertFalse($report['ready']);
     }
 
-    /** @return array<string, int|bool> */
+    public function test_details_report_breaks_down_missing_links_operations_and_assignment_risk(): void
+    {
+        $context = AdminApiTestContext::create();
+        $organizationId = (int) $context->organization->id;
+        $project = Project::factory()->create(['organization_id' => $organizationId]);
+        $legacy = MachineryAsset::query()->create([
+            'organization_id' => $organizationId,
+            'asset_code' => 'CUTOVER-DETAILS',
+            'name' => 'Диагностируемая единица',
+            'ownership_type' => 'owned',
+            'status' => 'available',
+            'operating_cost_per_hour' => 0,
+            'meter_hours' => 0,
+        ]);
+        foreach ([now()->subHours(2), now()->subHour()] as $plannedStartAt) {
+            MachineryAssignment::query()->create([
+                'organization_id' => $organizationId,
+                'asset_id' => $legacy->id,
+                'project_id' => $project->id,
+                'status' => 'active',
+                'planned_start_at' => $plannedStartAt,
+            ]);
+        }
+
+        $exitCode = Artisan::call('assets:verify-cutover', ['--format' => 'json', '--details' => true]);
+        $report = $this->jsonOutput();
+
+        self::assertSame(1, $exitCode);
+        self::assertSame([
+            'machinery_assets' => 1,
+            'operation_profiles' => 0,
+            'serialized_projections' => 0,
+        ], $report['details']['missing_links']);
+        self::assertSame(2, $report['details']['operations_without_canonical_id']['machinery_assignments']);
+        self::assertSame(2, $report['details']['assignments']['active']);
+        self::assertSame(2, $report['details']['assignments']['currently_effective']);
+        self::assertSame(1, $report['details']['assignments']['overlapping_pairs']);
+        self::assertSame(1, $report['details']['assignments']['distinct_projects']);
+        self::assertSame(2, DB::table('machinery_assignments')->whereNull('organization_asset_id')->count());
+    }
+
+    /** @return array<string, mixed> */
     private function jsonOutput(): array
     {
         $decoded = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Summary
- add opt-in aggregate cutover diagnostics
- break missing links and unlinked operations down by source
- report active, effective, overlapping and cross-project assignment risk
- expose details through the existing standard deploy log

## Verification
- focused PHPUnit: 3 tests, 21 assertions
- PHPStan: no errors
- Pint: pass
- workflow YAML parse: pass
- git diff check: pass