### PR TITLE
fix: restore read-only cutover deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -485,10 +485,10 @@ jobs:
                 && docker compose exec -T websockets php -r 'exit(@fsockopen("127.0.0.1", 8080) ? 0 : 1);' \
                 && docker compose exec -T clamav clamdscan --ping 1 \
                 && docker compose exec -T geometry-worker /usr/local/bin/geometry-runtime-smoke; then
-                docker compose exec -T api php artisan assets:backfill --format=json
+                docker compose exec -T api php artisan assets:backfill --dry-run --format=json || true
                 docker compose exec -T api php artisan assets:reconcile --format=json || true
                 docker compose exec -T api php artisan assets:verify-cutover --format=json --details || true
-                tail -n 24 storage/logs/asset-registry-cutover.log || true
+                docker compose exec -T scheduler tail -n 24 storage/logs/asset-registry-cutover.log || true
                 systemctl start nginx
                 systemctl is-active --quiet nginx
                 trap - ERR

--- a/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
+++ b/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
@@ -171,11 +171,11 @@ final class VerifyAssetRegistryCutover extends Command
         return $counts;
     }
 
-    /** @return array{active: int, currently_effective: int, overlapping_pairs: int, distinct_projects: int} */
+    /** @return array{active: int, currently_effective: int, overlapping_pairs: int, distinct_projects: int, assignment_organization_mismatches: int, project_organization_mismatches: int} */
     private function assignmentRiskBreakdown(): array
     {
         if (! Schema::hasTable('machinery_assignments')) {
-            return ['active' => 0, 'currently_effective' => 0, 'overlapping_pairs' => 0, 'distinct_projects' => 0];
+            return ['active' => 0, 'currently_effective' => 0, 'overlapping_pairs' => 0, 'distinct_projects' => 0, 'assignment_organization_mismatches' => 0, 'project_organization_mismatches' => 0];
         }
 
         $active = DB::table('machinery_assignments')
@@ -208,6 +208,15 @@ final class VerifyAssetRegistryCutover extends Command
             'currently_effective' => (int) $currentlyEffective,
             'overlapping_pairs' => (int) $overlappingPairs,
             'distinct_projects' => (int) (clone $active)->distinct()->count('project_id'),
+            'assignment_organization_mismatches' => (int) DB::table('machinery_assignments as assignment')
+                ->join('machinery_assets as asset', 'asset.id', '=', 'assignment.asset_id')
+                ->whereColumn('assignment.organization_id', '<>', 'asset.organization_id')
+                ->count(),
+            'project_organization_mismatches' => (int) DB::table('machinery_assignments as assignment')
+                ->join('machinery_assets as asset', 'asset.id', '=', 'assignment.asset_id')
+                ->join('projects as project', 'project.id', '=', 'assignment.project_id')
+                ->whereColumn('project.organization_id', '<>', 'asset.organization_id')
+                ->count(),
         ];
     }
 

--- a/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
+++ b/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
@@ -138,6 +138,8 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
         self::assertSame(2, $report['details']['assignments']['currently_effective']);
         self::assertSame(1, $report['details']['assignments']['overlapping_pairs']);
         self::assertSame(1, $report['details']['assignments']['distinct_projects']);
+        self::assertSame(0, $report['details']['assignments']['assignment_organization_mismatches']);
+        self::assertSame(0, $report['details']['assignments']['project_organization_mismatches']);
         self::assertSame(2, DB::table('machinery_assignments')->whereNull('organization_asset_id')->count());
     }
 


### PR DESCRIPTION
## Summary
- restore asset backfill to non-blocking dry-run in the standard deployment
- read scheduler observation output from the scheduler container
- distinguish assignment-organization and project-organization scope mismatches

## Verification
- Pint: pass
- PHPStan: no errors
- workflow YAML parse: pass
- git diff check: pass