### PR TITLE
feat: detail safe cutover scope candidates

### DIFF
--- a/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
+++ b/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
@@ -171,11 +171,11 @@ final class VerifyAssetRegistryCutover extends Command
         return $counts;
     }
 
-    /** @return array{active: int, currently_effective: int, overlapping_pairs: int, distinct_projects: int, assignment_organization_mismatches: int, project_organization_mismatches: int} */
+    /** @return array{active: int, currently_effective: int, overlapping_pairs: int, distinct_projects: int, assignment_organization_mismatches: int, project_organization_mismatches: int, scope_mismatch_assets: int, scope_mismatch_assets_without_candidate: int, scope_mismatch_assets_with_one_candidate: int, scope_mismatch_assets_with_multiple_candidates: int} */
     private function assignmentRiskBreakdown(): array
     {
         if (! Schema::hasTable('machinery_assignments')) {
-            return ['active' => 0, 'currently_effective' => 0, 'overlapping_pairs' => 0, 'distinct_projects' => 0, 'assignment_organization_mismatches' => 0, 'project_organization_mismatches' => 0];
+            return ['active' => 0, 'currently_effective' => 0, 'overlapping_pairs' => 0, 'distinct_projects' => 0, 'assignment_organization_mismatches' => 0, 'project_organization_mismatches' => 0, 'scope_mismatch_assets' => 0, 'scope_mismatch_assets_without_candidate' => 0, 'scope_mismatch_assets_with_one_candidate' => 0, 'scope_mismatch_assets_with_multiple_candidates' => 0];
         }
 
         $active = DB::table('machinery_assignments')
@@ -202,6 +202,21 @@ final class VerifyAssetRegistryCutover extends Command
                 ->whereNull('earlier.planned_end_at')
                 ->orWhereColumn('later.planned_start_at', '<', 'earlier.planned_end_at'))
             ->count();
+        $scopeMismatchAssets = DB::table('machinery_assignments as assignment')
+            ->join('machinery_assets as asset', 'asset.id', '=', 'assignment.asset_id')
+            ->join('projects as project', 'project.id', '=', 'assignment.project_id')
+            ->whereColumn('project.organization_id', '<>', 'asset.organization_id')
+            ->distinct()
+            ->get(['asset.id', 'asset.organization_id']);
+        $candidateBuckets = ['none' => 0, 'one' => 0, 'many' => 0];
+        foreach ($scopeMismatchAssets as $asset) {
+            $projects = DB::table('projects')->where('organization_id', $asset->organization_id);
+            if (Schema::hasColumn('projects', 'deleted_at')) {
+                $projects->whereNull('deleted_at');
+            }
+            $count = (int) $projects->count();
+            $candidateBuckets[$count === 0 ? 'none' : ($count === 1 ? 'one' : 'many')]++;
+        }
 
         return [
             'active' => (int) (clone $active)->count(),
@@ -217,6 +232,10 @@ final class VerifyAssetRegistryCutover extends Command
                 ->join('projects as project', 'project.id', '=', 'assignment.project_id')
                 ->whereColumn('project.organization_id', '<>', 'asset.organization_id')
                 ->count(),
+            'scope_mismatch_assets' => $scopeMismatchAssets->count(),
+            'scope_mismatch_assets_without_candidate' => $candidateBuckets['none'],
+            'scope_mismatch_assets_with_one_candidate' => $candidateBuckets['one'],
+            'scope_mismatch_assets_with_multiple_candidates' => $candidateBuckets['many'],
         ];
     }
 

--- a/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
+++ b/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
@@ -143,6 +143,40 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
         self::assertSame(2, DB::table('machinery_assignments')->whereNull('organization_asset_id')->count());
     }
 
+    public function test_details_report_whether_foreign_project_links_have_one_safe_local_candidate(): void
+    {
+        $context = AdminApiTestContext::create();
+        $foreign = AdminApiTestContext::create();
+        $organizationId = (int) $context->organization->id;
+        Project::factory()->create(['organization_id' => $organizationId]);
+        $foreignProject = Project::factory()->create(['organization_id' => $foreign->organization->id]);
+        $legacy = MachineryAsset::query()->create([
+            'organization_id' => $organizationId,
+            'asset_code' => 'CUTOVER-SCOPE-CANDIDATE',
+            'name' => 'Техника с ошибочным проектом',
+            'ownership_type' => 'owned',
+            'status' => 'available',
+            'operating_cost_per_hour' => 0,
+            'meter_hours' => 0,
+        ]);
+        MachineryAssignment::query()->create([
+            'organization_id' => $organizationId,
+            'asset_id' => $legacy->id,
+            'project_id' => $foreignProject->id,
+            'status' => 'active',
+            'planned_start_at' => now()->subHour(),
+        ]);
+
+        Artisan::call('assets:verify-cutover', ['--format' => 'json', '--details' => true]);
+        $assignments = $this->jsonOutput()['details']['assignments'];
+
+        self::assertSame(1, $assignments['project_organization_mismatches']);
+        self::assertSame(1, $assignments['scope_mismatch_assets']);
+        self::assertSame(0, $assignments['scope_mismatch_assets_without_candidate']);
+        self::assertSame(1, $assignments['scope_mismatch_assets_with_one_candidate']);
+        self::assertSame(0, $assignments['scope_mismatch_assets_with_multiple_candidates']);
+    }
+
     /** @return array<string, mixed> */
     private function jsonOutput(): array
     {


### PR DESCRIPTION
## Summary
- count assets whose assignments reference foreign-organization projects
- classify those assets by zero, one, or multiple valid local project candidates
- keep diagnostics aggregate and read-only

## Verification
- PHPUnit: 4 tests, 29 assertions
- PHPStan: no errors
- Pint: pass
- git diff check: pass