### PR TITLE
Task 10: diagnose shared project access

### DIFF
--- a/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
+++ b/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
@@ -336,6 +336,17 @@ final class VerifyAssetRegistryCutover extends Command
                 'asset_id' => $assetId,
                 'organization_id' => $organizationId,
                 'foreign_assignment_project_ids' => $foreignAssignmentProjectIds,
+                'accessible_foreign_assignment_project_ids' => Schema::hasTable('project_organization')
+                    ? DB::table('project_organization')
+                        ->where('organization_id', $organizationId)
+                        ->where('is_active', true)
+                        ->whereIn('project_id', $foreignAssignmentProjectIds)
+                        ->distinct()
+                        ->orderBy('project_id')
+                        ->pluck('project_id')
+                        ->map(static fn ($id): int => (int) $id)
+                        ->all()
+                    : [],
                 'legacy_current_project_id' => $legacyCurrentProjectId,
                 'legacy_current_project_is_local' => $legacyCurrentProjectId !== null && DB::table('projects')
                     ->where('id', $legacyCurrentProjectId)

--- a/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
+++ b/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
@@ -185,6 +185,15 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
         $localCurrentProject = Project::factory()->create(['organization_id' => $organizationId]);
         $otherLocalProject = Project::factory()->create(['organization_id' => $organizationId]);
         $foreignProject = Project::factory()->create(['organization_id' => $foreign->organization->id]);
+        DB::table('project_organization')->insert([
+            'project_id' => $foreignProject->id,
+            'organization_id' => $organizationId,
+            'role' => 'contractor',
+            'role_new' => 'contractor',
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
         $legacy = MachineryAsset::query()->create([
             'organization_id' => $organizationId,
             'current_project_id' => $localCurrentProject->id,
@@ -210,6 +219,7 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
             'asset_id' => (int) $legacy->id,
             'organization_id' => $organizationId,
             'foreign_assignment_project_ids' => [(int) $foreignProject->id],
+            'accessible_foreign_assignment_project_ids' => [(int) $foreignProject->id],
             'legacy_current_project_id' => (int) $localCurrentProject->id,
             'legacy_current_project_is_local' => true,
             'schedule_project_ids' => [],


### PR DESCRIPTION
## Summary
- identify foreign-owned assignment projects actively shared with the asset organization
- keep the diagnostic payload ID-only
- cover active project participation in the cutover command

## Verification
- PHPUnit: 5 tests, 31 assertions
- PHPStan: no errors
- Pint: PASS
- git diff --check: PASS