### PR TITLE
Task 10: honor shared project access during cutover

### DIFF
--- a/app/BusinessModules/Core/AssetManagement/Services/LegacyAssetMapper.php
+++ b/app/BusinessModules/Core/AssetManagement/Services/LegacyAssetMapper.php
@@ -10,6 +10,7 @@ use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
 use App\BusinessModules\Core\AssetManagement\Enums\AssetOperationalMode;
 use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
 use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
+use App\Models\Project;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -540,7 +541,7 @@ final readonly class LegacyAssetMapper
         $projectId = (int) $effective->project_id;
         if (
             (int) $effective->organization_id !== $organizationId
-            || ! DB::table('projects')->where('id', $projectId)->where('organization_id', $organizationId)->exists()
+            || ! Project::query()->accessibleByOrganization($organizationId)->whereKey($projectId)->exists()
         ) {
             $this->addConflict(
                 $report,

--- a/app/BusinessModules/Core/AssetManagement/Services/OrganizationAssetService.php
+++ b/app/BusinessModules/Core/AssetManagement/Services/OrganizationAssetService.php
@@ -12,6 +12,7 @@ use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
 use App\BusinessModules\Core\AssetManagement\Models\AssetCustodyEvent;
 use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\Domain\Authorization\Services\AuthorizationService;
+use App\Models\Project;
 use App\Models\User;
 use DomainException;
 use Illuminate\Support\Facades\DB;
@@ -174,7 +175,7 @@ final readonly class OrganizationAssetService
         }
 
         $this->assertOrganizationReference('organization_warehouses', $placement->warehouseId, $organizationId);
-        $this->assertOrganizationReference('projects', $placement->projectId, $organizationId);
+        $this->assertProjectReference($placement->projectId, $organizationId);
 
         if ($placement->userId !== null) {
             $this->assertOrganizationUser($placement->userId, $organizationId);
@@ -193,6 +194,13 @@ final readonly class OrganizationAssetService
             ->exists();
 
         if (! $exists) {
+            throw new DomainException(trans_message('asset_management.errors.foreign_reference'));
+        }
+    }
+
+    private function assertProjectReference(?int $projectId, int $organizationId): void
+    {
+        if ($projectId !== null && ! Project::query()->accessibleByOrganization($organizationId)->whereKey($projectId)->exists()) {
             throw new DomainException(trans_message('asset_management.errors.foreign_reference'));
         }
     }

--- a/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
+++ b/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
@@ -207,11 +207,24 @@ final class VerifyAssetRegistryCutover extends Command
             ->join('machinery_assets as asset', 'asset.id', '=', 'assignment.asset_id')
             ->join('projects as project', 'project.id', '=', 'assignment.project_id')
             ->whereColumn('project.organization_id', '<>', 'asset.organization_id')
+            ->whereNotExists(static fn (Builder $query) => $query
+                ->selectRaw('1')
+                ->from('project_organization as participant')
+                ->whereColumn('participant.project_id', 'assignment.project_id')
+                ->whereColumn('participant.organization_id', 'asset.organization_id')
+                ->where('participant.is_active', true))
             ->distinct()
             ->get(['asset.id', 'asset.organization_id']);
         $candidateBuckets = ['none' => 0, 'one' => 0, 'many' => 0];
         foreach ($scopeMismatchAssets as $asset) {
-            $projects = DB::table('projects')->where('organization_id', $asset->organization_id);
+            $projects = DB::table('projects')->where(static fn (Builder $query) => $query
+                ->where('organization_id', $asset->organization_id)
+                ->orWhereExists(static fn (Builder $participant) => $participant
+                    ->selectRaw('1')
+                    ->from('project_organization')
+                    ->whereColumn('project_organization.project_id', 'projects.id')
+                    ->where('project_organization.organization_id', $asset->organization_id)
+                    ->where('project_organization.is_active', true)));
             if (Schema::hasColumn('projects', 'deleted_at')) {
                 $projects->whereNull('deleted_at');
             }
@@ -232,6 +245,12 @@ final class VerifyAssetRegistryCutover extends Command
                 ->join('machinery_assets as asset', 'asset.id', '=', 'assignment.asset_id')
                 ->join('projects as project', 'project.id', '=', 'assignment.project_id')
                 ->whereColumn('project.organization_id', '<>', 'asset.organization_id')
+                ->whereNotExists(static fn (Builder $query) => $query
+                    ->selectRaw('1')
+                    ->from('project_organization as participant')
+                    ->whereColumn('participant.project_id', 'assignment.project_id')
+                    ->whereColumn('participant.organization_id', 'asset.organization_id')
+                    ->where('participant.is_active', true))
                 ->count(),
             'scope_mismatch_assets' => $scopeMismatchAssets->count(),
             'scope_mismatch_assets_without_candidate' => $candidateBuckets['none'],
@@ -271,6 +290,12 @@ final class VerifyAssetRegistryCutover extends Command
             ->join('machinery_assets as asset', 'asset.id', '=', 'assignment.asset_id')
             ->join('projects as project', 'project.id', '=', 'assignment.project_id')
             ->whereColumn('project.organization_id', '<>', 'asset.organization_id')
+            ->whereNotExists(static fn (Builder $query) => $query
+                ->selectRaw('1')
+                ->from('project_organization as participant')
+                ->whereColumn('participant.project_id', 'assignment.project_id')
+                ->whereColumn('participant.organization_id', 'asset.organization_id')
+                ->where('participant.is_active', true))
             ->distinct()
             ->orderBy('asset.id')
             ->get(['asset.id', 'asset.organization_id', 'asset.current_project_id', 'asset.current_schedule_task_id']);
@@ -278,7 +303,14 @@ final class VerifyAssetRegistryCutover extends Command
         return $assets->map(function (object $asset): array {
             $assetId = (int) $asset->id;
             $organizationId = (int) $asset->organization_id;
-            $localCandidates = DB::table('projects')->where('organization_id', $organizationId);
+            $localCandidates = DB::table('projects')->where(static fn (Builder $query) => $query
+                ->where('organization_id', $organizationId)
+                ->orWhereExists(static fn (Builder $participant) => $participant
+                    ->selectRaw('1')
+                    ->from('project_organization')
+                    ->whereColumn('project_organization.project_id', 'projects.id')
+                    ->where('project_organization.organization_id', $organizationId)
+                    ->where('project_organization.is_active', true)));
             if (Schema::hasColumn('projects', 'deleted_at')) {
                 $localCandidates->whereNull('deleted_at');
             }

--- a/tests/Feature/Console/BackfillOrganizationAssetsTest.php
+++ b/tests/Feature/Console/BackfillOrganizationAssetsTest.php
@@ -136,6 +136,39 @@ final class BackfillOrganizationAssetsTest extends TestCase
         self::assertSame(0, Artisan::call('assets:verify-cutover', ['--format' => 'json']));
     }
 
+    public function test_shared_project_assignment_is_backfilled_without_scope_rewrite(): void
+    {
+        $context = AdminApiTestContext::create();
+        $foreign = AdminApiTestContext::create();
+        $organizationId = (int) $context->organization->id;
+        $sharedProject = Project::factory()->create(['organization_id' => $foreign->organization->id]);
+        DB::table('project_organization')->insert([
+            'project_id' => $sharedProject->id,
+            'organization_id' => $organizationId,
+            'role' => 'contractor',
+            'role_new' => 'contractor',
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $legacy = $this->createMachineryAsset($organizationId, 'BF-SHARED-PROJECT', 'INV-BF-SHARED-PROJECT');
+        $legacy->update(['current_project_id' => $sharedProject->id]);
+        $assignment = MachineryAssignment::query()->create([
+            'organization_id' => $organizationId,
+            'asset_id' => $legacy->id,
+            'project_id' => $sharedProject->id,
+            'requested_by_user_id' => $context->user->id,
+            'status' => 'active',
+            'planned_start_at' => now()->subHour(),
+        ]);
+
+        self::assertSame(0, Artisan::call('assets:backfill', ['--format' => 'json']));
+
+        self::assertSame($sharedProject->id, OrganizationAsset::query()->sole()->current_project_id);
+        self::assertNotNull($assignment->fresh()->organization_asset_id);
+        self::assertSame(0, Artisan::call('assets:verify-cutover', ['--format' => 'json']));
+    }
+
     public function test_equal_start_overlap_remains_a_hard_conflict_without_partial_backfill(): void
     {
         $context = AdminApiTestContext::create();

--- a/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
+++ b/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
@@ -185,15 +185,6 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
         $localCurrentProject = Project::factory()->create(['organization_id' => $organizationId]);
         $otherLocalProject = Project::factory()->create(['organization_id' => $organizationId]);
         $foreignProject = Project::factory()->create(['organization_id' => $foreign->organization->id]);
-        DB::table('project_organization')->insert([
-            'project_id' => $foreignProject->id,
-            'organization_id' => $organizationId,
-            'role' => 'contractor',
-            'role_new' => 'contractor',
-            'is_active' => true,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
         $legacy = MachineryAsset::query()->create([
             'organization_id' => $organizationId,
             'current_project_id' => $localCurrentProject->id,
@@ -219,7 +210,7 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
             'asset_id' => (int) $legacy->id,
             'organization_id' => $organizationId,
             'foreign_assignment_project_ids' => [(int) $foreignProject->id],
-            'accessible_foreign_assignment_project_ids' => [(int) $foreignProject->id],
+            'accessible_foreign_assignment_project_ids' => [],
             'legacy_current_project_id' => (int) $localCurrentProject->id,
             'legacy_current_project_is_local' => true,
             'schedule_project_ids' => [],
@@ -227,6 +218,47 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
             'local_operation_project_ids' => [],
             'local_candidate_project_ids' => collect([$localCurrentProject->id, $otherLocalProject->id])->map(static fn ($id): int => (int) $id)->sort()->values()->all(),
         ]], $evidence);
+    }
+
+    public function test_active_shared_project_is_not_reported_as_a_scope_mismatch(): void
+    {
+        $context = AdminApiTestContext::create();
+        $foreign = AdminApiTestContext::create();
+        $organizationId = (int) $context->organization->id;
+        $sharedProject = Project::factory()->create(['organization_id' => $foreign->organization->id]);
+        DB::table('project_organization')->insert([
+            'project_id' => $sharedProject->id,
+            'organization_id' => $organizationId,
+            'role' => 'contractor',
+            'role_new' => 'contractor',
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $legacy = MachineryAsset::query()->create([
+            'organization_id' => $organizationId,
+            'current_project_id' => $sharedProject->id,
+            'asset_code' => 'CUTOVER-SHARED-PROJECT',
+            'name' => 'Техника на общем проекте',
+            'ownership_type' => 'owned',
+            'status' => 'available',
+            'operating_cost_per_hour' => 0,
+            'meter_hours' => 0,
+        ]);
+        MachineryAssignment::query()->create([
+            'organization_id' => $organizationId,
+            'asset_id' => $legacy->id,
+            'project_id' => $sharedProject->id,
+            'status' => 'active',
+            'planned_start_at' => now()->subHour(),
+        ]);
+
+        Artisan::call('assets:verify-cutover', ['--format' => 'json', '--details' => true]);
+        $details = $this->jsonOutput()['details'];
+
+        self::assertSame(0, $details['assignments']['project_organization_mismatches']);
+        self::assertSame(0, $details['assignments']['scope_mismatch_assets']);
+        self::assertSame([], $details['scope_repair_evidence']);
     }
 
     /** @return array<string, mixed> */

--- a/tests/Unit/Core/AssetManagement/OrganizationAssetServiceTest.php
+++ b/tests/Unit/Core/AssetManagement/OrganizationAssetServiceTest.php
@@ -19,6 +19,7 @@ use App\Models\Organization;
 use App\Models\Project;
 use DomainException;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use LogicException;
 use Mockery\MockInterface;
 use Tests\Support\AdminApiTestContext;
@@ -221,6 +222,35 @@ final class OrganizationAssetServiceTest extends TestCase
             new AssetPlacementData(userId: (int) $context->user->id),
             (int) $foreign->user->id,
         );
+    }
+
+    public function test_move_accepts_project_actively_shared_with_asset_organization(): void
+    {
+        $context = AdminApiTestContext::create();
+        $foreign = AdminApiTestContext::create();
+        $asset = $this->service()->create(
+            (int) $context->organization->id,
+            new CreateOrganizationAssetData(name: 'Кран', inventoryNumber: 'INV-SHARED-PROJECT'),
+        );
+        $sharedProject = Project::factory()->create(['organization_id' => $foreign->organization->id]);
+        DB::table('project_organization')->insert([
+            'project_id' => $sharedProject->id,
+            'organization_id' => $context->organization->id,
+            'role' => 'contractor',
+            'role_new' => 'contractor',
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $moved = $this->service()->move(
+            $asset,
+            new AssetPlacementData(projectId: (int) $sharedProject->id),
+            (int) $context->user->id,
+        );
+
+        self::assertSame($sharedProject->id, $moved->current_project_id);
+        self::assertSame($sharedProject->id, $moved->custodyEvents()->sole()->to_project_id);
     }
 
     public function test_available_actions_are_state_and_permission_aware(): void


### PR DESCRIPTION
## Summary
- use the platform project-access rule for canonical placement and legacy backfill
- treat active project participation as valid scope in cutover diagnostics
- keep inaccessible cross-organization project links blocked

## Verification
- verifier: 6 tests, 35 assertions
- asset service: 10 tests, 38 assertions
- backfill: 9 tests, 75 assertions
- machinery integrity: 8 tests, 8 assertions
- PHPStan: no errors
- Pint: PASS
- git diff --check: PASS