### PR TITLE
fix(assets): canonicalize operational economics

### DIFF
--- a/app/BusinessModules/Core/AssetManagement/DTO/CreateOrganizationAssetData.php
+++ b/app/BusinessModules/Core/AssetManagement/DTO/CreateOrganizationAssetData.php
@@ -30,5 +30,9 @@ final readonly class CreateOrganizationAssetData
         public bool $tracksProduction = false,
         public bool $maintenanceEnabled = false,
         public ?string $meterUnit = null,
+        public float $operatingCostPerHour = 0,
+        public ?string $fuelType = null,
+        public ?float $fuelConsumptionRate = null,
+        public float $meterValue = 0,
     ) {}
 }

--- a/app/BusinessModules/Core/AssetManagement/Models/AssetOperationProfile.php
+++ b/app/BusinessModules/Core/AssetManagement/Models/AssetOperationProfile.php
@@ -18,6 +18,10 @@ final class AssetOperationProfile extends Model
         'tracks_production',
         'maintenance_enabled',
         'meter_unit',
+        'operating_cost_per_hour',
+        'fuel_type',
+        'fuel_consumption_rate',
+        'meter_value',
     ];
 
     protected $casts = [
@@ -26,6 +30,9 @@ final class AssetOperationProfile extends Model
         'tracks_fuel' => 'boolean',
         'tracks_production' => 'boolean',
         'maintenance_enabled' => 'boolean',
+        'operating_cost_per_hour' => 'decimal:2',
+        'fuel_consumption_rate' => 'decimal:3',
+        'meter_value' => 'decimal:2',
     ];
 
     public function asset(): BelongsTo

--- a/app/BusinessModules/Core/AssetManagement/Services/LegacyAssetMapper.php
+++ b/app/BusinessModules/Core/AssetManagement/Services/LegacyAssetMapper.php
@@ -233,13 +233,20 @@ final readonly class LegacyAssetMapper
                     placement: $legacy->current_project_id !== null
                         ? new AssetPlacementData(projectId: (int) $legacy->current_project_id)
                         : null,
-                    metadata: ['legacy_source' => ['table' => 'machinery_assets', 'id' => (int) $legacy->id]],
+                    metadata: [
+                        ...(is_array($legacy->metadata) ? $legacy->metadata : (json_decode((string) ($legacy->metadata ?? ''), true) ?: [])),
+                        'legacy_source' => ['table' => 'machinery_assets', 'id' => (int) $legacy->id],
+                    ],
                     operationalMode: AssetOperationalMode::ShiftOperation,
                     tracksMeter: true,
                     tracksFuel: $legacy->fuel_type !== null || $legacy->fuel_consumption_rate !== null,
                     tracksProduction: true,
                     maintenanceEnabled: true,
                     meterUnit: 'hour',
+                    operatingCostPerHour: (float) $legacy->operating_cost_per_hour,
+                    fuelType: $legacy->fuel_type !== null ? (string) $legacy->fuel_type : null,
+                    fuelConsumptionRate: $legacy->fuel_consumption_rate !== null ? (float) $legacy->fuel_consumption_rate : null,
+                    meterValue: (float) $legacy->meter_hours,
                 ),
             );
             $canonical->update([

--- a/app/BusinessModules/Core/AssetManagement/Services/OrganizationAssetService.php
+++ b/app/BusinessModules/Core/AssetManagement/Services/OrganizationAssetService.php
@@ -59,6 +59,10 @@ final readonly class OrganizationAssetService
                 'tracks_production' => $data->tracksProduction,
                 'maintenance_enabled' => $data->maintenanceEnabled,
                 'meter_unit' => $data->meterUnit,
+                'operating_cost_per_hour' => $data->operatingCostPerHour,
+                'fuel_type' => $data->fuelType,
+                'fuel_consumption_rate' => $data->fuelConsumptionRate,
+                'meter_value' => $data->meterValue,
             ]);
 
             if ($data->placement !== null) {

--- a/app/BusinessModules/Features/AIAssistant/Services/Rag/Sources/MachineryRagSource.php
+++ b/app/BusinessModules/Features/AIAssistant/Services/Rag/Sources/MachineryRagSource.php
@@ -77,18 +77,20 @@ final class MachineryRagSource implements RagSourceCollectorInterface
 
     private function assetChunk(MachineryAsset $asset): RagChunkData
     {
+        $canonical = $asset->organizationAsset;
+        $profile = $canonical?->operationProfile;
         $content = $this->lines([
             'Единица техники: '.$this->stringValue($asset->asset_code),
-            'Название: '.$this->stringValue($asset->name),
-            'Инвентарный номер: '.$this->stringValue($asset->inventory_number),
-            'Проект: '.$this->stringValue($asset->currentProject?->name),
+            'Название: '.$this->stringValue($canonical?->name ?? $asset->name),
+            'Инвентарный номер: '.$this->stringValue($canonical?->inventory_number ?? $asset->inventory_number),
+            'Проект: '.$this->stringValue($canonical?->currentProject?->name ?? $asset->currentProject?->name),
             'Задача графика: '.$this->stringValue($asset->currentScheduleTask?->name),
             'Статус: '.$this->stringValue($asset->status),
-            'Владение: '.$this->stringValue($asset->ownership_type),
-            'Стоимость часа: '.$this->moneyValue($asset->operating_cost_per_hour),
-            'Топливо: '.$this->stringValue($asset->fuel_type),
-            'Расход топлива: '.$this->numberValue($asset->fuel_consumption_rate),
-            'Наработка: '.$this->numberValue($asset->meter_hours),
+            'Владение: '.$this->stringValue($canonical?->ownership_type ?? $asset->ownership_type),
+            'Стоимость часа: '.$this->moneyValue($profile !== null ? $profile->operating_cost_per_hour : $asset->operating_cost_per_hour),
+            'Топливо: '.$this->stringValue($profile !== null ? $profile->fuel_type : $asset->fuel_type),
+            'Расход топлива: '.$this->numberValue($profile !== null ? $profile->fuel_consumption_rate : $asset->fuel_consumption_rate),
+            'Наработка: '.$this->numberValue($profile !== null ? $profile->meter_value : $asset->meter_hours),
         ]);
 
         return $this->chunk(
@@ -96,7 +98,7 @@ final class MachineryRagSource implements RagSourceCollectorInterface
             $asset->current_project_id !== null ? (int) $asset->current_project_id : null,
             'machinery_asset',
             $asset->id,
-            'Техника: '.$this->stringValue($asset->name),
+            'Техника: '.$this->stringValue($canonical?->name ?? $asset->name),
             $content,
             [
                 'status' => $this->scalarValue($asset->status),
@@ -303,7 +305,7 @@ final class MachineryRagSource implements RagSourceCollectorInterface
     private function assets(int $organizationId, ?int $projectId): iterable
     {
         return MachineryAsset::query()
-            ->with(['machinery', 'currentProject', 'currentScheduleTask'])
+            ->with(['machinery', 'currentProject', 'currentScheduleTask', 'organizationAsset.operationProfile', 'organizationAsset.currentProject'])
             ->forOrganization($organizationId)
             ->when($projectId !== null, static fn ($query) => $query->where('current_project_id', $projectId))
             ->orderBy('id')
@@ -373,7 +375,10 @@ final class MachineryRagSource implements RagSourceCollectorInterface
 
     private function singleAsset(int $organizationId, string|int $entityId): array
     {
-        $asset = MachineryAsset::query()->with(['machinery', 'currentProject', 'currentScheduleTask'])->forOrganization($organizationId)->find($entityId);
+        $asset = MachineryAsset::query()
+            ->with(['machinery', 'currentProject', 'currentScheduleTask', 'organizationAsset.operationProfile', 'organizationAsset.currentProject'])
+            ->forOrganization($organizationId)
+            ->find($entityId);
 
         return $asset instanceof MachineryAsset ? [$this->assetChunk($asset)] : [];
     }

--- a/app/BusinessModules/Features/MachineryOperations/Services/AssetDispatchService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/AssetDispatchService.php
@@ -115,7 +115,7 @@ final readonly class AssetDispatchService
                 $reasons = $canonical === null ? ['canonical_link_missing'] : $this->exclusionReasons($canonical, $request);
                 $distance = $canonical === null ? null : $this->distanceKm($request->project, $canonical->currentProject);
                 $sameProject = $canonical?->current_project_id === $request->project_id;
-                $cost = (float) $legacy->operating_cost_per_hour;
+                $cost = (float) ($canonical?->operationProfile?->operating_cost_per_hour ?? $legacy->operating_cost_per_hour);
                 $score = ($sameProject ? 100000.0 : 0.0) - (($distance ?? 1000.0) * 100.0) - $cost;
 
                 return [

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetProjection.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetProjection.php
@@ -14,6 +14,7 @@ final readonly class MachineryAssetProjection
     public function project(MachineryAsset $legacy): array
     {
         $canonical = $legacy->organizationAsset;
+        $profile = $canonical?->operationProfile;
 
         return [
             'id' => (int) $legacy->id,
@@ -33,10 +34,10 @@ final readonly class MachineryAssetProjection
             'technical_status' => $canonical?->technical_status?->value,
             'current_warehouse_id' => $canonical?->current_warehouse_id,
             'responsible_user_id' => $canonical?->responsible_user_id,
-            'operating_cost_per_hour' => $legacy->operating_cost_per_hour,
-            'fuel_type' => $legacy->fuel_type,
-            'fuel_consumption_rate' => $legacy->fuel_consumption_rate,
-            'meter_hours' => $legacy->meter_hours,
+            'operating_cost_per_hour' => $profile !== null ? $profile->operating_cost_per_hour : $legacy->operating_cost_per_hour,
+            'fuel_type' => $profile !== null ? $profile->fuel_type : $legacy->fuel_type,
+            'fuel_consumption_rate' => $profile !== null ? $profile->fuel_consumption_rate : $legacy->fuel_consumption_rate,
+            'meter_hours' => $profile !== null ? $profile->meter_value : $legacy->meter_hours,
             'metadata' => $canonical?->metadata ?? $legacy->metadata,
         ];
     }

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetRegistryProjector.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryAssetRegistryProjector.php
@@ -11,6 +11,8 @@ final class MachineryAssetRegistryProjector
 {
     public function project(OrganizationAsset $asset): MachineryAsset
     {
+        $asset->loadMissing('operationProfile');
+        $profile = $asset->operationProfile;
         $existing = MachineryAsset::query()
             ->where('organization_asset_id', $asset->id)
             ->first();
@@ -29,8 +31,10 @@ final class MachineryAssetRegistryProjector
             'inventory_number' => $asset->inventory_number,
             'ownership_type' => $asset->ownership_type,
             'status' => 'available',
-            'operating_cost_per_hour' => 0,
-            'meter_hours' => 0,
+            'operating_cost_per_hour' => $profile?->operating_cost_per_hour ?? 0,
+            'fuel_type' => $profile?->fuel_type,
+            'fuel_consumption_rate' => $profile?->fuel_consumption_rate,
+            'meter_hours' => $profile?->meter_value ?? 0,
             'metadata' => [
                 'registry_projection' => true,
                 'canonical_source' => 'warehouse_receipt',

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryCostService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryCostService.php
@@ -20,7 +20,11 @@ final class MachineryCostService
     ): array {
         $effectiveDateTo = $dateTo->lessThan(CarbonImmutable::today()) ? $dateTo : CarbonImmutable::today();
         $shifts = MachineryShiftReport::forOrganization($organizationId)
-            ->with('asset:id,operating_cost_per_hour,ownership_type,metadata')
+            ->with([
+                'asset:id,operating_cost_per_hour,ownership_type,metadata',
+                'organizationAsset:id,ownership_type,metadata',
+                'organizationAsset.operationProfile:organization_asset_id,operating_cost_per_hour',
+            ])
             ->where('status', 'approved')
             ->whereBetween('report_date', [$dateFrom->toDateString(), $effectiveDateTo->toDateString()])
             ->when($projectId !== null, fn ($query) => $query->where('project_id', $projectId))
@@ -38,7 +42,8 @@ final class MachineryCostService
 
         $shiftEvidence = $shifts->map(function (MachineryShiftReport $shift): array {
             $snapshot = $shift->hourly_rate_snapshot;
-            $rate = (float) ($snapshot ?? $shift->asset?->operating_cost_per_hour ?? 0);
+            $canonicalRate = $shift->organizationAsset?->operationProfile?->operating_cost_per_hour;
+            $rate = (float) ($snapshot ?? $canonicalRate ?? $shift->asset?->operating_cost_per_hour ?? 0);
 
             return [
                 'shift_report_id' => (int) $shift->id,
@@ -47,7 +52,9 @@ final class MachineryCostService
                 'approved_at' => $shift->approved_at?->toIso8601String(),
                 'actual_hours' => (float) $shift->actual_hours,
                 'hourly_rate' => $rate,
-                'rate_source' => $snapshot !== null ? 'approval_snapshot' : 'legacy_current_rate',
+                'rate_source' => $snapshot !== null
+                    ? 'approval_snapshot'
+                    : ($canonicalRate !== null ? 'canonical_operation_profile' : 'legacy_current_rate'),
                 'rate_evidence' => $shift->cost_evidence,
                 'cost' => round((float) $shift->actual_hours * $rate, 2),
             ];
@@ -82,13 +89,18 @@ final class MachineryCostService
     /** @param array<int, MachineryShiftReport> $shifts @return array<int, array<string, mixed>> */
     private function rentalEvidence(array $shifts, CarbonImmutable $dateFrom, CarbonImmutable $dateTo, ?int $projectId): array
     {
-        $assets = collect($shifts)->map(fn (MachineryShiftReport $shift) => $shift->asset)->filter()->unique('id');
+        $assets = collect($shifts)
+            ->filter(fn (MachineryShiftReport $shift): bool => $shift->asset !== null)
+            ->unique('asset_id');
         $evidence = [];
-        foreach ($assets as $asset) {
-            if ($asset->ownership_type !== 'rented') {
+        foreach ($assets as $shift) {
+            $legacy = $shift->asset;
+            $canonical = $shift->organizationAsset;
+            if (! in_array($canonical?->ownership_type ?? $legacy->ownership_type, ['leased', 'rented'], true)) {
                 continue;
             }
-            $terms = is_array($asset->metadata) ? ($asset->metadata['rental_terms'] ?? null) : null;
+            $metadata = $canonical?->metadata ?? $legacy->metadata;
+            $terms = is_array($metadata) ? ($metadata['rental_terms'] ?? null) : null;
             if (! is_array($terms) || ! is_numeric($terms['daily_rate'] ?? null)) {
                 continue;
             }
@@ -105,7 +117,8 @@ final class MachineryCostService
             $days = $start->diffInDays($end) + 1;
             $rate = (float) $terms['daily_rate'];
             $evidence[] = [
-                'asset_id' => (int) $asset->id,
+                'asset_id' => (int) $legacy->id,
+                'organization_asset_id' => $canonical?->id,
                 'date_from' => $start->toDateString(),
                 'date_to' => $end->toDateString(),
                 'days' => $days,

--- a/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
+++ b/app/BusinessModules/Features/MachineryOperations/Services/MachineryOperationsService.php
@@ -109,6 +109,7 @@ final class MachineryOperationsService
                     ? new AssetPlacementData(projectId: (int) $legacy->current_project_id)
                     : null,
                 metadata: [
+                    ...($data['metadata'] ?? []),
                     'legacy_source' => ['table' => 'machinery_assets', 'id' => (int) $legacy->id],
                     'machinery_operation_status' => $initialStatus,
                 ],
@@ -118,6 +119,10 @@ final class MachineryOperationsService
                 tracksProduction: true,
                 maintenanceEnabled: true,
                 meterUnit: 'hour',
+                operatingCostPerHour: (float) $legacy->operating_cost_per_hour,
+                fuelType: $legacy->fuel_type !== null ? (string) $legacy->fuel_type : null,
+                fuelConsumptionRate: $legacy->fuel_consumption_rate !== null ? (float) $legacy->fuel_consumption_rate : null,
+                meterValue: (float) $legacy->meter_hours,
             ));
             $legacy->update(['organization_asset_id' => $canonical->id]);
 
@@ -361,7 +366,10 @@ final class MachineryOperationsService
         }
 
         return DB::transaction(function () use ($shift, $userId): MachineryShiftReport {
-            $hourlyRate = (float) ($shift->asset?->operating_cost_per_hour ?? 0);
+            $legacy = MachineryAsset::query()->whereKey($shift->asset_id)->lockForUpdate()->first();
+            $canonical = $legacy !== null ? $this->canonicalAsset($legacy, true) : null;
+            $profile = $canonical?->operationProfile()->lockForUpdate()->first();
+            $hourlyRate = (float) ($profile?->operating_cost_per_hour ?? $legacy?->operating_cost_per_hour ?? 0);
             $shift->update([
                 'status' => 'approved',
                 'approved_by_user_id' => $userId,
@@ -369,24 +377,17 @@ final class MachineryOperationsService
                 'hourly_rate_snapshot' => $hourlyRate,
                 'cost_evidence' => [
                     'version' => 1,
-                    'source' => 'asset_operating_cost_per_hour',
+                    'source' => $profile !== null ? 'canonical_operation_profile' : 'legacy_asset_fallback',
                     'asset_id' => (int) $shift->asset_id,
+                    'organization_asset_id' => $canonical?->id,
                     'hourly_rate' => $hourlyRate,
                     'captured_at' => now()->toIso8601String(),
                 ],
             ]);
 
             if ($shift->meter_end !== null) {
-                $shift->asset()->update(['meter_hours' => $shift->meter_end]);
-                $asset = $shift->asset()->first();
-                if ($asset !== null) {
-                    $canonical = $this->canonicalAsset($asset, true);
-                    if ($canonical !== null) {
-                        $metadata = is_array($canonical->metadata) ? $canonical->metadata : [];
-                        $metadata['meter_hours'] = (float) $shift->meter_end;
-                        $canonical->update(['metadata' => $metadata]);
-                    }
-                }
+                $profile?->update(['meter_value' => $shift->meter_end]);
+                $legacy?->update(['meter_hours' => $shift->meter_end]);
             }
 
             return $shift->fresh(self::SHIFT_RELATIONS);
@@ -652,8 +653,8 @@ final class MachineryOperationsService
                 ->get()
                 ->all(),
             'operating_cost_by_project' => MachineryShiftReport::query()
-                ->join('machinery_assets', 'machinery_shift_reports.asset_id', '=', 'machinery_assets.id')
-                ->selectRaw('machinery_shift_reports.project_id, sum(machinery_shift_reports.actual_hours * machinery_assets.operating_cost_per_hour) as cost')
+                ->leftJoin('asset_operation_profiles', 'machinery_shift_reports.organization_asset_id', '=', 'asset_operation_profiles.organization_asset_id')
+                ->selectRaw('machinery_shift_reports.project_id, sum(machinery_shift_reports.actual_hours * coalesce(machinery_shift_reports.hourly_rate_snapshot, asset_operation_profiles.operating_cost_per_hour, 0)) as cost')
                 ->where('machinery_shift_reports.organization_id', $organizationId)
                 ->where('machinery_shift_reports.status', 'approved')
                 ->where('machinery_shift_reports.report_date', '<=', now()->toDateString())

--- a/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
+++ b/app/Console/Commands/Assets/VerifyAssetRegistryCutover.php
@@ -121,6 +121,7 @@ final class VerifyAssetRegistryCutover extends Command
         $divergence = 0;
         $rows = DB::table('machinery_assets as legacy')
             ->join('organization_assets as canonical', 'canonical.id', '=', 'legacy.organization_asset_id')
+            ->leftJoin('asset_operation_profiles as profile', 'profile.organization_asset_id', '=', 'canonical.id')
             ->whereNull('legacy.deleted_at')
             ->get([
                 'legacy.organization_id as legacy_organization_id',
@@ -136,6 +137,14 @@ final class VerifyAssetRegistryCutover extends Command
                 'canonical.machinery_id as canonical_machinery_id',
                 'legacy.current_project_id as legacy_project_id',
                 'canonical.current_project_id as canonical_project_id',
+                'legacy.operating_cost_per_hour as legacy_operating_cost_per_hour',
+                'profile.operating_cost_per_hour as canonical_operating_cost_per_hour',
+                'legacy.fuel_type as legacy_fuel_type',
+                'profile.fuel_type as canonical_fuel_type',
+                'legacy.fuel_consumption_rate as legacy_fuel_consumption_rate',
+                'profile.fuel_consumption_rate as canonical_fuel_consumption_rate',
+                'legacy.meter_hours as legacy_meter_value',
+                'profile.meter_value as canonical_meter_value',
             ]);
 
         foreach ($rows as $row) {
@@ -146,6 +155,10 @@ final class VerifyAssetRegistryCutover extends Command
                 || (string) $row->legacy_ownership_type !== (string) $row->canonical_ownership_type
                 || $this->nullableInt($row->legacy_machinery_id) !== $this->nullableInt($row->canonical_machinery_id)
                 || $this->nullableInt($row->legacy_project_id) !== $this->nullableInt($row->canonical_project_id)
+                || ! $this->numericValuesMatch($row->legacy_operating_cost_per_hour, $row->canonical_operating_cost_per_hour)
+                || $this->nullableString($row->legacy_fuel_type) !== $this->nullableString($row->canonical_fuel_type)
+                || ! $this->numericValuesMatch($row->legacy_fuel_consumption_rate, $row->canonical_fuel_consumption_rate)
+                || ! $this->numericValuesMatch($row->legacy_meter_value, $row->canonical_meter_value)
             ) {
                 $divergence++;
             }
@@ -406,5 +419,14 @@ final class VerifyAssetRegistryCutover extends Command
     private function nullableInt(mixed $value): ?int
     {
         return $value === null ? null : (int) $value;
+    }
+
+    private function numericValuesMatch(mixed $first, mixed $second): bool
+    {
+        if ($first === null || $second === null) {
+            return $first === null && $second === null;
+        }
+
+        return abs((float) $first - (float) $second) < 0.0005;
     }
 }

--- a/database/migrations/2026_08_12_000001_add_operational_values_to_asset_operation_profiles.php
+++ b/database/migrations/2026_08_12_000001_add_operational_values_to_asset_operation_profiles.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('asset_operation_profiles', function (Blueprint $table): void {
+            $table->decimal('operating_cost_per_hour', 15, 2)->default(0);
+            $table->string('fuel_type', 80)->nullable();
+            $table->decimal('fuel_consumption_rate', 12, 3)->nullable();
+            $table->decimal('meter_value', 12, 2)->default(0);
+        });
+
+        DB::statement(<<<'SQL'
+            UPDATE asset_operation_profiles AS profile
+            SET operating_cost_per_hour = legacy.operating_cost_per_hour,
+                fuel_type = legacy.fuel_type,
+                fuel_consumption_rate = legacy.fuel_consumption_rate,
+                meter_value = legacy.meter_hours,
+                updated_at = CURRENT_TIMESTAMP
+            FROM machinery_assets AS legacy
+            WHERE legacy.organization_asset_id = profile.organization_asset_id
+            SQL);
+
+        DB::statement(<<<'SQL'
+            UPDATE organization_assets AS canonical
+            SET metadata = COALESCE(legacy.metadata::jsonb, '{}'::jsonb)
+                    || COALESCE(canonical.metadata, '{}'::jsonb),
+                updated_at = CURRENT_TIMESTAMP
+            FROM machinery_assets AS legacy
+            WHERE legacy.organization_asset_id = canonical.id
+              AND legacy.metadata IS NOT NULL
+            SQL);
+    }
+
+    public function down(): void
+    {
+        Schema::table('asset_operation_profiles', function (Blueprint $table): void {
+            $table->dropColumn([
+                'operating_cost_per_hour',
+                'fuel_type',
+                'fuel_consumption_rate',
+                'meter_value',
+            ]);
+        });
+    }
+};

--- a/tests/Feature/Api/V1/Admin/AssetDispatchWorkflowTest.php
+++ b/tests/Feature/Api/V1/Admin/AssetDispatchWorkflowTest.php
@@ -41,6 +41,11 @@ final class AssetDispatchWorkflowTest extends TestCase
             (int) $context->organization->id,
             ['asset_code' => 'DSP-1', 'name' => 'Dispatcher excavator', 'operating_cost_per_hour' => 1000],
         );
+        $misleadingLegacyAsset = $this->app->make(MachineryOperationsService::class)->createAsset(
+            (int) $context->organization->id,
+            ['asset_code' => 'DSP-LEGACY-TRAP', 'name' => 'Higher canonical cost', 'operating_cost_per_hour' => 2000],
+        );
+        $misleadingLegacyAsset->update(['operating_cost_per_hour' => 1]);
 
         $request = $this->withHeaders($context->authHeaders())->postJson('/api/v1/admin/machinery-operations/asset-requests', [
             'project_id' => $project->id,
@@ -69,6 +74,7 @@ final class AssetDispatchWorkflowTest extends TestCase
         $this->withHeaders($context->authHeaders())
             ->getJson("/api/v1/admin/machinery-operations/asset-requests/{$requestId}/candidates")
             ->assertOk()
+            ->assertJsonPath('data.0.asset.id', $asset->id)
             ->assertJsonPath('data.0.asset.organization_asset_id', $asset->organization_asset_id)
             ->assertJsonPath('data.0.eligible', true);
 

--- a/tests/Feature/Api/V1/Admin/MachineryOperationsWorkflowTest.php
+++ b/tests/Feature/Api/V1/Admin/MachineryOperationsWorkflowTest.php
@@ -180,6 +180,11 @@ final class MachineryOperationsWorkflowTest extends TestCase
             ->assertJsonPath('data.approved_by_user_id', $context->user->id)
             ->assertJsonPath('data.hourly_rate_snapshot', '4500.00');
 
+        $canonicalProfile = MachineryAsset::query()->findOrFail($assetId)
+            ->organizationAsset()->firstOrFail()
+            ->operationProfile()->firstOrFail();
+        self::assertSame('106.50', $canonicalProfile->meter_value);
+
         $downtimeResponse = $this->withHeaders($context->authHeaders())
             ->postJson('/api/v1/admin/machinery-operations/downtimes', [
                 'asset_id' => $assetId,
@@ -227,11 +232,14 @@ final class MachineryOperationsWorkflowTest extends TestCase
         $completedMaintenance->assertOk()
             ->assertJsonPath('data.status', 'completed');
 
+        MachineryAsset::query()->whereKey($assetId)->update(['operating_cost_per_hour' => 9999]);
+
         $reports = $this->withHeaders($context->authHeaders())
             ->getJson("/api/v1/admin/machinery-operations/reports?project_id={$project->id}");
         $reports->assertOk()
             ->assertJsonPath('data.downtime_by_reason.0.reason', 'waiting_material')
-            ->assertJsonPath('data.fuel_consumption.0.fuel_type', 'diesel');
+            ->assertJsonPath('data.fuel_consumption.0.fuel_type', 'diesel')
+            ->assertJsonPath('data.operating_cost_by_project.0.cost', static fn (mixed $cost): bool => (float) $cost === 29250.0);
 
         $reserveAsset = $this->withHeaders($context->authHeaders())
             ->postJson('/api/v1/admin/machinery-operations/assets', [

--- a/tests/Feature/Console/BackfillOrganizationAssetsTest.php
+++ b/tests/Feature/Console/BackfillOrganizationAssetsTest.php
@@ -49,6 +49,7 @@ final class BackfillOrganizationAssetsTest extends TestCase
         $context = AdminApiTestContext::create();
         $project = Project::factory()->create(['organization_id' => $context->organization->id]);
         $legacy = $this->createMachineryAsset((int) $context->organization->id, 'BF-IDEMPOTENT', 'INV-BF-IDEMPOTENT');
+        $legacy->update(['metadata' => ['rental_terms' => ['daily_rate' => 7500, 'version' => 'legacy-v3']]]);
         $assignment = MachineryAssignment::query()->create([
             'organization_id' => $context->organization->id,
             'asset_id' => $legacy->id,
@@ -76,11 +77,16 @@ final class BackfillOrganizationAssetsTest extends TestCase
             ['id' => $legacy->id, 'table' => 'machinery_assets'],
             $canonical->metadata['legacy_source'],
         );
+        self::assertEquals(['daily_rate' => 7500, 'version' => 'legacy-v3'], $canonical->metadata['rental_terms']);
         self::assertSame(AssetOperationalMode::ShiftOperation, $canonical->operationProfile->operational_mode);
         self::assertTrue($canonical->operationProfile->tracks_meter);
         self::assertTrue($canonical->operationProfile->tracks_fuel);
         self::assertTrue($canonical->operationProfile->tracks_production);
         self::assertTrue($canonical->operationProfile->maintenance_enabled);
+        self::assertSame('1000.00', $canonical->operationProfile->operating_cost_per_hour);
+        self::assertSame('diesel', $canonical->operationProfile->fuel_type);
+        self::assertNull($canonical->operationProfile->fuel_consumption_rate);
+        self::assertSame('12.00', $canonical->operationProfile->meter_value);
     }
 
     public function test_duplicate_legacy_inventory_numbers_are_reported_and_not_auto_resolved(): void

--- a/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
+++ b/tests/Feature/Console/VerifyAssetRegistryCutoverTest.php
@@ -100,6 +100,27 @@ final class VerifyAssetRegistryCutoverTest extends TestCase
         self::assertFalse($report['ready']);
     }
 
+    public function test_command_blocks_cutover_when_operational_profile_diverges_from_legacy_mirror(): void
+    {
+        $context = AdminApiTestContext::create();
+        $legacy = app(MachineryOperationsService::class)->createAsset((int) $context->organization->id, [
+            'asset_code' => 'CUTOVER-ECONOMICS',
+            'name' => 'Экскаватор',
+            'operating_cost_per_hour' => 1750,
+            'fuel_type' => 'diesel',
+            'fuel_consumption_rate' => 14.5,
+            'meter_hours' => 90,
+        ]);
+        $legacy->organizationAsset->operationProfile()->update(['operating_cost_per_hour' => 1800]);
+
+        $exitCode = Artisan::call('assets:verify-cutover', ['--format' => 'json']);
+        $report = $this->jsonOutput();
+
+        self::assertSame(1, $exitCode);
+        self::assertSame(1, $report['dual_write_divergence']);
+        self::assertFalse($report['ready']);
+    }
+
     public function test_details_report_breaks_down_missing_links_operations_and_assignment_risk(): void
     {
         $context = AdminApiTestContext::create();

--- a/tests/Unit/Core/AssetManagement/OrganizationAssetServiceTest.php
+++ b/tests/Unit/Core/AssetManagement/OrganizationAssetServiceTest.php
@@ -67,6 +67,32 @@ final class OrganizationAssetServiceTest extends TestCase
         self::assertSame($context->user->id, $event->actor_user_id);
     }
 
+    public function test_create_persists_operational_economics_in_canonical_profile(): void
+    {
+        $context = AdminApiTestContext::create();
+
+        $asset = $this->service()->create(
+            (int) $context->organization->id,
+            new CreateOrganizationAssetData(
+                name: 'Экскаватор №1',
+                inventoryNumber: 'EX-0001',
+                operationalMode: AssetOperationalMode::ShiftOperation,
+                tracksMeter: true,
+                tracksFuel: true,
+                meterUnit: 'hour',
+                operatingCostPerHour: 2750.50,
+                fuelType: 'diesel',
+                fuelConsumptionRate: 18.25,
+                meterValue: 412.75,
+            ),
+        );
+
+        self::assertSame('2750.50', $asset->operationProfile->operating_cost_per_hour);
+        self::assertSame('diesel', $asset->operationProfile->fuel_type);
+        self::assertSame('18.250', $asset->operationProfile->fuel_consumption_rate);
+        self::assertSame('412.75', $asset->operationProfile->meter_value);
+    }
+
     public function test_inventory_number_is_unique_only_inside_organization(): void
     {
         $first = AdminApiTestContext::create();

--- a/tests/Unit/MachineryOperations/MachineryCostServiceTest.php
+++ b/tests/Unit/MachineryOperations/MachineryCostServiceTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\MachineryOperations;
 
+use App\BusinessModules\Core\AssetManagement\DTO\CreateOrganizationAssetData;
+use App\BusinessModules\Core\AssetManagement\Enums\AssetOperationalMode;
+use App\BusinessModules\Core\AssetManagement\Services\OrganizationAssetService;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryFuelIssue;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryMaintenanceOrder;
@@ -16,6 +19,42 @@ use Tests\TestCase;
 
 final class MachineryCostServiceTest extends TestCase
 {
+    public function test_unsnapshotted_shift_uses_canonical_operation_profile_rate(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $canonical = app(OrganizationAssetService::class)->create(
+            (int) $context->organization->id,
+            new CreateOrganizationAssetData(
+                name: 'Canonical excavator',
+                inventoryNumber: 'COST-CANONICAL',
+                operationalMode: AssetOperationalMode::ShiftOperation,
+                operatingCostPerHour: 1250,
+            ),
+        );
+        $legacy = MachineryAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'organization_asset_id' => $canonical->id,
+            'current_project_id' => $project->id,
+            'asset_code' => 'COST-CANONICAL',
+            'name' => 'Legacy excavator',
+            'status' => 'in_operation',
+            'ownership_type' => 'owned',
+            'operating_cost_per_hour' => 9999,
+        ]);
+        $this->shift($legacy, $project, 'approved', '2026-08-10', 2, null, (int) $canonical->id);
+
+        $report = app(MachineryCostService::class)->calculate(
+            (int) $context->organization->id,
+            CarbonImmutable::parse('2026-08-01'),
+            CarbonImmutable::parse('2026-08-31'),
+            (int) $project->id,
+        );
+
+        self::assertSame(2500.0, $report['totals']['operation_cost']);
+        self::assertSame('canonical_operation_profile', $report['evidence']['shifts'][0]['rate_source']);
+    }
+
     public function test_cost_is_period_bound_approved_only_and_uses_rate_snapshot(): void
     {
         $context = AdminApiTestContext::create();
@@ -69,17 +108,63 @@ final class MachineryCostServiceTest extends TestCase
         self::assertSame('approval_snapshot', $report['evidence']['shifts'][0]['rate_source']);
     }
 
+    public function test_rental_cost_uses_canonical_asset_terms(): void
+    {
+        $context = AdminApiTestContext::create();
+        $project = Project::factory()->create(['organization_id' => $context->organization->id]);
+        $canonical = app(OrganizationAssetService::class)->create(
+            (int) $context->organization->id,
+            new CreateOrganizationAssetData(
+                name: 'Rented crane',
+                inventoryNumber: 'RENT-CANONICAL',
+                ownershipType: 'leased',
+                metadata: ['rental_terms' => [
+                    'daily_rate' => 5000,
+                    'project_id' => (int) $project->id,
+                    'valid_from' => '2026-08-10',
+                    'valid_to' => '2026-08-11',
+                    'version' => 'contract-v2',
+                ]],
+            ),
+        );
+        $legacy = MachineryAsset::query()->create([
+            'organization_id' => $context->organization->id,
+            'organization_asset_id' => $canonical->id,
+            'current_project_id' => $project->id,
+            'asset_code' => 'RENT-CANONICAL',
+            'name' => 'Legacy crane',
+            'status' => 'in_operation',
+            'ownership_type' => 'owned',
+            'operating_cost_per_hour' => 0,
+            'metadata' => ['rental_terms' => ['daily_rate' => 1]],
+        ]);
+        $this->shift($legacy, $project, 'approved', '2026-08-10', 1, 0, (int) $canonical->id);
+
+        $report = app(MachineryCostService::class)->calculate(
+            (int) $context->organization->id,
+            CarbonImmutable::parse('2026-08-10'),
+            CarbonImmutable::parse('2026-08-11'),
+            (int) $project->id,
+        );
+
+        self::assertSame(10000.0, $report['totals']['rental_cost']);
+        self::assertSame((int) $canonical->id, $report['evidence']['rental'][0]['organization_asset_id']);
+        self::assertSame('contract-v2', $report['evidence']['rental'][0]['terms_version']);
+    }
+
     private function shift(
         MachineryAsset $asset,
         Project $project,
         string $status,
         string $date,
         float $hours,
-        float $rate,
+        ?float $rate,
+        ?int $organizationAssetId = null,
     ): void {
         MachineryShiftReport::query()->create([
             'organization_id' => $asset->organization_id,
             'asset_id' => $asset->id,
+            'organization_asset_id' => $organizationAssetId,
             'project_id' => $project->id,
             'report_date' => $date,
             'status' => $status,

--- a/tests/Unit/MachineryOperations/MachineryWorkflowPolicyTest.php
+++ b/tests/Unit/MachineryOperations/MachineryWorkflowPolicyTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\MachineryOperations;
 
 use App\BusinessModules\Core\AssetManagement\Enums\AssetLifecycleStatus;
 use App\BusinessModules\Core\AssetManagement\Enums\AssetTechnicalStatus;
+use App\BusinessModules\Core\AssetManagement\Models\AssetOperationProfile;
 use App\BusinessModules\Core\AssetManagement\Models\OrganizationAsset;
 use App\BusinessModules\Features\MachineryOperations\Models\MachineryAsset;
 use App\BusinessModules\Features\MachineryOperations\Services\MachineryAssetProjection;
@@ -62,6 +63,9 @@ final class MachineryWorkflowPolicyTest extends TestCase
         self::assertSame(array_keys($projection->project($legacy)), array_keys($projection->project($linked)));
         self::assertSame(900, $projection->project($linked)['organization_asset_id']);
         self::assertSame('Canonical excavator', $projection->project($linked)['name']);
+        self::assertSame('2500.00', $projection->project($linked)['operating_cost_per_hour']);
+        self::assertSame('17.500', $projection->project($linked)['fuel_consumption_rate']);
+        self::assertSame('321.00', $projection->project($linked)['meter_hours']);
         self::assertNull($projection->project($legacy)['organization_asset_id']);
         self::assertSame('Legacy excavator', $projection->project($legacy)['name']);
     }
@@ -89,6 +93,13 @@ final class MachineryWorkflowPolicyTest extends TestCase
             'metadata' => ['machinery_operation_status' => 'available'],
         ], $canonicalOverrides));
         $canonical->id = 900;
+        $canonical->setRelation('operationProfile', new AssetOperationProfile([
+            'organization_asset_id' => 900,
+            'operating_cost_per_hour' => '2500',
+            'fuel_type' => 'diesel',
+            'fuel_consumption_rate' => '17.5',
+            'meter_value' => '321',
+        ]));
         $asset->setRelation('organizationAsset', $canonical);
 
         return $asset;
@@ -103,7 +114,7 @@ final class MachineryWorkflowPolicyTest extends TestCase
             'inventory_number' => 'INV-LEG',
             'ownership_type' => 'owned',
             'status' => 'available',
-            'operating_cost_per_hour' => 1000,
+            'operating_cost_per_hour' => '1000',
         ]);
         $asset->id = 70;
         $asset->setRelation('organizationAsset', null);


### PR DESCRIPTION
## Что изменено
- ставка часа, топливо и счётчик перенесены в канонический asset_operation_profiles
- create/backfill/approval поддерживают dual-write до cutover
- расчёты, диспетчеризация, отчёты, API-проекция и RAG читают канонический профиль
- verifier блокирует cutover при расхождении эксплуатационных значений
- rental terms читаются из канонического metadata; leased поддержан как штатный тип аренды

## Проверки
- 61 целевой тест, 369 assertions
- свежий критический набор: 20 тестов, 144 assertions
- PHPStan: 0 ошибок
- Pint: PASS
- git diff --check: PASS

Полный RefreshDatabase по-прежнему блокируется существующими проблемами основной миграционной цепочки (pgvector и отсутствующие warehouse/safety таблицы в частичной локальной схеме); целевые тесты выполнены на изолированном PostgreSQL.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Extended AssetOperationProfile and CreateOrganizationAssetData DTO to include operational fields: operating_cost_per_hour, fuel_type, fuel_consumption_rate, and meter_value.</li>
<li>Updated LegacyAssetMapper to map new operational fields during asset backfilling.</li>
<li>Refactored MachineryRagSource to prioritize canonical organization asset data over legacy machinery asset data.</li>
<li>Added database migration to persist new operational fields in the asset_operation_profiles table.</li>
<li>Updated related services and added comprehensive tests for asset registry cutover and machinery operations workflows.</li>
</ul></div>