### PR TITLE
fix[backend]: исправлен поиск JSON-пробелов ликвидности

### DIFF
--- a/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquiditySourceVersionRecorder.php
+++ b/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/PortfolioLiquiditySourceVersionRecorder.php
@@ -248,15 +248,19 @@ final readonly class PortfolioLiquiditySourceVersionRecorder
             'organization_id' => $organizationId,
             'source_type' => $sourceType,
             'source_id' => $sourceId,
-            'missing_fields' => array_values($missingFields),
         ];
+        $sourceHash = hash('sha256', CanonicalJson::encode([
+            ...$identity,
+            'missing_fields' => array_values($missingFields),
+        ]));
 
         PortfolioLiquiditySourceGap::query()->firstOrCreate(
             [
                 ...$identity,
-                'source_hash' => hash('sha256', CanonicalJson::encode($identity)),
+                'source_hash' => $sourceHash,
             ],
             [
+                'missing_fields' => array_values($missingFields),
                 'observed_at' => $recordedAt ?? now(),
                 'business_effective_at' => $businessEffectiveAt ?? now(),
                 'recorded_at' => $recordedAt ?? now(),

--- a/tests/Unit/Reporting/Waves23/PortfolioHardeningBehaviorTest.php
+++ b/tests/Unit/Reporting/Waves23/PortfolioHardeningBehaviorTest.php
@@ -302,6 +302,21 @@ final class PortfolioHardeningBehaviorTest extends TestCase
     }
 
     #[Test]
+    public function liquidity_gap_lookup_uses_scalar_hash_identity(): void
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 4)
+            .'/app/BusinessModules/Features/Budgeting/Reporting/Portfolio/'
+            .'PortfolioLiquiditySourceVersionRecorder.php',
+        );
+
+        self::assertIsString($source);
+        self::assertStringContainsString("'source_hash' => \$sourceHash", $source);
+        self::assertStringContainsString("'missing_fields' => array_values(\$missingFields),\n        ]));", $source);
+        self::assertStringContainsString("'missing_fields' => array_values(\$missingFields),\n                'observed_at'", $source);
+    }
+
+    #[Test]
     public function unknown_history_gap_uses_stable_sentinel_closed_by_first_real_version(): void
     {
         self::assertSame([0, 73], HoldingAllocationFactProjector::resolvableGapSourceVersions(73));


### PR DESCRIPTION
## GlitchTip

- Исправляет [PROHELPER-BACKEND-GU / issue 573](http://5.129.220.32:8000/prohelper-backend/issues/573).

## Причина

`firstOrCreate()` использовал массив `missing_fields` как условие равенства для `jsonb`, из-за чего PostgreSQL получал невалидный JSON-параметр.

## Изменения

- JSON-поле исключено из условий поиска.
- Полный детерминированный идентификатор по-прежнему задаётся `source_hash`, включающим `missing_fields`.
- Добавлен регрессионный тест контракта поиска.

## Проверки

- `php -l` для изменённых файлов
- `phpunit tests/Unit/Reporting/Waves23/PortfolioHardeningBehaviorTest.php`
- `phpstan analyse` для изменённых файлов
- `git diff --check`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated PortfolioLiquiditySourceVersionRecorder to include missing_fields in the source_hash calculation.</li>
<li>Modified PortfolioLiquiditySourceGap lookup to use the updated source_hash which now accounts for missing fields.</li>
<li>Added a unit test in PortfolioHardeningBehaviorTest to verify the source_hash logic includes missing fields.</li>
</ul></div>