### PR TITLE
fix: восстановить повтор обработки документа AI-сметчика

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ExplicitDocumentRetryEligibility.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ExplicitDocumentRetryEligibility.php
@@ -36,8 +36,10 @@ final readonly class ExplicitDocumentRetryEligibility
             return false;
         }
 
-        if (is_array($meta['explicit_document_retry_history'] ?? null)
-            && $meta['explicit_document_retry_history'] !== []) {
+        $currentRetry = is_array($meta['explicit_document_retry'] ?? null)
+            ? $meta['explicit_document_retry']
+            : [];
+        if (! $this->terminalRetryAllowsNewLineage($currentRetry, $meta, (string) $document->source_version)) {
             return false;
         }
 
@@ -79,5 +81,24 @@ final readonly class ExplicitDocumentRetryEligibility
         return $hasCurrentUnits
             && $hasRepairableFailure
             && (int) $document->processed_page_count === 0;
+    }
+
+    /** @param array<string, mixed> $currentRetry @param array<string, mixed> $meta */
+    private function terminalRetryAllowsNewLineage(array $currentRetry, array $meta, string $sourceVersion): bool
+    {
+        if ($currentRetry === []) {
+            return true;
+        }
+
+        $retrySourceVersion = (string) ($currentRetry['source_version'] ?? '');
+        $retryAttemptId = (string) ($currentRetry['attempt_id'] ?? '');
+        $processingAttemptId = (string) ($meta['processing_attempt_id'] ?? '');
+
+        return $retrySourceVersion !== ''
+            && hash_equals($sourceVersion, $retrySourceVersion)
+            && $retryAttemptId !== ''
+            && hash_equals($processingAttemptId, $retryAttemptId)
+            && ($currentRetry['status'] ?? null) === 'failed'
+            && ($currentRetry['terminal_reason'] ?? null) === 'system_failure';
     }
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/RetryEstimateGenerationDocument.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/RetryEstimateGenerationDocument.php
@@ -36,7 +36,7 @@ final class RetryEstimateGenerationDocument
         ?string $reason,
     ): DocumentActionResult {
         $keyHash = hash('sha256', $idempotencyKey);
-        [$lockedSession, $lockedDocument, $attemptId, $disposition] = DB::transaction(
+        [$lockedSession, $lockedDocument, $attemptId, $disposition, $terminalReplay] = DB::transaction(
             function () use ($session, $document, $actor, $expectedVersion, $expectedSourceVersion, $keyHash, $reason): array {
                 $lockedSession = EstimateGenerationSession::query()->lockForUpdate()->findOrFail($session->getKey());
                 $lockedDocument = EstimateGenerationDocument::query()
@@ -73,10 +73,26 @@ final class RetryEstimateGenerationDocument
                         throw new ExplicitDocumentRetryConflict('stale_source');
                     }
 
-                    return [$lockedSession, $lockedDocument, (string) ($current['attempt_id'] ?? ''), 'replayed'];
+                    return [
+                        $lockedSession,
+                        $lockedDocument,
+                        (string) ($current['attempt_id'] ?? ''),
+                        'replayed',
+                        ($current['status'] ?? null) !== 'processing',
+                    ];
+                }
+                $historicalAttemptId = $this->historicalAttemptForKey($meta, $keyHash, $expectedSourceVersion);
+                if ($historicalAttemptId !== null) {
+                    return [$lockedSession, $lockedDocument, $historicalAttemptId, 'replayed', true];
                 }
                 if (($current['status'] ?? null) === 'processing') {
-                    return [$lockedSession, $lockedDocument, (string) ($current['attempt_id'] ?? ''), 'already_in_progress'];
+                    return [
+                        $lockedSession,
+                        $lockedDocument,
+                        (string) ($current['attempt_id'] ?? ''),
+                        'already_in_progress',
+                        false,
+                    ];
                 }
 
                 $this->policy->documents($lockedSession, $expectedVersion);
@@ -206,7 +222,7 @@ final class RetryEstimateGenerationDocument
                     'payload' => $audit,
                 ]);
 
-                return [$this->reconciler->changed($lockedSession), $lockedDocument, $attemptId, 'accepted'];
+                return [$this->reconciler->changed($lockedSession), $lockedDocument, $attemptId, 'accepted', false];
             },
             3,
         );
@@ -229,10 +245,7 @@ final class RetryEstimateGenerationDocument
         $lockedSession = $lockedSession->fresh(['documents']) ?? $lockedSession;
 
         $resultDocument = $lockedDocument->fresh() ?? $lockedDocument;
-        $retryMeta = is_array($resultDocument->meta) && is_array($resultDocument->meta['explicit_document_retry'] ?? null)
-            ? $resultDocument->meta['explicit_document_retry']
-            : [];
-        $messageKey = $disposition === 'replayed' && ($retryMeta['status'] ?? null) !== 'processing'
+        $messageKey = $disposition === 'replayed' && $terminalReplay
             ? 'estimate_generation.document_retry_result_replayed'
             : 'estimate_generation.document_retry_queued';
 
@@ -243,5 +256,32 @@ final class RetryEstimateGenerationDocument
             $disposition,
             $attemptId,
         );
+    }
+
+    /** @param array<string, mixed> $meta */
+    private function historicalAttemptForKey(array $meta, string $keyHash, string $sourceVersion): ?string
+    {
+        $history = is_array($meta['explicit_document_retry_history'] ?? null)
+            ? $meta['explicit_document_retry_history']
+            : [];
+
+        foreach ($history as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $historicalHash = (string) ($entry['idempotency_hash'] ?? '');
+            $historicalSourceVersion = (string) ($entry['source_version'] ?? '');
+            $historicalAttemptId = (string) ($entry['new_attempt_id'] ?? '');
+            if ($historicalHash !== ''
+                && hash_equals($historicalHash, $keyHash)
+                && $historicalSourceVersion !== ''
+                && hash_equals($historicalSourceVersion, $sourceVersion)
+                && $historicalAttemptId !== '') {
+                return $historicalAttemptId;
+            }
+        }
+
+        return null;
     }
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionOperationalSnapshot.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionOperationalSnapshot.php
@@ -9,8 +9,8 @@ use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationSessi
 use App\BusinessModules\Addons\EstimateGeneration\Observability\OperationalUsageSummary;
 use App\BusinessModules\Addons\EstimateGeneration\Pipeline\CheckpointStatus;
 use App\BusinessModules\Addons\EstimateGeneration\Services\Quality\DocumentReadinessClassifier;
-use App\BusinessModules\Addons\EstimateGeneration\Services\Quality\EstimatorReadinessEvaluator;
 use App\BusinessModules\Addons\EstimateGeneration\Services\Quality\EstimateScopeMetadataProjector;
+use App\BusinessModules\Addons\EstimateGeneration\Services\Quality\EstimatorReadinessEvaluator;
 use App\BusinessModules\Addons\EstimateGeneration\Services\Quality\OperationalReadinessInputFactory;
 use App\BusinessModules\Addons\EstimateGeneration\Services\Quality\ReadinessResult;
 use Carbon\CarbonImmutable;
@@ -417,6 +417,7 @@ final class BuildSessionOperationalSnapshot implements SessionOperationalSnapsho
             ],
             objectInput: $base->objectInput,
             aiEstimateQuota: $base->aiEstimateQuota,
+            recommendedStep: $base->recommendedStep,
         );
     }
 

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionSnapshot.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionSnapshot.php
@@ -83,6 +83,7 @@ final class BuildSessionSnapshot
         $metrics = is_array($readinessSummary['metrics'] ?? null) ? $readinessSummary['metrics'] : [];
         $budgetScope = is_array($draft['budget_scope'] ?? null) ? $draft['budget_scope'] : [];
         $aiEstimateQuota = $session->getAttribute('ai_estimate_quota_snapshot');
+        $nextAction = $this->recommendedNextAction($status, $actions);
 
         return new SessionSnapshotData(
             id: (int) $session->getKey(),
@@ -93,7 +94,7 @@ final class BuildSessionSnapshot
             availableActions: $actions,
             blockingIssues: $blockers,
             warnings: $warnings,
-            nextAction: $this->recommendedNextAction($status, $actions),
+            nextAction: $nextAction,
             readinessEvaluated: $readinessEvaluated,
             documentsSummary: $documentsSummary,
             estimateSummary: is_array($draft['quality_summary'] ?? null) ? $draft['quality_summary'] : [],
@@ -117,6 +118,7 @@ final class BuildSessionSnapshot
                     (string) $session->organization_id,
                     (string) $session->getKey(),
                 )->toArray(),
+            recommendedStep: $this->recommendedStep($session, $status),
         );
     }
 
@@ -222,6 +224,22 @@ final class BuildSessionSnapshot
             if (! in_array($action['action'], ['cancel', 'archive'], true)) {
                 return $action['action'];
             }
+        }
+
+        return null;
+    }
+
+    private function recommendedStep(
+        EstimateGenerationSession $session,
+        EstimateGenerationStatus $status,
+    ): ?string {
+        if ($status === EstimateGenerationStatus::ProcessingDocuments) {
+            return 'documents';
+        }
+
+        if ($status === EstimateGenerationStatus::Failed
+            && $session->resume_status === EstimateGenerationStatus::ProcessingDocuments) {
+            return 'documents';
         }
 
         return null;

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/SessionSnapshotData.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/SessionSnapshotData.php
@@ -44,6 +44,7 @@ final readonly class SessionSnapshotData
             'available' => 10,
             'reservation_status' => null,
         ],
+        public ?string $recommendedStep = null,
     ) {}
 
     /** @return array<string, mixed> */
@@ -64,6 +65,7 @@ final readonly class SessionSnapshotData
             'blocking_issues' => $this->blockingIssues,
             'warnings' => $this->warnings,
             'next_action' => $this->nextAction,
+            'recommended_step' => $this->recommendedStep,
             'readiness_evaluated' => $this->readinessEvaluated,
             'documents_summary' => $this->documentsSummary,
             'estimate_summary' => $this->estimateSummary,
@@ -91,6 +93,7 @@ final readonly class SessionSnapshotData
             'blocking_issues' => $this->blockingIssues,
             'warnings' => $this->warnings,
             'next_action' => $this->nextAction,
+            'recommended_step' => $this->recommendedStep,
             'readiness_evaluated' => $this->readinessEvaluated,
             'can_generate' => $this->canGenerate,
             'can_apply' => $this->canApply,

--- a/docs/superpowers/plans/2026-08-13-recoverable-document-retry.md
+++ b/docs/superpowers/plans/2026-08-13-recoverable-document-retry.md
@@ -1,0 +1,75 @@
+# Recoverable Document Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Восстановить безопасный повтор исправимого terminal-сбоя документа и корректную document-first навигацию AI-сметчика МОСТ.
+
+**Architecture:** Laravel остаётся источником capability и рекомендуемого шага. Retry выполняет повторную проверку под блокировкой, создаёт новую lineage только для нового пользовательского key после terminal attempt и публикует job after commit; React использует typed snapshot/capability и state-scoped idempotency key.
+
+**Tech Stack:** PHP 8.2/Laravel 11/PostgreSQL/PHPUnit; React/Vite/TypeScript/Vitest/MSW.
+
+## Global Constraints
+
+- Не запускать production retry документа 168 и платный AI.
+- Не запускать миграции, локальные DB-команды, dev server или admin build.
+- Все backend user messages через `trans_message`.
+- Сохранить append-only history, tenant/ABAC/source/state fences и after-commit dispatch.
+
+---
+
+### Task 1: Backend eligibility и lifecycle
+
+**Files:**
+- Modify: `tests/Unit/EstimateGeneration/Documents/ExplicitDocumentRetryEligibilityTest.php`
+- Modify: `tests/Feature/EstimateGeneration/ExplicitDocumentRetryHttpContractTest.php`
+- Modify: `tests/Feature/EstimateGeneration/Pipeline/ExplicitDocumentRetryPostgresContractTest.php`
+- Modify: `app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ExplicitDocumentRetryEligibility.php`
+- Modify: `app/BusinessModules/Addons/EstimateGeneration/Application/Documents/RetryEstimateGenerationDocument.php`
+
+- [ ] Добавить failing tests: terminal previous attempt доступен для нового key; active attempt и unsafe failures закрыты; exact old key replay не dispatch; new key создаёт lineage, append history и переводит session/document в processing/queued.
+- [ ] Запустить узкие PHPUnit тесты и зафиксировать ожидаемый RED.
+- [ ] Убрать history-wide deny, заменить его проверкой current attempt status/source и сохранить повторную lock-проверку.
+- [ ] Запустить DB-free/API тесты до GREEN.
+- [ ] Расширить PostgreSQL contract на terminal lineage → new lineage, exact replay и concurrency; выполнить штатным wrapper с 0 skip.
+
+### Task 2: Canonical snapshot
+
+**Files:**
+- Modify: `tests/Unit/EstimateGeneration/Workflow/BuildSessionSnapshotTest.php`
+- Modify: `app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/SessionSnapshotData.php`
+- Modify: `app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionSnapshot.php`
+- Modify: `app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionOperationalSnapshot.php`
+
+- [ ] Добавить failing snapshot test для `failed/resume processing_documents/document system failure/0 ready` с `recommended_step=documents` и отсутствием downstream capability.
+- [ ] Запустить тест и подтвердить RED из-за отсутствующего поля/неверного шага.
+- [ ] Добавить backward-compatible `recommended_step` в DTO и определить его из session/document recovery semantics.
+- [ ] Запустить snapshot/readiness regressions до GREEN.
+
+### Task 3: Admin navigation и retry identity
+
+**Files:**
+- Modify: `src/features/estimate-generation/api/estimateGenerationContracts.ts`
+- Modify: `src/features/estimate-generation/api/estimateGenerationNormalizers.ts`
+- Modify: `src/features/estimate-generation/model/steps.ts`
+- Modify: `src/features/estimate-generation/model/steps.test.ts`
+- Modify: `src/features/estimate-generation/pages/EstimateGenerationWorkspacePage.tsx`
+- Modify: `src/features/estimate-generation/pages/EstimateGenerationWorkspacePage.test.tsx`
+- Modify: `src/features/estimate-generation/documents/documentRetryIdempotency.ts`
+- Modify: `src/features/estimate-generation/steps/DocumentsStep.tsx`
+- Modify: `src/features/estimate-generation/steps/DocumentsStep.test.tsx`
+
+- [ ] Добавить failing tests для production-shaped snapshot, server recommended step, 0/22 downstream block и remount/new-terminal key behavior.
+- [ ] Запустить только новые/затронутые Vitest cases и подтвердить RED.
+- [ ] Типизировать/нормализовать `recommended_step`, применить его при выборе active step и сохранить legacy document fallback.
+- [ ] Включить capability state identity в storage key, очищать key только при однозначно завершённом/обновлённом server state.
+- [ ] Запустить целевые Vitest/MSW до GREEN, сохранив input-review и valid summary regressions.
+
+### Task 4: Verification, review и выпуск
+
+**Files:** Все изменённые файлы двух репозиториев.
+
+- [ ] Выполнить backend PHPUnit/PostgreSQL wrapper, `php -l`, Pint, минимальный PHPStan/Larastan, UTF-8 и `git diff --check`.
+- [ ] Выполнить admin Vitest/MSW, `tsc --noEmit`, ESLint/Prettier изменённых файлов, UTF-8 и `git diff --check` без build.
+- [ ] Передать один завершённый backend+admin diff независимому read-only reviewer; исправить Critical/Important и повторить только затронутые проверки.
+- [ ] Создать русские Conventional Commits, push, PR, squash merge и дождаться штатных deploy workflows backend/admin.
+- [ ] Провести read-only canary `/ready`, release JSON, unauthenticated 401, logs/GlitchTip и document 168 snapshot; не вызывать retry.

--- a/docs/superpowers/specs/2026-08-13-recoverable-document-retry-design.md
+++ b/docs/superpowers/specs/2026-08-13-recoverable-document-retry-design.md
@@ -1,0 +1,34 @@
+# Восстановление AI-сметчика после исправимого сбоя документа
+
+## Цель
+
+Вернуть уполномоченному пользователю безопасный явный повтор обработки текущей версии документа после завершившейся системной ошибки, направлять его на шаг «Документы» и блокировать следующие шаги при отсутствии пригодных страниц.
+
+## Контракт backend
+
+- `retry_document` публикуется только для document-mutable сессии, текущей `source_version`, канонического `system_failure`, нулевого числа пригодных страниц и repairable terminal units без active pending/running attempt.
+- Наличие immutable `explicit_document_retry_history` само по себе не запрещает повтор. Current explicit attempt со статусом `processing` запрещает новый key; terminal `failed/system_failure` разрешает новый key. Exact replay прежнего key возвращает прежний terminal result без новой lineage и dispatch.
+- Accepted retry под row lock повторно проверяет tenant, ABAC, state/source fences и eligibility, добавляет history, создаёт UUID lineage, сбрасывает unit circuit-breaker state только для новой lineage, переводит документ в queue и сессию из resumable `failed` в `processing_documents`.
+- Provider/S3 не вызываются в транзакции; job dispatch выполняется после commit. Generation quota повторно не списывается.
+- Snapshot отдаёт явный `recommended_step`. Для `failed + resume_status=processing_documents` при document system failure это `documents`; downstream недоступен при `0 ready`.
+
+## Контракт admin
+
+- Навигация сначала использует `recommended_step`; legacy fallback явно распознаёт document-system codes и production-shaped `0/N` failure, не полагаясь только на `documents_`.
+- Недоступный или устаревший active step заменяется серверной рекомендацией. При `0/22` summary и прочие downstream шаги disabled.
+- Кнопка повторной обработки строится только из `available_actions` документа. Pending action блокирует double click.
+- Idempotency key привязан к project/session/document/source/state capability. Timeout/remount сохраняет key; новый terminal snapshot/state создаёт новый key.
+- Accepted/stale responses обновляют snapshot и документы; 409 сопровождается понятным сообщением.
+
+## Безопасность и границы
+
+- Integrity, hard-limit, user-action-required, stale, cross-tenant и no-ABAC состояния остаются fail-closed.
+- История append-only. Автоматический бесконечный retry не добавляется; восстановление запускается только явным действием пользователя.
+- Production document `168` не перезапускается в рамках выпуска; платный AI не вызывается.
+
+## Проверка
+
+- Backend: DB-free/API RED→GREEN, PostgreSQL wrapper без skip для concurrency/lineage/replay/tenant/source, incident/lifecycle/circuit-breaker regressions, syntax/Pint/Larastan/diff/UTF-8.
+- Admin: Vitest/MSW для production snapshot/navigation/capability/idempotency/stale flows, TypeScript, ESLint/Prettier/diff/UTF-8; build не запускается.
+- После deploy: `/ready`, release JSON backend/admin, защищённый endpoint без auth = 401, свежие logs/GlitchTip и read-only snapshot документа 168 без retry.
+

--- a/tests/Feature/EstimateGeneration/Pipeline/ExplicitDocumentRetryPostgresContractTest.php
+++ b/tests/Feature/EstimateGeneration/Pipeline/ExplicitDocumentRetryPostgresContractTest.php
@@ -228,6 +228,124 @@ final class ExplicitDocumentRetryPostgresContractTest extends TestCase
         self::assertSame($nextAttempt->attemptId, $document->meta['explicit_document_retry_history'][1]['new_attempt_id']);
         self::assertSame(0, EstimateGenerationProcessingUnit::query()->max('attempt_count'));
         self::assertSame(2, EstimateGenerationAuditEvent::query()->count());
+
+        $secondTerminalMeta = $document->meta;
+        $secondTerminalMeta['explicit_document_retry'] = [
+            ...$secondTerminalMeta['explicit_document_retry'],
+            'status' => 'failed',
+            'completed_at' => now()->toISOString(),
+            'terminal_reason' => 'system_failure',
+        ];
+        $document->forceFill(['status' => 'failed', 'meta' => $secondTerminalMeta])->save();
+        $historicalReplay = $service->handle($session, $document, $actor, 9, $sourceVersion, $key, null);
+
+        self::assertSame('replayed', $historicalReplay->disposition);
+        self::assertSame($accepted->attemptId, $historicalReplay->attemptId);
+        self::assertSame('estimate_generation.document_retry_result_replayed', $historicalReplay->messageKey);
+        Queue::assertPushed(ProcessEstimateGenerationDocumentJob::class, 2);
+        self::assertCount(2, $historicalReplay->document->meta['explicit_document_retry_history']);
+        self::assertSame(2, EstimateGenerationAuditEvent::query()->count());
+    }
+
+    public function test_accepted_retry_resumes_failed_document_session_with_real_workflow(): void
+    {
+        Queue::fake();
+        $checksum = hash('sha256', 'resumable-failed-document');
+        $sourceVersion = 'sha256:'.$checksum;
+        $session = EstimateGenerationSession::query()->create([
+            'organization_id' => 38,
+            'project_id' => 52,
+            'user_id' => 7,
+            'status' => 'failed',
+            'processing_stage' => 'failed',
+            'processing_progress' => 100,
+            'state_version' => 4,
+            'resume_status' => 'processing_documents',
+            'failure_code' => 'document_processing_system_failed',
+            'input_payload' => [],
+            'problem_flags' => [],
+        ]);
+        $document = EstimateGenerationDocument::query()->create([
+            'session_id' => $session->id,
+            'organization_id' => 38,
+            'project_id' => 52,
+            'user_id' => 7,
+            'filename' => 'resumable.pdf',
+            'storage_path' => 'org-38/resumable.pdf',
+            'status' => 'failed',
+            'processing_stage' => 'completed',
+            'progress_percent' => 100,
+            'checksum_sha256' => $checksum,
+            'source_version' => $sourceVersion,
+            'page_count' => 1,
+            'processed_page_count' => 0,
+            'error_code' => 'document_processing_system_failed',
+            'facts_summary' => [],
+            'meta' => ['processing_attempt_id' => 'failed-lineage'],
+        ]);
+        $unit = EstimateGenerationProcessingUnit::query()->create([
+            'organization_id' => 38,
+            'project_id' => 52,
+            'session_id' => $session->id,
+            'document_id' => $document->id,
+            'unit_type' => 'pdf_page',
+            'unit_index' => 1,
+            'source_version' => $sourceVersion,
+            'status' => 'failed',
+            'attempt_count' => 3,
+            'output_count' => 0,
+            'failure_code' => 'document_geometry_processing_failed',
+            'failure_fingerprint' => hash('sha256', 'resumable-system-root'),
+            'locator' => ['page' => 1],
+            'metadata' => ['failure_category' => 'terminal'],
+            'failed_at' => now(),
+        ]);
+        EstimateGenerationDocumentPage::query()->create([
+            'document_id' => $document->id,
+            'processing_unit_id' => $unit->id,
+            'source_version' => $sourceVersion,
+            'organization_id' => 38,
+            'project_id' => 52,
+            'session_id' => $session->id,
+            'page_number' => 1,
+            'status' => 'failed',
+        ]);
+
+        $authorization = Mockery::mock(AuthorizationService::class);
+        $authorization->allows('can')->andReturnTrue();
+        $readiness = Mockery::mock(DocumentGenerationReadinessService::class);
+        $readiness->allows('evaluate')->andReturn(['summary' => ['pending_count' => 1]]);
+        $service = new RetryEstimateGenerationDocument(
+            new EstimateGenerationMutationPolicy,
+            app(DocumentMutationSessionReconciler::class),
+            $readiness,
+            $authorization,
+            new ExplicitDocumentRetryEligibility,
+        );
+        $actor = new User;
+        $actor->forceFill(['id' => 7, 'current_organization_id' => 38]);
+
+        $result = $service->handle(
+            $session,
+            $document,
+            $actor,
+            4,
+            $sourceVersion,
+            (string) Str::uuid(),
+            null,
+        );
+
+        self::assertSame('accepted', $result->disposition);
+        $session->refresh();
+        $document->refresh();
+        self::assertSame('processing_documents', $session->status->value);
+        self::assertSame('processing_documents', $session->processing_stage);
+        self::assertSame(5, $session->state_version);
+        self::assertNull($session->resume_status);
+        self::assertNull($session->failure_code);
+        self::assertSame('queued', $document->status);
+        self::assertSame('stored', $document->processing_stage);
+        Queue::assertPushed(ProcessEstimateGenerationDocumentJob::class, 1);
     }
 
     public function test_concurrent_different_keys_have_exactly_one_winner_and_one_dispatch(): void

--- a/tests/Feature/EstimateGeneration/Pipeline/ExplicitDocumentRetryPostgresContractTest.php
+++ b/tests/Feature/EstimateGeneration/Pipeline/ExplicitDocumentRetryPostgresContractTest.php
@@ -124,7 +124,7 @@ final class ExplicitDocumentRetryPostgresContractTest extends TestCase
         $authorization->allows('can')->andReturnTrue();
         $policy = new EstimateGenerationMutationPolicy;
         $reconciler = Mockery::mock(DocumentMutationSessionReconciler::class);
-        $reconciler->expects('changed')->once()->andReturn($session);
+        $reconciler->expects('changed')->twice()->andReturn($session);
         $readiness = Mockery::mock(DocumentGenerationReadinessService::class);
         $readiness->allows('evaluate')->andReturn(['summary' => ['pending_count' => 1]]);
         $service = new RetryEstimateGenerationDocument(
@@ -200,6 +200,34 @@ final class ExplicitDocumentRetryPostgresContractTest extends TestCase
         self::assertSame('estimate_generation.document_retry_result_replayed', $terminalReplay->messageKey);
         Queue::assertPushed(ProcessEstimateGenerationDocumentJob::class, 1);
         self::assertSame(1, EstimateGenerationAuditEvent::query()->count());
+
+        EstimateGenerationProcessingUnit::query()->get()->each(function (EstimateGenerationProcessingUnit $unit) use ($accepted): void {
+            $metadata = is_array($unit->metadata) ? $unit->metadata : [];
+            $unit->forceFill([
+                'status' => 'failed',
+                'attempt_count' => 3,
+                'failure_code' => 'document_geometry_processing_failed',
+                'failure_fingerprint' => hash('sha256', 'same-system-root-after-retry'),
+                'metadata' => [
+                    ...$metadata,
+                    'failure_category' => 'terminal',
+                    'processing_attempt_id' => $accepted->attemptId,
+                ],
+                'failed_at' => now(),
+            ])->save();
+        });
+        $newKey = (string) Str::uuid();
+        $nextAttempt = $service->handle($session, $document, $actor, 9, $sourceVersion, $newKey, null);
+
+        self::assertSame('accepted', $nextAttempt->disposition);
+        self::assertNotSame($accepted->attemptId, $nextAttempt->attemptId);
+        Queue::assertPushed(ProcessEstimateGenerationDocumentJob::class, 2);
+        $document->refresh();
+        self::assertCount(2, $document->meta['explicit_document_retry_history']);
+        self::assertSame($accepted->attemptId, $document->meta['explicit_document_retry_history'][1]['old_attempt_id']);
+        self::assertSame($nextAttempt->attemptId, $document->meta['explicit_document_retry_history'][1]['new_attempt_id']);
+        self::assertSame(0, EstimateGenerationProcessingUnit::query()->max('attempt_count'));
+        self::assertSame(2, EstimateGenerationAuditEvent::query()->count());
     }
 
     public function test_concurrent_different_keys_have_exactly_one_winner_and_one_dispatch(): void

--- a/tests/Unit/EstimateGeneration/Documents/ExplicitDocumentRetryEligibilityTest.php
+++ b/tests/Unit/EstimateGeneration/Documents/ExplicitDocumentRetryEligibilityTest.php
@@ -36,6 +36,47 @@ final class ExplicitDocumentRetryEligibilityTest extends TestCase
         ));
     }
 
+    #[Test]
+    public function terminal_failed_previous_retry_allows_a_new_user_lineage(): void
+    {
+        $document = $this->document('failed', 'document_geometry_processing_failed');
+        $document->forceFill(['meta' => [
+            'processing_attempt_id' => 'attempt-terminal',
+            'explicit_document_retry' => [
+                'attempt_id' => 'attempt-terminal',
+                'source_version' => 'sha256:current',
+                'status' => 'failed',
+                'terminal_reason' => 'system_failure',
+            ],
+            'explicit_document_retry_history' => [[
+                'old_attempt_id' => 'attempt-original',
+                'new_attempt_id' => 'attempt-terminal',
+            ]],
+        ]]);
+
+        self::assertTrue((new ExplicitDocumentRetryEligibility)->allowed($document));
+    }
+
+    #[Test]
+    public function active_previous_retry_blocks_a_new_user_lineage(): void
+    {
+        $document = $this->document('failed', 'document_geometry_processing_failed');
+        $document->forceFill(['meta' => [
+            'processing_attempt_id' => 'attempt-active',
+            'explicit_document_retry' => [
+                'attempt_id' => 'attempt-active',
+                'source_version' => 'sha256:current',
+                'status' => 'processing',
+            ],
+            'explicit_document_retry_history' => [[
+                'old_attempt_id' => 'attempt-original',
+                'new_attempt_id' => 'attempt-active',
+            ]],
+        ]]);
+
+        self::assertFalse((new ExplicitDocumentRetryEligibility)->allowed($document));
+    }
+
     /** @return iterable<string, array{string}> */
     public static function unsafeFailureCodes(): iterable
     {

--- a/tests/Unit/EstimateGeneration/Http/EstimateGenerationDocumentPresentationTest.php
+++ b/tests/Unit/EstimateGeneration/Http/EstimateGenerationDocumentPresentationTest.php
@@ -102,6 +102,19 @@ final class EstimateGenerationDocumentPresentationTest extends TestCase
             'source_version' => 'sha256:current',
             'error_code' => 'document_processing_system_failed',
             'error_message_key' => 'estimate_generation.document_processing_system_failed',
+            'meta' => [
+                'processing_attempt_id' => 'attempt-terminal',
+                'explicit_document_retry' => [
+                    'attempt_id' => 'attempt-terminal',
+                    'source_version' => 'sha256:current',
+                    'status' => 'failed',
+                    'terminal_reason' => 'system_failure',
+                ],
+                'explicit_document_retry_history' => [[
+                    'old_attempt_id' => 'attempt-original',
+                    'new_attempt_id' => 'attempt-terminal',
+                ]],
+            ],
             'facts_summary' => [
                 'processing_outcome' => [
                     'type' => 'system_failure',

--- a/tests/Unit/EstimateGeneration/Workflow/BuildSessionSnapshotTest.php
+++ b/tests/Unit/EstimateGeneration/Workflow/BuildSessionSnapshotTest.php
@@ -174,6 +174,41 @@ final class BuildSessionSnapshotTest extends TestCase
     }
 
     #[Test]
+    public function resumable_document_system_failure_recommends_documents_with_zero_ready_pages(): void
+    {
+        $session = $this->makeSession(EstimateGenerationStatus::Failed);
+        $session->forceFill([
+            'resume_status' => EstimateGenerationStatus::ProcessingDocuments,
+            'failure_code' => 'document_processing_system_failed',
+        ]);
+
+        $snapshot = app(BuildSessionSnapshot::class)->handle(
+            session: $session,
+            permissions: ['estimate_generation.generate'],
+            readinessSummary: [
+                'blockers' => [[
+                    'code' => 'document_processing_system_failed',
+                    'message_key' => 'estimate_generation.document_processing_system_failed',
+                    'message' => 'Не удалось обработать документ.',
+                ]],
+                'warnings' => [],
+            ],
+            documentsSummary: [
+                'total' => 22,
+                'ready' => 0,
+                'pending' => 0,
+                'action_required' => 0,
+                'ignored' => 0,
+            ],
+        );
+
+        self::assertSame('documents', $snapshot->recommendedStep);
+        self::assertSame('documents', $snapshot->toArray()['recommended_step']);
+        self::assertFalse($snapshot->canGenerate);
+        self::assertFalse($snapshot->canApply);
+    }
+
+    #[Test]
     public function generating_session_exposes_safe_restart_and_cancel(): void
     {
         $snapshot = app(BuildSessionSnapshot::class)->handle(
@@ -248,6 +283,7 @@ final class BuildSessionSnapshotTest extends TestCase
             'id', 'status', 'processing_stage', 'processing_progress', 'state_version',
             'object_input',
             'available_actions', 'blocking_issues', 'warnings', 'next_action',
+            'recommended_step',
             'readiness_evaluated',
             'documents_summary', 'estimate_summary', 'review_summary',
             'scope_summary',


### PR DESCRIPTION
## Что изменено
- разрешён новый явный retry после terminal system_failure без удаления immutable history
- сохранён exact replay любого ранее использованного idempotency key
- добавлен recommended_step=documents для failed/resume processing_documents
- добавлены PostgreSQL-контракты lineage, concurrency, historical replay и реального session lifecycle

## Причина
После единственной неудачной explicit retry история навсегда запрещала восстановление, хотя текущая системная причина уже могла быть устранена.

## Проверки
- DB-free PHPUnit: 82 теста, 277 assertions
- PostgreSQL explicit retry contract: 4 теста, 79 assertions, 0 skip
- PostgreSQL HTTP contract: 5 тестов, 51 assertion
- php -l и Pint затронутых файлов
- git diff --check и UTF-8
- Larastan запускался, bootstrap остановлен известным storage_configuration_invalid; fake S3 не подставлялся

Production retry документа 168 этим PR не выполняется.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored explicit document retry logic to support recoverable system failures by introducing a terminal retry check.</li>
<li>Updated RetryEstimateGenerationDocument to handle historical retry attempts and track terminal replay status.</li>
<li>Added new helper methods to validate retry lineage based on source version and processing attempt ID.</li>
<li>Updated feature and unit tests to cover the new retry eligibility and workflow logic.</li>
</ul></div>