### PR TITLE
fix[backend]: добавлена безопасная диагностика Vision-сбоев

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/DocumentProcessingOutcomeResolver.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/DocumentProcessingOutcomeResolver.php
@@ -53,7 +53,7 @@ final readonly class DocumentProcessingOutcomeResolver
                 $counts['ready']++;
             } else {
                 $counts['system_failed']++;
-                if (($unit['failure_code'] ?? null) === 'document_systemic_failure') {
+                if (in_array($unit['failure_code'] ?? null, ['breaker_stopped', 'document_systemic_failure'], true)) {
                     $counts['breaker_stopped']++;
                 } else {
                     $counts['terminal_system_failed']++;

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/DocumentSystemFailureDetector.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/DocumentSystemFailureDetector.php
@@ -34,7 +34,7 @@ final readonly class DocumentSystemFailureDetector
                 && (int) $unit->document_id === (int) $document->getKey()
                 && hash_equals((string) $document->source_version, (string) $unit->source_version),
         );
-        if ($units->count() < 3) {
+        if ($units->count() < 2) {
             return false;
         }
 

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/EloquentDocumentProcessingUnitStore.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/EloquentDocumentProcessingUnitStore.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Str;
 
 final readonly class EloquentDocumentProcessingUnitStore implements DocumentProcessingUnitStore
 {
+    private const SYSTEMIC_FAILURE_THRESHOLD = 2;
+
     public function __construct(private Connection $database) {}
 
     public function create(int $organizationId, int $projectId, int $sessionId, int $documentId, DocumentUnitData $unit): DocumentProcessingUnitRecord
@@ -141,7 +143,8 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
                 ->where('session_id', $unit->session_id)
                 ->where('document_id', $unit->document_id)
                 ->where('source_version', $unit->source_version)
-                ->where($this->attemptLineagePredicate($attemptId));
+                ->where($this->attemptLineagePredicate($attemptId))
+                ->where($this->processingRoutePredicate($unit));
             $runningCount = (clone $scopeQuery)
                 ->where('status', DocumentProcessingUnitStatus::Running->value)
                 ->where('lease_expires_at', '>', $now)
@@ -153,15 +156,17 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
                     'unexpected_internal_failure',
                     'document_representation_contract_invalid',
                     'document_representation_source_mismatch',
+                    'vision_provider_request_rejected',
+                    'vision_http_failed',
                 ])
                 ->selectRaw('count(*) as aggregate')
                 ->groupBy('failure_fingerprint')
                 ->orderByDesc('aggregate')
                 ->value('aggregate') ?? 0);
-            if ($systemicFailureCount >= 3) {
+            if ($systemicFailureCount >= self::SYSTEMIC_FAILURE_THRESHOLD) {
                 return new DocumentProcessingUnitClaim($unitId, DocumentProcessingUnitClaimStatus::Exhausted);
             }
-            if ($systemicFailureCount + $runningCount >= 3) {
+            if ($systemicFailureCount + $runningCount >= self::SYSTEMIC_FAILURE_THRESHOLD) {
                 return new DocumentProcessingUnitClaim(
                     $unitId,
                     DocumentProcessingUnitClaimStatus::Busy,
@@ -346,9 +351,11 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
             $attemptId = is_string(((array) $unit->metadata)['processing_attempt_id'] ?? null)
                 ? ((array) $unit->metadata)['processing_attempt_id']
                 : null;
-            if ($updated && $circuitBreaking && $this->systemicFailureCount($claim, $fingerprint, $attemptId) >= 3) {
+            if ($updated && $circuitBreaking
+                && $this->systemicFailureCount($claim, $unit, $fingerprint, $attemptId) >= self::SYSTEMIC_FAILURE_THRESHOLD) {
                 $pendingIds = $this->scopedUnitQuery($claim)
                     ->where($this->attemptLineagePredicate($attemptId))
+                    ->where($this->processingRoutePredicate($unit))
                     ->where('status', DocumentProcessingUnitStatus::Pending->value)
                     ->lockForUpdate()
                     ->pluck('id');
@@ -362,7 +369,7 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
                             'claim_token' => null,
                             'lease_expires_at' => null,
                             'next_dispatch_at' => null,
-                            'failure_code' => 'document_systemic_failure',
+                            'failure_code' => 'breaker_stopped',
                             'failure_fingerprint' => $fingerprint,
                             'metadata' => $this->terminalFailureMetadataExpression(),
                             'failed_at' => $now,
@@ -527,10 +534,15 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
             ->where('source_version', $claim->sourceVersion);
     }
 
-    private function systemicFailureCount(DocumentProcessingUnitClaim $claim, string $fingerprint, ?string $attemptId): int
-    {
+    private function systemicFailureCount(
+        DocumentProcessingUnitClaim $claim,
+        EstimateGenerationProcessingUnit $unit,
+        string $fingerprint,
+        ?string $attemptId,
+    ): int {
         return $this->scopedUnitQuery($claim)
             ->where($this->attemptLineagePredicate($attemptId))
+            ->where($this->processingRoutePredicate($unit))
             ->where('status', DocumentProcessingUnitStatus::Failed->value)
             ->where('failure_fingerprint', $fingerprint)
             ->count();
@@ -546,6 +558,26 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
             }
 
             $query->whereRaw("metadata->>'processing_attempt_id' = ?", [$attemptId]);
+        };
+    }
+
+    private function processingRoutePredicate(EstimateGenerationProcessingUnit $unit): \Closure
+    {
+        $unitType = $unit->unit_type->value;
+        $contentType = is_string(((array) $unit->locator)['content_type'] ?? null)
+            ? ((array) $unit->locator)['content_type']
+            : null;
+
+        return static function (Builder $query) use ($unitType, $contentType): void {
+            $query->where('unit_type', $unitType);
+            if ($unitType === DocumentUnitType::PdfPage->value) {
+                if ($contentType === null) {
+                    $query->whereRaw("locator->>'content_type' IS NULL");
+
+                    return;
+                }
+                $query->whereRaw("locator->>'content_type' = ?", [$contentType]);
+            }
         };
     }
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ExplicitDocumentRetryEligibility.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ExplicitDocumentRetryEligibility.php
@@ -19,10 +19,13 @@ final readonly class ExplicitDocumentRetryEligibility
         'document_representation_contract_invalid',
         'document_representation_measurement_invalid',
         'document_unit_processing_failed',
+        'vision_provider_request_rejected',
+        'vision_http_failed',
     ];
 
     private const BREAKER_FAILURE_CODES = [
         'document_systemic_failure',
+        'breaker_stopped',
     ];
 
     public function __construct(

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/InMemoryDocumentProcessingUnitStore.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/InMemoryDocumentProcessingUnitStore.php
@@ -10,6 +10,17 @@ use Illuminate\Support\Str;
 
 final class InMemoryDocumentProcessingUnitStore implements DocumentProcessingUnitStore
 {
+    private const SYSTEMIC_FAILURE_THRESHOLD = 2;
+
+    private const SYSTEMIC_FAILURE_CODES = [
+        'document_unit_processing_failed',
+        'unexpected_internal_failure',
+        'document_representation_contract_invalid',
+        'document_representation_source_mismatch',
+        'vision_provider_request_rejected',
+        'vision_http_failed',
+    ];
+
     /** @var array<int, DocumentProcessingUnitRecord> */
     private array $records = [];
 
@@ -92,6 +103,18 @@ final class InMemoryDocumentProcessingUnitStore implements DocumentProcessingUni
 
         if ($record->attemptCount >= $maxAttempts || $leaseExpiresAt <= $now) {
             return new DocumentProcessingUnitClaim($unitId, DocumentProcessingUnitClaimStatus::Exhausted);
+        }
+
+        $systemicFailureCount = $this->largestSystemicFailureGroup($record);
+        if ($systemicFailureCount >= self::SYSTEMIC_FAILURE_THRESHOLD) {
+            return new DocumentProcessingUnitClaim($unitId, DocumentProcessingUnitClaimStatus::Exhausted);
+        }
+        if ($systemicFailureCount + $this->runningCount($record, $now) >= self::SYSTEMIC_FAILURE_THRESHOLD) {
+            return new DocumentProcessingUnitClaim(
+                $unitId,
+                DocumentProcessingUnitClaimStatus::Busy,
+                busyUntil: $now->modify('+5 seconds'),
+            );
         }
 
         $record->status = DocumentProcessingUnitStatus::Running;
@@ -180,14 +203,10 @@ final class InMemoryDocumentProcessingUnitStore implements DocumentProcessingUni
             $record->attemptCount = ProcessDocumentUnit::MAX_ATTEMPTS;
         }
 
-        if ($circuitBreaking && $this->matchingTerminalFailures($record, $fingerprint) >= 3) {
+        if ($circuitBreaking && $this->matchingTerminalFailures($record, $fingerprint) >= self::SYSTEMIC_FAILURE_THRESHOLD) {
             $attemptId = $record->metadata['processing_attempt_id'] ?? null;
             foreach ($this->records as $candidate) {
-                if ($candidate->organizationId !== $record->organizationId
-                    || $candidate->projectId !== $record->projectId
-                    || $candidate->sessionId !== $record->sessionId
-                    || $candidate->documentId !== $record->documentId
-                    || $candidate->unit->sourceVersion !== $record->unit->sourceVersion
+                if (! $this->sameScope($candidate, $record)
                     || ($candidate->metadata['processing_attempt_id'] ?? null) !== $attemptId
                     || $candidate->status !== DocumentProcessingUnitStatus::Pending) {
                     continue;
@@ -195,7 +214,7 @@ final class InMemoryDocumentProcessingUnitStore implements DocumentProcessingUni
 
                 $candidate->status = DocumentProcessingUnitStatus::Failed;
                 $candidate->attemptCount = ProcessDocumentUnit::MAX_ATTEMPTS;
-                $candidate->failureCode = 'document_systemic_failure';
+                $candidate->failureCode = 'breaker_stopped';
                 $candidate->failureFingerprint = $fingerprint;
                 $candidate->failureCategory = FailureCategory::Terminal;
                 $candidate->metadata = [
@@ -224,6 +243,46 @@ final class InMemoryDocumentProcessingUnitStore implements DocumentProcessingUni
                 && $candidate->status === DocumentProcessingUnitStatus::Failed
                 && $candidate->failureFingerprint === $fingerprint,
         ));
+    }
+
+    private function largestSystemicFailureGroup(DocumentProcessingUnitRecord $scope): int
+    {
+        $groups = [];
+        foreach ($this->records as $candidate) {
+            if (! $this->sameScope($candidate, $scope)
+                || $candidate->status !== DocumentProcessingUnitStatus::Failed
+                || ! in_array($candidate->failureCode, self::SYSTEMIC_FAILURE_CODES, true)
+                || $candidate->failureFingerprint === null) {
+                continue;
+            }
+
+            $groups[$candidate->failureFingerprint] = ($groups[$candidate->failureFingerprint] ?? 0) + 1;
+        }
+
+        return $groups === [] ? 0 : max($groups);
+    }
+
+    private function runningCount(DocumentProcessingUnitRecord $scope, DateTimeImmutable $now): int
+    {
+        return count(array_filter(
+            $this->records,
+            fn (DocumentProcessingUnitRecord $candidate): bool => $this->sameScope($candidate, $scope)
+                && $candidate->status === DocumentProcessingUnitStatus::Running
+                && $candidate->leaseExpiresAt !== null
+                && $candidate->leaseExpiresAt > $now,
+        ));
+    }
+
+    private function sameScope(DocumentProcessingUnitRecord $candidate, DocumentProcessingUnitRecord $scope): bool
+    {
+        return $candidate->organizationId === $scope->organizationId
+            && $candidate->projectId === $scope->projectId
+            && $candidate->sessionId === $scope->sessionId
+            && $candidate->documentId === $scope->documentId
+            && $candidate->unit->sourceVersion === $scope->unit->sourceVersion
+            && $candidate->unit->type === $scope->unit->type
+            && ($candidate->unit->locator['content_type'] ?? null) === ($scope->unit->locator['content_type'] ?? null)
+            && ($candidate->metadata['processing_attempt_id'] ?? null) === ($scope->metadata['processing_attempt_id'] ?? null);
     }
 
     public function supersedeDocumentSource(int $documentId, string $currentSourceVersion): void

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProcessDocumentUnit.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProcessDocumentUnit.php
@@ -107,6 +107,8 @@ final readonly class ProcessDocumentUnit
                         'unexpected_internal_failure',
                         'document_representation_contract_invalid',
                         'document_representation_source_mismatch',
+                        'vision_provider_request_rejected',
+                        'vision_http_failed',
                     ], true),
                 $this->resourceUsage($error),
             );

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProductionDocumentUnitProcessor.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProductionDocumentUnitProcessor.php
@@ -109,7 +109,10 @@ final readonly class ProductionDocumentUnitProcessor implements DocumentUnitProc
             $exception instanceof VisionProviderException => new TypedFailureException(
                 $exception->retryable ? FailureCategory::Recoverable : FailureCategory::Terminal,
                 $exception->reason,
-                $exception->httpCode === null ? [] : ['http_status' => $exception->httpCode],
+                [
+                    ...$exception->safeContext,
+                    ...($exception->httpCode === null ? [] : ['http_status' => $exception->httpCode]),
+                ],
                 $exception,
                 $resourceUsage,
             ),

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ReconcileEstimateGenerationDocuments.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ReconcileEstimateGenerationDocuments.php
@@ -68,7 +68,10 @@ final class ReconcileEstimateGenerationDocuments implements DocumentMutationSess
     public function reconcile(EstimateGenerationSession $session): EstimateGenerationSession
     {
         $session = $session->fresh(['documents.processingUnits']) ?? $session;
-        if ($session->status !== EstimateGenerationStatus::ProcessingDocuments) {
+        if (! in_array($session->status, [
+            EstimateGenerationStatus::ProcessingDocuments,
+            EstimateGenerationStatus::InputReviewRequired,
+        ], true)) {
             return $session;
         }
 
@@ -86,7 +89,11 @@ final class ReconcileEstimateGenerationDocuments implements DocumentMutationSess
                     )
                         ? 'document_processing_system_failed'
                         : 'document_processing_temporarily_unavailable',
+                    EstimateGenerationStatus::ProcessingDocuments,
                 );
+            }
+            if ($session->status === EstimateGenerationStatus::InputReviewRequired) {
+                return $session;
             }
             if ((int) ($readiness['summary']['pending_count'] ?? 0) === 0
                 && (int) ($readiness['summary']['action_required_count'] ?? 0) > 0) {

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/AdvanceEstimateGeneration.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/AdvanceEstimateGeneration.php
@@ -237,8 +237,11 @@ final class AdvanceEstimateGeneration
             : $this->workflow->transition($session, $event, $attributes);
     }
 
-    public function failed(EstimateGenerationSession $session, string $failureCode): EstimateGenerationSession
-    {
+    public function failed(
+        EstimateGenerationSession $session,
+        string $failureCode,
+        ?EstimateGenerationStatus $resumeStatus = null,
+    ): EstimateGenerationSession {
         if (preg_match('/\A[a-z][a-z0-9_]{0,79}\z/', $failureCode) !== 1) {
             throw new \InvalidArgumentException('Invalid estimate generation failure code.');
         }
@@ -248,10 +251,10 @@ final class AdvanceEstimateGeneration
 
         return $this->workflow->transition($session, EstimateGenerationEvent::Failed, [
             'processing_stage' => 'failed',
-            'processing_progress' => 0,
+            'processing_progress' => $resumeStatus === EstimateGenerationStatus::ProcessingDocuments ? 100 : 0,
             'last_error' => null,
             'failure_code' => $failureCode,
-        ]);
+        ], $resumeStatus);
     }
 
     /** @param array<string, mixed> $attributes */

--- a/app/BusinessModules/Addons/EstimateGeneration/Domain/Workflow/EstimateGenerationTransitionMap.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Domain/Workflow/EstimateGenerationTransitionMap.php
@@ -22,6 +22,7 @@ final class EstimateGenerationTransitionMap
             'input_confirmed' => 'ready_to_generate',
             'retried' => 'processing_documents',
             'documents_changed' => 'processing_documents',
+            'failed' => 'failed',
             'cancelled' => 'cancelled',
         ],
         'ready_to_generate' => [

--- a/app/BusinessModules/Addons/EstimateGeneration/Domain/Workflow/EstimateGenerationWorkflow.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Domain/Workflow/EstimateGenerationWorkflow.php
@@ -20,6 +20,7 @@ final class EstimateGenerationWorkflow
         EstimateGenerationSession $session,
         EstimateGenerationEvent $event,
         array $attributes = [],
+        ?EstimateGenerationStatus $failureResumeStatus = null,
     ): EstimateGenerationSession {
         $currentStatus = $session->status;
         $targetStatus = $this->transitionMap->resolve($currentStatus, $event, $session->resume_status);
@@ -28,7 +29,7 @@ final class EstimateGenerationWorkflow
         $attributes['resume_status'] = null;
 
         if ($event === EstimateGenerationEvent::Failed) {
-            $attributes['resume_status'] = $currentStatus->value;
+            $attributes['resume_status'] = ($failureResumeStatus ?? $currentStatus)->value;
         }
 
         $expectedVersion = $session->state_version;

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureNormalizer.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureNormalizer.php
@@ -42,8 +42,8 @@ final readonly class FailureNormalizer
         };
 
         $diagnostics = [
-            ...$diagnostics,
             ...$this->diagnostics->forThrowable($error, $this->executionBoundary($context)),
+            ...$diagnostics,
         ];
 
         return new FailureData($context, $category, $code, $this->sanitizer->sanitize($diagnostics));

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/SensitiveDiagnosticSanitizer.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/SensitiveDiagnosticSanitizer.php
@@ -11,6 +11,14 @@ final readonly class SensitiveDiagnosticSanitizer
     /** @var array<string, array{string, int}> */
     private const STRING_DOMAINS = [
         'provider_code' => ['/\A[a-z][a-z0-9._-]*\z/', 80],
+        'provider_error_type' => ['/\A[a-zA-Z][a-zA-Z0-9._-]*\z/', 80],
+        'provider_error_code' => ['/\A[a-zA-Z][a-zA-Z0-9._-]*\z/', 80],
+        'provider_error_param' => ['/\A[a-zA-Z][a-zA-Z0-9_.\[\]-]*\z/', 80],
+        'endpoint_kind' => ['/\A[a-z][a-z0-9_]*\z/', 40],
+        'body_fingerprint' => ['/\Asha256:[0-9a-f]{64}\z/', 71],
+        'body_shape_fingerprint' => ['/\Asha256:[0-9a-f]{64}\z/', 71],
+        'prompt_contract_fingerprint' => ['/\Asha256:[0-9a-f]{64}\z/', 71],
+        'payload_shape_fingerprint' => ['/\Asha256:[0-9a-f]{64}\z/', 71],
         'http_class' => ['/\A[1-5]xx\z/', 3],
         'status' => ['/\A[a-z][a-z0-9_]*\z/', 40],
         'safe_code' => ['/\A[a-z][a-z0-9_]*\z/', 80],
@@ -29,6 +37,7 @@ final readonly class SensitiveDiagnosticSanitizer
     /** @var array<string, array{int, int}> */
     private const INTEGER_DOMAINS = [
         'http_code' => [100, 599],
+        'provider_http_status' => [100, 599],
         'retry_after_seconds' => [0, 86400],
         'attempt' => [1, 1000],
     ];

--- a/app/BusinessModules/Addons/EstimateGeneration/Services/Quality/DocumentReadinessClassifier.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Services/Quality/DocumentReadinessClassifier.php
@@ -46,7 +46,7 @@ EXISTS (
       AND systemic_units.document_id = estimate_generation_documents.id
       AND systemic_units.source_version = estimate_generation_documents.source_version
     GROUP BY systemic_units.failure_fingerprint
-    HAVING COUNT(*) >= 3
+    HAVING COUNT(*) >= 2
        AND COUNT(*) = (
            SELECT COUNT(*)
            FROM estimate_generation_processing_units AS current_units

--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/Exceptions/VisionProviderException.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/Exceptions/VisionProviderException.php
@@ -14,6 +14,8 @@ final class VisionProviderException extends RuntimeException
         public readonly ?int $httpCode = null,
         public readonly bool $retryable = false,
         ?Throwable $previous = null,
+        /** @var array<string, int|string> */
+        public readonly array $safeContext = [],
     ) {
         parent::__construct($reason, 0, $previous);
     }

--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/ProviderErrorDiagnostics.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/ProviderErrorDiagnostics.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Vision\Providers;
+
+final readonly class ProviderErrorDiagnostics
+{
+    /**
+     * @param  array<string, bool|int|string>  $payload
+     * @param  array<string, int|string>  $failureContext
+     */
+    public function __construct(
+        public array $payload,
+        public array $failureContext,
+    ) {}
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebProviderErrorInspector.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebProviderErrorInspector.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Vision\Providers;
+
+use Illuminate\Http\Client\Response;
+use JsonException;
+
+final readonly class TimewebProviderErrorInspector
+{
+    private const SENSITIVE_BODY_KEYS = [
+        'request_dump', 'request', 'messages', 'prompt', 'input', 'user_text', 'image_url',
+        'authorization', 'api_key',
+    ];
+
+    private const MAX_TYPED_VALUE_BYTES = 120;
+
+    private const MAX_MESSAGE_BYTES = 320;
+
+    public function inspect(
+        Response $response,
+        int $httpStatus,
+        string $model,
+        string $endpointKind,
+        string $promptContractFingerprint,
+        string $payloadShapeFingerprint,
+        int $maxBytes,
+    ): ProviderErrorDiagnostics {
+        $limit = max(256, min(65_536, $maxBytes));
+        [$body, $truncated] = $this->readBounded($response, $limit);
+        $bodyFingerprint = 'sha256:'.hash('sha256', $body."\0".($truncated ? 'truncated' : 'complete'));
+        $contentType = $this->contentType($response);
+        $error = $truncated ? null : $this->openAiError($body);
+        $type = $this->typedValue($error['type'] ?? null);
+        $code = $this->typedValue($error['code'] ?? null);
+        $param = $this->parameter($error['param'] ?? null);
+        $envelopeKind = $error === null ? 'unknown' : 'openai_error';
+        $bodyShapeFingerprint = $this->bodyShapeFingerprint($body, $truncated, $contentType);
+        $diagnosticFingerprint = 'sha256:'.hash('sha256', json_encode([
+            'provider' => TimewebVisionProvider::PROVIDER,
+            'http_status' => $httpStatus,
+            'error_type' => $type,
+            'error_code' => $code,
+            'error_param' => $param,
+            'error_identity' => $error === null
+                ? $bodyShapeFingerprint
+                : ['type' => $type, 'code' => $code, 'param' => $param],
+            'model' => $model,
+            'endpoint_kind' => $endpointKind,
+            'prompt_contract_fingerprint' => $promptContractFingerprint,
+            'payload_shape_fingerprint' => $payloadShapeFingerprint,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        $payload = [
+            'provider_http_status' => $httpStatus,
+            'envelope_kind' => $envelopeKind,
+            'response_content_type' => $contentType,
+            'body_fingerprint' => $bodyFingerprint,
+            'body_shape_fingerprint' => $bodyShapeFingerprint,
+            'body_truncated' => $truncated,
+            'model' => $model,
+            'endpoint_kind' => $endpointKind,
+            'prompt_contract_fingerprint' => $promptContractFingerprint,
+            'payload_shape_fingerprint' => $payloadShapeFingerprint,
+            'diagnostic_fingerprint' => $diagnosticFingerprint,
+        ];
+        if ($type !== null) {
+            $payload['error_type'] = $type;
+        }
+        if ($code !== null) {
+            $payload['error_code'] = $code;
+        }
+        if ($param !== null) {
+            $payload['error_param'] = $param;
+        }
+        $payload['diagnostic_summary'] = $this->diagnosticSummary($httpStatus, $envelopeKind, $type, $code, $param);
+        if ($error === null) {
+            $payload['redacted_preview'] = $this->safeText($body, $limit);
+        }
+
+        return new ProviderErrorDiagnostics($payload, array_filter([
+            'provider_http_status' => $httpStatus,
+            'provider_error_type' => $type,
+            'provider_error_code' => $code,
+            'provider_error_param' => $param,
+            'body_fingerprint' => $bodyFingerprint,
+            'body_shape_fingerprint' => $bodyShapeFingerprint,
+            'endpoint_kind' => $endpointKind,
+            'prompt_contract_fingerprint' => $promptContractFingerprint,
+            'payload_shape_fingerprint' => $payloadShapeFingerprint,
+            'diagnostic_fingerprint' => $diagnosticFingerprint,
+        ], static fn (mixed $value): bool => $value !== null));
+    }
+
+    /** @return array{string, bool} */
+    private function readBounded(Response $response, int $maxBytes): array
+    {
+        $resource = $response->resource();
+        $body = '';
+        try {
+            while (! feof($resource) && strlen($body) <= $maxBytes) {
+                $remaining = $maxBytes + 1 - strlen($body);
+                $chunk = fread($resource, min(16_384, $remaining));
+                if ($chunk === false || ($chunk === '' && ! feof($resource))) {
+                    break;
+                }
+                $body .= $chunk;
+            }
+        } finally {
+            fclose($resource);
+        }
+
+        $truncated = strlen($body) > $maxBytes;
+
+        return [substr($body, 0, $maxBytes), $truncated];
+    }
+
+    /** @return array<string, mixed>|null */
+    private function openAiError(string $body): ?array
+    {
+        try {
+            $decoded = json_decode($body, true, 16, JSON_THROW_ON_ERROR | JSON_BIGINT_AS_STRING);
+        } catch (JsonException) {
+            return null;
+        }
+        $error = is_array($decoded) ? ($decoded['error'] ?? null) : null;
+
+        return is_array($error) ? $error : null;
+    }
+
+    private function typedValue(mixed $value): ?string
+    {
+        if (! is_string($value) || strlen($value) > self::MAX_TYPED_VALUE_BYTES
+            || preg_match('/\A[a-zA-Z][a-zA-Z0-9._-]*\z/', $value) !== 1) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function parameter(mixed $value): ?string
+    {
+        if (! is_string($value) || strlen($value) > self::MAX_TYPED_VALUE_BYTES
+            || preg_match('/\A[a-zA-Z][a-zA-Z0-9_.\[\]-]*\z/', $value) !== 1) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function contentType(Response $response): string
+    {
+        $value = strtolower(trim(explode(';', $response->header('Content-Type'), 2)[0]));
+
+        return preg_match('/\A[a-z0-9.+-]+\/[a-z0-9.+-]+\z/', $value) === 1 ? $value : 'unknown';
+    }
+
+    private function diagnosticSummary(
+        int $httpStatus,
+        string $envelopeKind,
+        ?string $type,
+        ?string $code,
+        ?string $param,
+    ): string {
+        return implode('; ', array_filter([
+            'provider_http_status='.$httpStatus,
+            'envelope='.$envelopeKind,
+            $type === null ? null : 'type='.$type,
+            $code === null ? null : 'code='.$code,
+            $param === null ? null : 'param='.$param,
+        ], static fn (?string $value): bool => $value !== null));
+    }
+
+    private function bodyShapeFingerprint(string $body, bool $truncated, string $contentType): string
+    {
+        $shape = null;
+        if (! $truncated) {
+            try {
+                $shape = $this->valueShape(json_decode($body, true, 16, JSON_THROW_ON_ERROR | JSON_BIGINT_AS_STRING));
+            } catch (JsonException) {
+            }
+        }
+
+        return 'sha256:'.hash('sha256', json_encode([
+            'content_type' => $contentType,
+            'body_shape' => $shape ?? ($truncated ? 'truncated' : 'malformed'),
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+    }
+
+    private function valueShape(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return get_debug_type($value);
+        }
+        if (array_is_list($value)) {
+            return ['list' => $value === [] ? 'empty' : $this->valueShape($value[0])];
+        }
+
+        $shape = [];
+        $keys = array_keys($value);
+        sort($keys, SORT_STRING);
+        foreach ($keys as $key) {
+            $shape[(string) $key] = $this->valueShape($value[$key]);
+        }
+
+        return $shape;
+    }
+
+    private function safeText(string $value, int $maxBytes = self::MAX_MESSAGE_BYTES): string
+    {
+        $value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+        try {
+            $decoded = json_decode($value, true, 16, JSON_THROW_ON_ERROR | JSON_BIGINT_AS_STRING);
+            if (is_array($decoded)) {
+                $value = json_encode($this->redactStructuredValue($decoded), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+            }
+        } catch (JsonException) {
+            if (preg_match('/"(?:'.implode('|', self::SENSITIVE_BODY_KEYS).')"\s*:\s*[\[{]/i', $value) === 1) {
+                return '[redacted-structured-content]';
+            }
+        }
+        $patterns = [
+            '~("(?:'.implode('|', self::SENSITIVE_BODY_KEYS).')"\s*:\s*)"(?:\\\\.|[^"])*(?:"|$)~is' => '$1"[redacted]"',
+            '~data:[^,\s]+,[A-Za-z0-9+/=_-]+~i' => '[redacted-data]',
+            '~https?://[^\s"\'<>]+~i' => '[redacted-url]',
+            '~(?:authorization\s*[:=]\s*)?bearer\s+[A-Za-z0-9._+/=-]+~i' => 'Authorization: [redacted]',
+            '~\b(?:sk|gh[pousr]|akia)[-_][A-Za-z0-9_-]{8,}\b~i' => '[redacted-secret]',
+            '~[?&](?:x-amz-[a-z-]+|signature|token|key|secret)=[^&\s"\']+~i' => '[redacted-query]',
+            '~\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b~i' => '[redacted-email]',
+            '~(?<!\d)(?:\+?\d[\s().-]*){10,15}(?!\d)~' => '[redacted-phone]',
+            '~[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]+~u' => ' ',
+        ];
+        $redacted = preg_replace(array_keys($patterns), array_values($patterns), $value) ?? '';
+        $redacted = preg_replace('/\s+/u', ' ', $redacted) ?? '';
+
+        return trim(mb_strcut($redacted, 0, max(1, $maxBytes), 'UTF-8'));
+    }
+
+    private function redactStructuredValue(mixed $value, ?string $key = null): mixed
+    {
+        if ($key !== null && in_array(strtolower($key), self::SENSITIVE_BODY_KEYS, true)) {
+            return '[redacted]';
+        }
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $redacted = [];
+        foreach ($value as $childKey => $childValue) {
+            $redacted[$childKey] = $this->redactStructuredValue(
+                $childValue,
+                is_string($childKey) ? $childKey : null,
+            );
+        }
+
+        return $redacted;
+    }
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebVisionProvider.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebVisionProvider.php
@@ -52,6 +52,7 @@ final readonly class TimewebVisionProvider implements VisionProvider
         private ?EffectiveSettingsResolver $settingsResolver = null,
         private ?AiPriceSnapshotResolver $priceResolver = null,
         private ?DocumentRuntimeLimits $documentLimits = null,
+        private TimewebProviderErrorInspector $errorInspector = new TimewebProviderErrorInspector,
     ) {}
 
     public function analyze(VisionDocumentInput $input): VisionAnalysisData
@@ -105,6 +106,8 @@ final readonly class TimewebVisionProvider implements VisionProvider
             ]);
         }
         $payload = $this->requestPayload($input, $model, $maxElements, $maxFacts, $contractHash);
+        $endpointKind = 'chat_completions';
+        $payloadShapeFingerprint = $this->payloadShapeFingerprint($payload, $contractHash, $endpointKind);
         $attempts = $effective !== null
             ? max(1, $effective->retryAttempts('vision') + 1)
             : max(1, min(5, (int) config('estimate-generation.vision.retry_attempts', 3)));
@@ -199,17 +202,36 @@ final readonly class TimewebVisionProvider implements VisionProvider
                         ->post($baseUri.'/chat/completions', $payload);
                     $httpCode = $response->status();
                     if (! $response->successful()) {
-                        $response->toPsrResponse()->getBody()->close();
+                        $diagnostics = $this->errorInspector->inspect(
+                            $response,
+                            $httpCode,
+                            $model,
+                            $endpointKind,
+                            $contractHash,
+                            $payloadShapeFingerprint,
+                            (int) config('estimate-generation.vision.max_error_response_bytes', 16_384),
+                        );
+                        $responsePayload = ['provider_error' => $diagnostics->payload];
                         $status = 'http_failed';
                         $this->physicalAttempts->storeResponse(
-                            $physicalContext->attemptId, $requestFingerprint, $ownerToken, [], $status, $httpCode,
+                            $physicalContext->attemptId, $requestFingerprint, $ownerToken, $responsePayload, $status, $httpCode,
                             (int) max(0, round((hrtime(true) - $startedAt) / 1_000_000)), null, $priceSnapshot->toArray(),
                         );
                         $wireStarted = false;
                         $hasPersistedResponse = true;
-                        $lastException = new VisionProviderException(
-                            'vision_http_failed', $httpCode, $this->retryableStatus($httpCode),
-                        );
+                        Log::warning('[EstimateGeneration Vision] provider HTTP failure', [
+                            ...array_diff_key($diagnostics->payload, [
+                                'redacted_preview' => true,
+                            ]),
+                            'organization_id' => $input->organizationId,
+                            'project_id' => $input->projectId,
+                            'session_id' => $input->sessionId,
+                            'document_id' => $input->documentId,
+                            'page_id' => $input->pageId,
+                            'unit_id' => $input->processingUnitId,
+                            'attempt_id' => $physicalContext->attemptId,
+                        ]);
+                        $lastException = $this->httpFailureException($httpCode, $responsePayload);
                     } else {
                         $body = $this->bodyReader->read($response, max(1_024, (int) config('estimate-generation.vision.max_response_bytes', 1_000_000)));
                         $this->physicalAttempts->storeResponse(
@@ -222,9 +244,7 @@ final readonly class TimewebVisionProvider implements VisionProvider
                     }
                 }
                 if (($replayed && $status === 'http_failed') || (! $replayed && $status === 'http_failed')) {
-                    $lastException = new VisionProviderException(
-                        'vision_http_failed', $httpCode, $httpCode !== null && $this->retryableStatus($httpCode),
-                    );
+                    $lastException = $this->httpFailureException($httpCode, $responsePayload);
                 } else {
                     if ($replayed) {
                         $encodedBody = $responsePayload['raw_body_base64'] ?? null;
@@ -375,7 +395,87 @@ final readonly class TimewebVisionProvider implements VisionProvider
 
     private function retryableStatus(int $status): bool
     {
-        return in_array($status, [408, 429], true) || $status >= 500;
+        return in_array($status, [408, 409, 429], true) || $status >= 500;
+    }
+
+    /** @param array<string, mixed> $responsePayload */
+    private function httpFailureException(?int $httpCode, array $responsePayload): VisionProviderException
+    {
+        $retryable = $httpCode !== null && $this->retryableStatus($httpCode);
+        $reason = match (true) {
+            $retryable => 'vision_provider_unavailable',
+            $httpCode !== null && $httpCode >= 400 && $httpCode < 500 => 'vision_provider_request_rejected',
+            default => 'vision_provider_http_failed',
+        };
+        $diagnostic = is_array($responsePayload['provider_error'] ?? null)
+            ? $responsePayload['provider_error']
+            : [];
+        $context = [];
+        foreach ([
+            'provider_http_status', 'provider_error_type', 'provider_error_code', 'provider_error_param',
+            'body_fingerprint', 'body_shape_fingerprint', 'endpoint_kind', 'prompt_contract_fingerprint',
+            'payload_shape_fingerprint', 'diagnostic_fingerprint',
+        ] as $key) {
+            $sourceKey = match ($key) {
+                'provider_error_type' => 'error_type',
+                'provider_error_code' => 'error_code',
+                'provider_error_param' => 'error_param',
+                default => $key,
+            };
+            $value = $diagnostic[$sourceKey] ?? null;
+            if (is_int($value) || is_string($value)) {
+                $context[$key] = $value;
+            }
+        }
+
+        return new VisionProviderException($reason, $httpCode, $retryable, safeContext: $context);
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function payloadShapeFingerprint(array $payload, string $contractHash, string $endpointKind): string
+    {
+        $topLevelKeys = array_keys($payload);
+        sort($topLevelKeys, SORT_STRING);
+        $messages = is_array($payload['messages'] ?? null) ? $payload['messages'] : [];
+        $messageShape = [];
+        foreach ($messages as $message) {
+            if (! is_array($message)) {
+                continue;
+            }
+            $content = $message['content'] ?? null;
+            $contentTypes = [];
+            if (is_array($content)) {
+                foreach ($content as $part) {
+                    if (is_array($part) && is_string($part['type'] ?? null)) {
+                        $contentTypes[] = $part['type'];
+                    }
+                }
+            } elseif (is_string($content)) {
+                $contentTypes[] = 'text';
+            }
+            $messageShape[] = [
+                'role' => is_string($message['role'] ?? null) ? $message['role'] : 'unknown',
+                'content_types' => $contentTypes,
+            ];
+        }
+        $schema = Arr::get($payload, 'response_format.json_schema.schema');
+
+        return 'sha256:'.hash('sha256', json_encode([
+            'endpoint_kind' => $endpointKind,
+            'model' => $payload['model'] ?? null,
+            'top_level_keys' => $topLevelKeys,
+            'messages' => $messageShape,
+            'token_budget_key' => array_key_exists('max_completion_tokens', $payload)
+                ? 'max_completion_tokens'
+                : (array_key_exists('max_tokens', $payload) ? 'max_tokens' : null),
+            'reasoning_effort' => array_key_exists('reasoning_effort', $payload),
+            'response_format' => Arr::get($payload, 'response_format.type'),
+            'strict_schema' => Arr::get($payload, 'response_format.json_schema.strict') === true,
+            'schema_fingerprint' => is_array($schema)
+                ? 'sha256:'.hash('sha256', json_encode($schema, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES))
+                : null,
+            'prompt_contract_fingerprint' => $contractHash,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
     }
 
     private function boundedDocumentAttemptTimeout(VisionDocumentInput $input, int $attempts, int $configuredTimeout): int

--- a/config/estimate-generation.php
+++ b/config/estimate-generation.php
@@ -27,6 +27,7 @@ return [
         'targeted_max_output_tokens' => (int) env('ESTIMATE_GENERATION_VISION_TARGETED_MAX_OUTPUT_TOKENS', 6144),
         'max_input_tokens' => (int) env('ESTIMATE_GENERATION_VISION_MAX_INPUT_TOKENS', 32_768),
         'max_response_bytes' => (int) env('ESTIMATE_GENERATION_VISION_MAX_RESPONSE_BYTES', 1_000_000),
+        'max_error_response_bytes' => (int) env('ESTIMATE_GENERATION_VISION_MAX_ERROR_RESPONSE_BYTES', 16_384),
         'max_elements' => (int) env('ESTIMATE_GENERATION_VISION_MAX_ELEMENTS', 500),
         'max_depth' => (int) env('ESTIMATE_GENERATION_VISION_MAX_DEPTH', 16),
         'image_detail' => env('ESTIMATE_GENERATION_VISION_IMAGE_DETAIL', 'high'),

--- a/docs/specs/2026-08-13-vision-luna-diagnostic-hotfix.md
+++ b/docs/specs/2026-08-13-vision-luna-diagnostic-hotfix.md
@@ -1,0 +1,42 @@
+# Диагностический hotfix Vision GPT-5.6 Luna
+
+## Цель выпуска
+
+Первый выпуск не меняет запрос GPT-5.6 Luna и не заявляет исправление причины HTTP 400. Он сохраняет безопасную диагностическую причину следующего отказа, предотвращает каскад одинаковых terminal 4xx и честно показывает системное завершение обработки без пригодных страниц.
+
+## Контракт provider error
+
+- Неуспешный HTTP body читается до закрытия stream с жёстким пределом; превышение фиксируется без сохранения остатка.
+- Поддерживается OpenAI-compatible envelope `error.message`, `error.type`, `error.code`, `error.param`.
+- Durable observability содержит только HTTP status, нормализованный content type, allowlisted typed fields, bounded redacted summary/preview, hash прочитанного body, модель, endpoint kind, prompt contract и payload-shape fingerprints.
+- Заголовки, ключи, request body, prompt, пользовательский текст, image data/signed URL и произвольный raw response не сохраняются.
+- Неизвестный или malformed envelope получает bounded redacted preview только во внутренней observability; API и UI получают общий человекочитаемый системный статус.
+
+## Классификация и повторы
+
+- `408`, `409`, `429` и `5xx` — transient provider failures и могут повторяться в пределах настроенного лимита.
+- Остальные `4xx` — deterministic request rejection и не повторяются по сети внутри unit.
+- Transport outcome после начала wire остаётся отдельным ambiguous/idempotency состоянием.
+- Rejected request записывает unavailable usage с нулевыми tokens/cost.
+
+## Document breaker
+
+- Breaker fingerprint включает стабильный provider error identity, модель, endpoint kind, prompt contract и payload shape; изменчивые message, request ID, body hash, image/prompt contents в него не входят. Отдельный body hash остаётся только observability-сигналом.
+- Два одинаковых terminal rejection для текущих document/source/attempt lineage являются минимальным доказательным порогом.
+- Транзакционная блокировка документа сериализует два worker; оставшиеся pending units становятся `breaker_stopped` без выполнения HTTP.
+- Другой document, source version, attempt lineage или processing route не наследует breaker; model/prompt contract immutable внутри attempt lineage.
+- Уже completed units и их страницы не изменяются.
+
+## Session и UX
+
+- Ноль ready pages при provider/system failure — `failed`/`document_processing_system_failed`, не пользовательская проверка.
+- `progress_percent = 100` означает только завершённое выполнение; readiness остаётся `blocked`.
+- После выпуска явный `retry_document` доступен для исправленного системного результата; автоматический retry не запускается.
+
+## Release gate
+
+- RED→GREEN unit tests provider diagnostics/classification/replay/usage.
+- PostgreSQL contracts breaker concurrency/scope/idempotency и session reconciliation без skip.
+- PHP lint, Pint, targeted Larastan; frontend checks только если изменится admin.
+- Одно независимое correctness/security/architecture review.
+- Стандартные PR/merge/deploy и read-only canary (`/ready`, `release.json`, защищённый endpoint `401`, логи/GlitchTip) без Vision AI-вызова.

--- a/docs/superpowers/plans/2026-08-13-vision-luna-diagnostic-hotfix.md
+++ b/docs/superpowers/plans/2026-08-13-vision-luna-diagnostic-hotfix.md
@@ -1,0 +1,9 @@
+# Vision Luna Diagnostic Hotfix Implementation Plan
+
+1. Add failing provider tests for OpenAI and unknown error envelopes, malformed/oversized bodies, redaction, replay, HTTP classification and zero usage.
+2. Add failing PostgreSQL contracts for a two-worker document breaker, attempt/source/fingerprint isolation and `breaker_stopped` persistence.
+3. Add failing workflow tests for a zero-ready system failure while a session is in document review.
+4. Implement bounded error inspection and safe typed diagnostics without changing the Luna request payload.
+5. Propagate the stable diagnostic fingerprint through failure normalization and enable the Vision terminal breaker.
+6. Make document reconciliation transition system failures to a resumable failed session and preserve honest progress/readiness.
+7. Run focused verification, independent review, then the standard release and read-only canary.

--- a/tests/Feature/EstimateGeneration/Pipeline/DocumentRepresentationJsonbRoundTripPostgresTest.php
+++ b/tests/Feature/EstimateGeneration/Pipeline/DocumentRepresentationJsonbRoundTripPostgresTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Feature\EstimateGeneration\Pipeline;
 
-use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentProcessingUnitClaimStatus;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentRepresentation;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\EloquentDocumentProcessingUnitStore;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\EloquentDocumentUnitAggregateReconciler;
@@ -22,6 +21,7 @@ use DateTimeImmutable;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Process\Process;
@@ -227,14 +227,38 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
             'locator' => $this->locator($organization->id, $sourceVersion, 99),
             'metadata' => (object) [],
         ]);
+        $differentLineage = EstimateGenerationProcessingUnit::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'session_id' => $session->id,
+            'document_id' => $document->id,
+            'unit_type' => 'pdf_page',
+            'unit_index' => 6,
+            'source_version' => $sourceVersion,
+            'status' => 'pending',
+            'locator' => $this->locator($organization->id, $sourceVersion, 100),
+            'metadata' => ['processing_attempt_id' => '51462476-b870-44eb-b31d-1b5d74d511e9'],
+        ]);
+        $differentContractLocator = $this->locator($organization->id, $sourceVersion, 101);
+        $differentContractLocator['content_type'] = 'application/pdf';
+        $differentContract = EstimateGenerationProcessingUnit::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'session_id' => $session->id,
+            'document_id' => $document->id,
+            'unit_type' => 'pdf_page',
+            'unit_index' => 7,
+            'source_version' => $sourceVersion,
+            'status' => 'pending',
+            'locator' => $differentContractLocator,
+            'metadata' => ['processing_attempt_id' => $attemptId],
+        ]);
         $store = new EloquentDocumentProcessingUnitStore(DB::connection());
         $now = new DateTimeImmutable('2026-08-13T00:00:00+00:00');
         $claims = [];
-        foreach (array_slice($units, 0, 3) as $unit) {
+        foreach (array_slice($units, 0, 2) as $unit) {
             $claims[] = $store->claim($unit->id, $sourceVersion, $now, $now->modify('+60 seconds'), ProcessDocumentUnit::MAX_ATTEMPTS);
         }
-        $fourthClaim = $store->claim($units[3]->id, $sourceVersion, $now, $now->modify('+60 seconds'), ProcessDocumentUnit::MAX_ATTEMPTS);
-        self::assertSame(DocumentProcessingUnitClaimStatus::Busy, $fourthClaim->status);
         $fingerprint = hash('sha256', 'shared-systemic-root');
 
         $processes = [];
@@ -265,15 +289,17 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
 
         $persisted = EstimateGenerationProcessingUnit::query()
             ->where('document_id', $document->id)
+            ->where('metadata->processing_attempt_id', $attemptId)
+            ->where('locator->content_type', 'image/png')
             ->orderBy('unit_index')
             ->get();
         self::assertSame([3, 3, 3, 3, 3], $persisted->pluck('attempt_count')->all());
         self::assertSame(
-            ['document_representation_contract_invalid', 'document_representation_contract_invalid', 'document_representation_contract_invalid', 'document_systemic_failure', 'document_systemic_failure'],
+            ['document_representation_contract_invalid', 'document_representation_contract_invalid', 'breaker_stopped', 'breaker_stopped', 'breaker_stopped'],
             $persisted->pluck('failure_code')->all(),
         );
         self::assertSame(['failed', 'failed', 'failed', 'failed', 'failed'], $persisted->pluck('status')->map->value->all());
-        self::assertSame([1, 1, 1, 0, 0], $persisted->map(
+        self::assertSame([1, 1, 0, 0, 0], $persisted->map(
             static fn ($unit): int => (int) ($unit->metadata['actual_execution_count'] ?? -1),
         )->all());
         self::assertSame(['failed', 'failed', 'failed', 'failed', 'failed'], EstimateGenerationDocumentPage::query()
@@ -282,6 +308,8 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
             ->pluck('status')
             ->all());
         self::assertSame('pending', EstimateGenerationProcessingUnit::query()->findOrFail($unrelated->id)->status->value);
+        self::assertSame('pending', EstimateGenerationProcessingUnit::query()->findOrFail($differentLineage->id)->status->value);
+        self::assertSame('pending', EstimateGenerationProcessingUnit::query()->findOrFail($differentContract->id)->status->value);
     }
 
     #[Test]
@@ -465,7 +493,8 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
     }
 
     #[Test]
-    public function legacy_systemic_units_transition_processing_session_to_resumable_system_failure(): void
+    #[DataProvider('documentProcessingSessionStatuses')]
+    public function legacy_systemic_units_transition_session_to_resumable_system_failure(string $initialStatus): void
     {
         $this->requireEnvironment();
         DB::beginTransaction();
@@ -478,9 +507,9 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
                 'organization_id' => $organization->id,
                 'project_id' => $project->id,
                 'user_id' => $user->id,
-                'status' => 'processing_documents',
-                'processing_stage' => 'processing_documents',
-                'processing_progress' => 30,
+                'status' => $initialStatus,
+                'processing_stage' => $initialStatus === 'input_review_required' ? 'input_review_required' : 'processing_documents',
+                'processing_progress' => 100,
                 'input_payload' => [],
                 'state_version' => 0,
             ]);
@@ -527,6 +556,13 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
         } finally {
             DB::rollBack();
         }
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function documentProcessingSessionStatuses(): iterable
+    {
+        yield 'processing documents' => ['processing_documents'];
+        yield 'premature input review' => ['input_review_required'];
     }
 
     private function requireEnvironment(): void

--- a/tests/Unit/EstimateGeneration/DocumentProcessingUnitContractTest.php
+++ b/tests/Unit/EstimateGeneration/DocumentProcessingUnitContractTest.php
@@ -400,7 +400,7 @@ final class DocumentProcessingUnitContractTest extends TestCase
     }
 
     #[Test]
-    public function third_identical_systemic_terminal_failure_stops_remaining_document_units(): void
+    public function second_identical_systemic_terminal_failure_stops_remaining_document_units(): void
     {
         $store = new InMemoryDocumentProcessingUnitStore;
         $units = [];
@@ -427,21 +427,21 @@ final class DocumentProcessingUnitContractTest extends TestCase
         };
         $usecase = $this->processUnit($store, $processor, $reconciler);
 
-        foreach (array_slice($units, 0, 3) as $unit) {
+        foreach (array_slice($units, 0, 2) as $unit) {
             self::assertSame(DocumentProcessingUnitClaimStatus::Terminal, $usecase->handle($unit->id, 'source')->status);
         }
 
-        self::assertSame(3, $processor->calls);
-        foreach (array_slice($units, 3) as $unit) {
+        self::assertSame(2, $processor->calls);
+        foreach (array_slice($units, 2) as $unit) {
             $record = $store->find($unit->id);
             self::assertSame(DocumentProcessingUnitStatus::Failed, $record?->status);
             self::assertSame(ProcessDocumentUnit::MAX_ATTEMPTS, $record?->attemptCount);
-            self::assertSame('document_systemic_failure', $record?->failureCode);
+            self::assertSame('breaker_stopped', $record?->failureCode);
         }
     }
 
     #[Test]
-    public function third_identical_unexpected_terminal_failure_stops_remaining_document_units(): void
+    public function second_identical_unexpected_terminal_failure_stops_remaining_document_units(): void
     {
         $store = new InMemoryDocumentProcessingUnitStore;
         $units = [];
@@ -468,10 +468,73 @@ final class DocumentProcessingUnitContractTest extends TestCase
             $usecase->handle($unit->id, 'source');
         }
 
-        self::assertSame(3, $processor->calls);
-        foreach (array_slice($units, 3) as $unit) {
-            self::assertSame('document_systemic_failure', $store->find($unit->id)?->failureCode);
+        self::assertSame(2, $processor->calls);
+        foreach (array_slice($units, 2) as $unit) {
+            self::assertSame('breaker_stopped', $store->find($unit->id)?->failureCode);
         }
+    }
+
+    #[Test]
+    public function repeated_terminal_vision_rejection_never_executes_all_twenty_two_units(): void
+    {
+        $store = new InMemoryDocumentProcessingUnitStore;
+        $units = [];
+        foreach (range(1, 22) as $index) {
+            $units[] = $store->create(1, 2, 3, 4, $this->unit(DocumentUnitType::PdfPage, $index, 'source'));
+        }
+        $differentContract = $store->create(1, 2, 3, 4, $this->unit(DocumentUnitType::CadDrawing, 1, 'source'));
+        $processor = new class implements DocumentUnitProcessor
+        {
+            public int $calls = 0;
+
+            public function process(DocumentUnitExecutionContext $context): DocumentUnitOutput
+            {
+                $this->calls++;
+
+                throw new TypedFailureException(
+                    FailureCategory::Terminal,
+                    'vision_provider_request_rejected',
+                    ['diagnostic_fingerprint' => 'sha256:'.str_repeat('a', 64)],
+                );
+            }
+        };
+        $usecase = $this->processUnit($store, $processor, new class implements DocumentUnitAggregateReconciler
+        {
+            public function reconcile(int $documentId, string $sourceVersion): void {}
+        });
+
+        foreach ($units as $unit) {
+            $usecase->handle($unit->id, 'source');
+        }
+
+        self::assertSame(2, $processor->calls);
+        foreach (array_slice($units, 2) as $unit) {
+            self::assertSame('breaker_stopped', $store->find($unit->id)?->failureCode);
+            self::assertSame(0, $store->find($unit->id)?->metadata['actual_execution_count']);
+        }
+        self::assertSame(DocumentProcessingUnitStatus::Pending, $store->find($differentContract->id)?->status);
+        self::assertSame(0, $store->find($differentContract->id)?->attemptCount);
+    }
+
+    #[Test]
+    public function pre_wire_claim_guard_allows_only_two_concurrent_units_in_the_same_scope(): void
+    {
+        $store = new InMemoryDocumentProcessingUnitStore;
+        $units = [];
+        foreach (range(1, 4) as $index) {
+            $units[] = $store->create(1, 2, 3, 4, $this->unit(DocumentUnitType::PdfPage, $index, 'source'));
+        }
+        $now = new DateTimeImmutable('2026-08-13T00:00:00+00:00');
+        $lease = $now->modify('+60 seconds');
+
+        self::assertTrue($store->claim($units[0]->id, 'source', $now, $lease, ProcessDocumentUnit::MAX_ATTEMPTS)->acquired());
+        self::assertTrue($store->claim($units[1]->id, 'source', $now, $lease, ProcessDocumentUnit::MAX_ATTEMPTS)->acquired());
+        self::assertSame(
+            DocumentProcessingUnitClaimStatus::Busy,
+            $store->claim($units[2]->id, 'source', $now, $lease, ProcessDocumentUnit::MAX_ATTEMPTS)->status,
+        );
+        self::assertSame(DocumentProcessingUnitStatus::Pending, $store->find($units[2]->id)?->status);
+        self::assertSame(0, $store->find($units[2]->id)?->attemptCount);
     }
 
     #[Test]

--- a/tests/Unit/EstimateGeneration/Documents/DocumentProcessingOutcomeResolverTest.php
+++ b/tests/Unit/EstimateGeneration/Documents/DocumentProcessingOutcomeResolverTest.php
@@ -83,7 +83,7 @@ final class DocumentProcessingOutcomeResolverTest extends TestCase
                 $ready ? 'completed' : 'failed',
                 $ready ? 1 : 0,
                 $ready ? null : 'terminal',
-                $breaker ? 'document_systemic_failure' : ($ready ? null : 'invalid_analysis_schema'),
+                $breaker ? 'breaker_stopped' : ($ready ? null : 'invalid_analysis_schema'),
             );
         }
 

--- a/tests/Unit/EstimateGeneration/Documents/ExplicitDocumentRetryEligibilityTest.php
+++ b/tests/Unit/EstimateGeneration/Documents/ExplicitDocumentRetryEligibilityTest.php
@@ -99,6 +99,17 @@ final class ExplicitDocumentRetryEligibilityTest extends TestCase
         self::assertTrue((new ExplicitDocumentRetryEligibility)->allowed($document));
     }
 
+    #[Test]
+    public function vision_request_rejection_with_breaker_stops_allows_one_explicit_document_retry(): void
+    {
+        $document = $this->document('failed', 'vision_provider_request_rejected');
+        foreach ($document->processingUnits->skip(2) as $unit) {
+            $unit->forceFill(['failure_code' => 'breaker_stopped']);
+        }
+
+        self::assertTrue((new ExplicitDocumentRetryEligibility)->allowed($document));
+    }
+
     /** @return iterable<string, array{string}> */
     public static function unsafeFailureCodes(): iterable
     {

--- a/tests/Unit/EstimateGeneration/Observability/FailureNormalizerTest.php
+++ b/tests/Unit/EstimateGeneration/Observability/FailureNormalizerTest.php
@@ -155,6 +155,28 @@ final class FailureNormalizerTest extends TestCase
         self::assertStringNotContainsString('filename', json_encode($sameClass->safeContext, JSON_THROW_ON_ERROR));
     }
 
+    #[Test]
+    public function typed_provider_diagnostic_identity_overrides_the_generic_exception_chain(): void
+    {
+        $fingerprint = 'sha256:'.str_repeat('b', 64);
+        $failure = (new FailureNormalizer)->normalize(new TypedFailureException(
+            FailureCategory::Terminal,
+            'vision_provider_request_rejected',
+            [
+                'provider_http_status' => 400,
+                'provider_error_type' => 'invalid_request_error',
+                'provider_error_code' => 'unsupported_parameter',
+                'provider_error_param' => 'response_format',
+                'payload_shape_fingerprint' => 'sha256:'.str_repeat('a', 64),
+                'diagnostic_fingerprint' => $fingerprint,
+            ],
+        ), $this->context());
+
+        self::assertSame($fingerprint, $failure->safeContext['diagnostic_fingerprint']);
+        self::assertSame('response_format', $failure->safeContext['provider_error_param']);
+        self::assertSame(400, $failure->safeContext['provider_http_status']);
+    }
+
     private function context(
         int $organizationId = 1,
         ProcessingStage $stage = ProcessingStage::UnderstandDocuments,

--- a/tests/Unit/EstimateGeneration/ProductionDocumentUnitProcessorTest.php
+++ b/tests/Unit/EstimateGeneration/ProductionDocumentUnitProcessorTest.php
@@ -524,7 +524,13 @@ final class ProductionDocumentUnitProcessorTest extends DatabaseLessTestCase
     #[Test]
     public function retryable_vision_failure_preserves_recoverable_category(): void
     {
-        $original = new VisionProviderException('vision_provider_unavailable', 503, true);
+        $fingerprint = 'sha256:'.str_repeat('c', 64);
+        $original = new VisionProviderException(
+            'vision_provider_unavailable',
+            503,
+            true,
+            safeContext: ['diagnostic_fingerprint' => $fingerprint, 'provider_http_status' => 503],
+        );
 
         try {
             $this->visionFailureProcessor($original)->process($this->rasterContext());
@@ -532,6 +538,8 @@ final class ProductionDocumentUnitProcessorTest extends DatabaseLessTestCase
         } catch (TypedFailureException $exception) {
             self::assertSame(FailureCategory::Recoverable, $exception->category);
             self::assertSame('vision_provider_unavailable', $exception->safeCode);
+            self::assertSame($fingerprint, $exception->safeContext['diagnostic_fingerprint']);
+            self::assertSame(503, $exception->safeContext['provider_http_status']);
             self::assertSame($original, $exception->getPrevious());
         }
     }

--- a/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
+++ b/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
@@ -17,7 +17,6 @@ use App\BusinessModules\Addons\EstimateGeneration\Settings\EffectiveSettingsPair
 use App\BusinessModules\Addons\EstimateGeneration\Settings\EffectiveSettingsResolver;
 use App\BusinessModules\Addons\EstimateGeneration\Settings\SettingsSnapshotHash;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\Contracts\VisionProvider;
-use App\BusinessModules\Addons\EstimateGeneration\Vision\Contracts\VisionResponseBodyReader;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\DTO\VisionAnalysisData;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\DTO\VisionDocumentInput;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\Exceptions\VisionContractException;
@@ -26,12 +25,12 @@ use App\BusinessModules\Addons\EstimateGeneration\Vision\Exceptions\VisionRespon
 use App\BusinessModules\Addons\EstimateGeneration\Vision\PhysicalAttempt\VisionPhysicalAttemptSnapshot;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\PhysicalAttempt\VisionPhysicalAttemptStore;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\Preprocessing\ProjectiveTransformFactory;
-use App\BusinessModules\Addons\EstimateGeneration\Vision\Providers\BoundedVisionResponseBodyReader;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\Providers\TimewebVisionProvider;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\TargetedSheetEvidence;
 use App\BusinessModules\Addons\EstimateGeneration\Vision\TargetedSheetRecheckScope;
 use DateTimeImmutable;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Support\DatabaseLessTestCase;
@@ -53,7 +52,8 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
             'api_key' => 'secret', 'base_uri' => 'https://vision.test/v1', 'timeout_seconds' => 10,
             'retry_attempts' => 3, 'retry_delay_ms' => 0,
             'primary_max_output_tokens' => 8192, 'targeted_max_output_tokens' => 6144,
-            'max_response_bytes' => 100_000, 'max_elements' => 100, 'max_depth' => 12,
+            'max_response_bytes' => 100_000, 'max_error_response_bytes' => 16_384,
+            'max_elements' => 100, 'max_depth' => 12,
             'image_detail' => 'high',
         ]);
         $this->app->instance(AiUsageStore::class, new class($this->attempts) implements AiUsageStore
@@ -312,7 +312,7 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
     #[Test]
     public function it_retries_only_retryable_physical_calls_without_model_fallback(): void
     {
-        Http::fakeSequence()->pushStatus(429)->pushStatus(503)->push($this->response());
+        Http::fakeSequence()->pushStatus(409)->pushStatus(429)->push($this->response());
 
         $this->provider()->analyze($this->input());
 
@@ -322,22 +322,11 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
     }
 
     #[Test]
-    public function oversized_or_malformed_retryable_error_bodies_are_never_decoded_and_still_retry(): void
+    public function retryable_error_bodies_are_bounded_and_still_retry(): void
     {
-        $reader = new class implements VisionResponseBodyReader
-        {
-            public int $calls = 0;
-
-            public function read(\Illuminate\Http\Client\Response $response, int $maxBytes): string
-            {
-                $this->calls++;
-
-                return (new BoundedVisionResponseBodyReader)->read($response, $maxBytes);
-            }
-        };
-        $this->app->instance(VisionResponseBodyReader::class, $reader);
+        config()->set('estimate-generation.vision.max_error_response_bytes', 256);
         Http::fakeSequence()
-            ->push(str_repeat('x', 200_000), 429)
+            ->push(str_repeat('x', 20_000), 429, ['Content-Type' => 'text/plain'])
             ->push('{malformed', 503)
             ->push($this->response());
 
@@ -345,7 +334,176 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
 
         self::assertSame(['http_failed', 'http_failed', 'succeeded'], array_map(fn (AiUsageData $row): string => $row->status, $this->attempts));
         self::assertSame([429, 503, 200], array_map(fn (AiUsageData $row): ?int => $row->httpCode, $this->attempts));
-        self::assertSame(1, $reader->calls);
+        self::assertTrue($this->physicalAttempts->snapshots()[0]->responsePayload['provider_error']['body_truncated']);
+        self::assertLessThanOrEqual(256, strlen($this->physicalAttempts->snapshots()[0]->responsePayload['provider_error']['redacted_preview']));
+    }
+
+    #[Test]
+    public function standard_openai_error_is_captured_safely_and_terminal_400_is_not_wire_retried(): void
+    {
+        $secret = 'sk-live-DoNotPersist123456789';
+        Log::spy();
+        Http::fake(['*' => Http::response([
+            'error' => [
+                'message' => "Unsupported parameter: 'response_format'. Authorization: Bearer {$secret}",
+                'type' => 'invalid_request_error',
+                'param' => 'response_format',
+                'code' => 'unsupported_parameter',
+            ],
+        ], 400, ['Content-Type' => 'application/json; charset=utf-8'])]);
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Terminal provider rejection was accepted.');
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_provider_request_rejected', $exception->reason);
+            self::assertFalse($exception->retryable);
+            self::assertSame('response_format', $exception->safeContext['provider_error_param']);
+            self::assertMatchesRegularExpression('/\Asha256:[0-9a-f]{64}\z/', $exception->safeContext['diagnostic_fingerprint']);
+        }
+
+        Http::assertSentCount(1);
+        self::assertCount(1, $this->attempts);
+        self::assertSame('unavailable', $this->attempts[0]->usageStatus);
+        self::assertSame(0, $this->attempts[0]->inputTokens);
+        self::assertSame(0, $this->attempts[0]->outputTokens);
+        self::assertSame(0, $this->attempts[0]->reasoningTokens);
+        $diagnostic = $this->physicalAttempts->onlySnapshot()->responsePayload['provider_error'];
+        self::assertSame(400, $diagnostic['provider_http_status']);
+        self::assertSame('invalid_request_error', $diagnostic['error_type']);
+        self::assertSame('unsupported_parameter', $diagnostic['error_code']);
+        self::assertSame('response_format', $diagnostic['error_param']);
+        self::assertSame(
+            'provider_http_status=400; envelope=openai_error; type=invalid_request_error; code=unsupported_parameter; param=response_format',
+            $diagnostic['diagnostic_summary'],
+        );
+        self::assertArrayNotHasKey('error_message', $diagnostic);
+        self::assertSame('application/json', $diagnostic['response_content_type']);
+        self::assertSame('openai/gpt-5.6-luna', $diagnostic['model']);
+        self::assertSame('chat_completions', $diagnostic['endpoint_kind']);
+        self::assertMatchesRegularExpression('/\Asha256:[0-9a-f]{64}\z/', $diagnostic['body_fingerprint']);
+        self::assertMatchesRegularExpression('/\Asha256:[0-9a-f]{64}\z/', $diagnostic['payload_shape_fingerprint']);
+        self::assertStringNotContainsString($secret, json_encode($diagnostic, JSON_THROW_ON_ERROR));
+        self::assertArrayNotHasKey('raw_body', $diagnostic);
+        self::assertArrayNotHasKey('request', $diagnostic);
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Durable terminal provider rejection was accepted on replay.');
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_provider_request_rejected', $exception->reason);
+            self::assertSame($diagnostic['diagnostic_fingerprint'], $exception->safeContext['diagnostic_fingerprint']);
+        }
+
+        Http::assertSentCount(1);
+        self::assertCount(1, $this->attempts);
+        Log::shouldHaveReceived('warning')->once()->withArgs(
+            static fn (string $message, array $context): bool => $message === '[EstimateGeneration Vision] provider HTTP failure'
+                && ($context['error_param'] ?? null) === 'response_format'
+                && ! str_contains(json_encode($context, JSON_THROW_ON_ERROR), $secret)
+                && ! array_key_exists('redacted_preview', $context)
+                && ! array_key_exists('request', $context),
+        );
+    }
+
+    #[Test]
+    public function production_shaped_unknown_oversized_400_keeps_only_a_redacted_bounded_preview_and_hash(): void
+    {
+        config()->set('estimate-generation.vision.max_error_response_bytes', 384);
+        $secret = 'sk-live-DoNotPersist123456789';
+        $signedUrl = 'https://storage.example/private.png?X-Amz-Signature=secret';
+        $body = json_encode([
+            'status' => 400,
+            'detail' => "Gateway rejected request. Authorization: Bearer {$secret}. image={$signedUrl}. ".str_repeat('Ошибка ', 1_000),
+            'request_dump' => 'data:image/png;base64,'.str_repeat('A', 10_000),
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        Http::fake(['*' => Http::response($body, 400, ['Content-Type' => 'application/problem+json'])]);
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Unknown terminal provider rejection was accepted.');
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_provider_request_rejected', $exception->reason);
+        }
+
+        Http::assertSentCount(1);
+        $diagnostic = $this->physicalAttempts->onlySnapshot()->responsePayload['provider_error'];
+        self::assertSame('unknown', $diagnostic['envelope_kind']);
+        self::assertTrue($diagnostic['body_truncated']);
+        self::assertLessThanOrEqual(384, strlen($diagnostic['redacted_preview']));
+        self::assertStringNotContainsString($secret, $diagnostic['redacted_preview']);
+        self::assertStringNotContainsString('X-Amz-Signature', $diagnostic['redacted_preview']);
+        self::assertStringNotContainsString('data:image', $diagnostic['redacted_preview']);
+        self::assertMatchesRegularExpression('/\Asha256:[0-9a-f]{64}\z/', $diagnostic['body_fingerprint']);
+    }
+
+    #[Test]
+    public function typed_error_breaker_identity_ignores_variable_provider_message_and_request_id(): void
+    {
+        Http::fakeSequence()
+            ->push(['error' => [
+                'message' => "Unsupported parameter for request req-first and customer text 'private one'.",
+                'type' => 'invalid_request_error',
+                'param' => 'response_format',
+                'code' => 'unsupported_parameter',
+            ]], 400)
+            ->push(['error' => [
+                'message' => "Unsupported parameter for request req-second and customer text 'private two'.",
+                'type' => 'invalid_request_error',
+                'param' => 'response_format',
+                'code' => 'unsupported_parameter',
+            ]], 400);
+
+        foreach ([1, 2] as $claim) {
+            try {
+                $this->provider()->analyze($this->input(claim: $claim));
+                self::fail('Terminal provider rejection was accepted.');
+            } catch (VisionProviderException) {
+            }
+        }
+
+        $snapshots = $this->physicalAttempts->snapshots();
+        self::assertCount(2, $snapshots);
+        self::assertNotSame(
+            $snapshots[0]->responsePayload['provider_error']['body_fingerprint'],
+            $snapshots[1]->responsePayload['provider_error']['body_fingerprint'],
+        );
+        self::assertSame(
+            $snapshots[0]->responsePayload['provider_error']['diagnostic_fingerprint'],
+            $snapshots[1]->responsePayload['provider_error']['diagnostic_fingerprint'],
+        );
+        self::assertStringNotContainsString('private', json_encode($snapshots, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
+    public function unknown_json_recursively_redacts_nested_request_content_and_keeps_preview_out_of_logs(): void
+    {
+        Log::spy();
+        Http::fake(['*' => Http::response([
+            'status' => 400,
+            'detail' => 'Gateway rejected request for +7 (999) 123-45-67.',
+            'request' => [
+                'messages' => [['role' => 'user', 'content' => 'PRIVATE CUSTOMER TEXT']],
+                'image_url' => ['url' => 'https://storage.example/private.png?signature=secret'],
+            ],
+        ], 400, ['Content-Type' => 'application/problem+json'])]);
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Unknown terminal provider rejection was accepted.');
+        } catch (VisionProviderException) {
+        }
+
+        $diagnostic = $this->physicalAttempts->onlySnapshot()->responsePayload['provider_error'];
+        self::assertStringNotContainsString('PRIVATE CUSTOMER TEXT', $diagnostic['redacted_preview']);
+        self::assertStringNotContainsString('999', $diagnostic['redacted_preview']);
+        self::assertStringNotContainsString('storage.example', $diagnostic['redacted_preview']);
+        self::assertStringContainsString('[redacted]', $diagnostic['redacted_preview']);
+        Log::shouldHaveReceived('warning')->once()->withArgs(
+            static fn (string $message, array $context): bool => $message === '[EstimateGeneration Vision] provider HTTP failure'
+                && ! array_key_exists('redacted_preview', $context)
+                && ! str_contains(json_encode($context, JSON_THROW_ON_ERROR), 'PRIVATE CUSTOMER TEXT'),
+        );
     }
 
     #[Test]
@@ -473,6 +631,7 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
             }
         }
         self::assertCount(4, $this->attempts);
+        Http::assertSentCount(4);
     }
 
     #[Test]
@@ -1105,6 +1264,15 @@ final class InMemoryVisionPhysicalAttemptStore implements VisionPhysicalAttemptS
         }
 
         return array_values($this->attempts)[0]['snapshot'];
+    }
+
+    /** @return list<VisionPhysicalAttemptSnapshot> */
+    public function snapshots(): array
+    {
+        return array_values(array_map(
+            static fn (array $attempt): VisionPhysicalAttemptSnapshot => $attempt['snapshot'],
+            $this->attempts,
+        ));
     }
 
     public function claim(AiOperationContext $context, string $requestFingerprint, string $ownerToken, DateTimeImmutable $now, DateTimeImmutable $leaseExpiresAt): VisionPhysicalAttemptSnapshot


### PR DESCRIPTION
## Что изменено
- безопасно и bounded сохраняются typed HTTP-ошибки Timeweb до закрытия stream
- terminal 4xx не повторяются внутри unit; transient 408/409/429/5xx классифицированы отдельно
- document breaker ограничивает каскад двумя конкурентными Vision-вызовами и помечает остаток breaker_stopped
- ноль пригодных страниц переводит сессию в возобновляемую системную ошибку
- payload GPT-5.6 Luna в этом диагностическом выпуске не изменён

## Проверки
- 115 targeted DB-free tests / 518 assertions (1 documented fixture skip)
- 3 isolated PostgreSQL contract tests / 16 assertions, no skips
- php-l, Pint, targeted Larastan
- independent correctness/security/architecture review; all findings closed

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Reduced the systemic failure threshold from 3 to 2 across document processing units.</li>
<li>Updated failure handling to include 'breaker_stopped' as a systemic failure state.</li>
<li>Added 'vision_provider_request_rejected' and 'vision_http_failed' to the list of tracked systemic failure codes.</li>
<li>Refined circuit breaking logic to include processing route predicates when identifying systemic failures.</li>
<li>Updated failure metadata to mark units as 'breaker_stopped' instead of 'document_systemic_failure' when the circuit breaker triggers.</li>
</ul></div>