### PR TITLE
fix[backend]: исправлена lineage повторной обработки Vision

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/CreateDocumentProcessingUnits.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/CreateDocumentProcessingUnits.php
@@ -36,6 +36,7 @@ final readonly class CreateDocumentProcessingUnits
         $document->loadMissing('session');
         $sourceVersion = DocumentSourceVersion::fromDocument($document);
         $previousSourceVersion = (string) $document->source_version;
+        $processingAttemptId = $this->processingAttemptId($document);
 
         if (
             $document->session === null
@@ -57,6 +58,7 @@ final readonly class CreateDocumentProcessingUnits
             ->get();
 
         if ($existing->isNotEmpty()) {
+            $this->synchronizeProcessingAttempt($existing, $processingAttemptId);
             $this->publish($claim, static fn (): bool => true);
             if (in_array((string) $document->status, ['uploaded', 'queued', 'processing'], true)) {
                 $this->ensureQueuedPages($document, $existing, $sourceVersion);
@@ -88,7 +90,7 @@ final readonly class CreateDocumentProcessingUnits
 
             return collect();
         }
-        $models = $this->publish($claim, function () use ($document, $previousSourceVersion, $sourceVersion, $units): Collection {
+        $models = $this->publish($claim, function () use ($document, $previousSourceVersion, $sourceVersion, $processingAttemptId, $units): Collection {
             $models = $this->replacement->commit(
                 (int) $document->organization_id,
                 (int) $document->project_id,
@@ -96,7 +98,7 @@ final readonly class CreateDocumentProcessingUnits
                 (int) $document->id,
                 $previousSourceVersion,
                 $sourceVersion,
-                function () use ($document, $sourceVersion, $units): Collection {
+                function () use ($document, $sourceVersion, $processingAttemptId, $units): Collection {
                     EstimateGenerationProcessingUnit::query()
                         ->where('organization_id', $document->organization_id)
                         ->where('project_id', $document->project_id)
@@ -144,7 +146,10 @@ final readonly class CreateDocumentProcessingUnits
                             'attempt_count' => 0,
                             'output_count' => 0,
                             'locator' => json_encode($unit->locator, JSON_THROW_ON_ERROR),
-                            'metadata' => '{}',
+                            'metadata' => json_encode(
+                                $processingAttemptId === null ? (object) [] : ['processing_attempt_id' => $processingAttemptId],
+                                JSON_THROW_ON_ERROR,
+                            ),
                             'created_at' => now(),
                             'updated_at' => now(),
                         ]);
@@ -178,6 +183,33 @@ final readonly class CreateDocumentProcessingUnits
         });
 
         return $models;
+    }
+
+    private function processingAttemptId(EstimateGenerationDocument $document): ?string
+    {
+        $meta = is_array($document->meta) ? $document->meta : [];
+        $attemptId = $meta['processing_attempt_id'] ?? null;
+
+        return is_string($attemptId) && trim($attemptId) !== '' ? trim($attemptId) : null;
+    }
+
+    /** @param Collection<int, EstimateGenerationProcessingUnit> $units */
+    private function synchronizeProcessingAttempt(Collection $units, ?string $processingAttemptId): void
+    {
+        if ($processingAttemptId === null) {
+            return;
+        }
+
+        foreach ($units as $unit) {
+            $metadata = is_array($unit->metadata) ? $unit->metadata : [];
+            if (($metadata['processing_attempt_id'] ?? null) === $processingAttemptId) {
+                continue;
+            }
+
+            $unit->forceFill([
+                'metadata' => [...$metadata, 'processing_attempt_id' => $processingAttemptId],
+            ])->saveQuietly();
+        }
     }
 
     private function publish(CheckpointClaim $claim, callable $publication): mixed

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/DocumentUnitExecutionContext.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/DocumentUnitExecutionContext.php
@@ -28,6 +28,7 @@ final readonly class DocumentUnitExecutionContext
         public string $sessionStatus,
         public ?int $pageId = null,
         public ?\Closure $renewLease = null,
+        public string $processingAttemptId = '',
     ) {}
 
     public function renewLeaseOrFail(): void

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/EloquentDocumentProcessingUnitStore.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/EloquentDocumentProcessingUnitStore.php
@@ -94,8 +94,26 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
                         $now->modify(sprintf('+%d seconds', \App\BusinessModules\Addons\EstimateGeneration\Application\Documents\Understanding\SheetAnalysisLeasePolicy::UNIT_LEASE_SECONDS)),
                     );
                 },
+                processingAttemptId: $this->processingAttemptId($unit),
             );
         }, 3);
+    }
+
+    private function processingAttemptId(EstimateGenerationProcessingUnit $unit): string
+    {
+        $metadata = is_array($unit->metadata) ? $unit->metadata : [];
+        $attemptId = $metadata['processing_attempt_id'] ?? null;
+
+        if (! is_string($attemptId) || trim($attemptId) === '') {
+            $documentMeta = $unit->document instanceof EstimateGenerationDocument && is_array($unit->document->meta)
+                ? $unit->document->meta
+                : [];
+            $attemptId = $documentMeta['processing_attempt_id'] ?? null;
+        }
+
+        return is_string($attemptId) && trim($attemptId) !== ''
+            ? trim($attemptId)
+            : 'legacy-unit-'.(int) $unit->getKey();
     }
 
     public function claim(int $unitId, string $sourceVersion, DateTimeImmutable $now, DateTimeImmutable $leaseExpiresAt, int $maxAttempts): DocumentProcessingUnitClaim

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/InMemoryDocumentProcessingUnitStore.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/InMemoryDocumentProcessingUnitStore.php
@@ -82,7 +82,17 @@ final class InMemoryDocumentProcessingUnitStore implements DocumentProcessingUni
                     $now->modify(sprintf('+%d seconds', \App\BusinessModules\Addons\EstimateGeneration\Application\Documents\Understanding\SheetAnalysisLeasePolicy::UNIT_LEASE_SECONDS)),
                 );
             },
+            processingAttemptId: $this->processingAttemptId($record),
         );
+    }
+
+    private function processingAttemptId(DocumentProcessingUnitRecord $record): string
+    {
+        $attemptId = $record->metadata['processing_attempt_id'] ?? null;
+
+        return is_string($attemptId) && trim($attemptId) !== ''
+            ? trim($attemptId)
+            : 'legacy-unit-'.$record->id;
     }
 
     public function claim(int $unitId, string $sourceVersion, DateTimeImmutable $now, DateTimeImmutable $leaseExpiresAt, int $maxAttempts): DocumentProcessingUnitClaim

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProductionDocumentUnitProcessor.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProductionDocumentUnitProcessor.php
@@ -273,7 +273,12 @@ final readonly class ProductionDocumentUnitProcessor implements DocumentUnitProc
         $auxiliaryText = is_string($nativePdfText) ? mb_substr($nativePdfText, 0, 12_000) : null;
         $auxiliaryMetadata = $this->visionAuxiliaryMetadata($auxiliary, $preprocessed, $nativePdfText);
         $correlationId = SheetAnalysisOperationIdentity::primary(
-            $context->sessionId, $context->documentId, $context->unitId, $context->sourceVersion, $preprocessed->derivativeHash,
+            $context->sessionId,
+            $context->documentId,
+            $context->unitId,
+            $context->sourceVersion,
+            $preprocessed->derivativeHash,
+            $context->processingAttemptId,
         );
         $input = new VisionDocumentInput(
             organizationId: $context->organizationId,
@@ -355,6 +360,7 @@ final readonly class ProductionDocumentUnitProcessor implements DocumentUnitProc
             $targetedRouting['targeted_scope'] = $targetedPlan->scope->toSafeUsageContext();
             $targetedOperation = SheetAnalysisOperationIdentity::targeted(
                 $context->sessionId, $context->documentId, $context->unitId, $context->sourceVersion, $preprocessed->derivativeHash,
+                $context->processingAttemptId,
                 $targetedRouting,
             );
             try {

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ResetDocumentProcessingUnitsForAttempt.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ResetDocumentProcessingUnitsForAttempt.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Application\Documents;
+
+use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationDocument;
+
+final readonly class ResetDocumentProcessingUnitsForAttempt
+{
+    public function handle(
+        EstimateGenerationDocument $document,
+        string $sourceVersion,
+        ?string $oldAttemptId,
+        string $attemptId,
+    ): int {
+        $document->loadMissing(['processingUnits', 'pages']);
+        $retryUnitIds = [];
+        $preservedReady = 0;
+
+        foreach ($document->processingUnits as $unit) {
+            if (! hash_equals($sourceVersion, (string) $unit->source_version)) {
+                continue;
+            }
+            $unitMeta = is_array($unit->metadata) ? $unit->metadata : [];
+            $unitStatus = $unit->status instanceof DocumentProcessingUnitStatus
+                ? $unit->status->value
+                : (string) $unit->status;
+            if ($unitStatus === DocumentProcessingUnitStatus::Completed->value && (int) $unit->output_count > 0) {
+                $unit->forceFill(['metadata' => [...$unitMeta, 'processing_attempt_id' => $attemptId]])->save();
+                $preservedReady++;
+
+                continue;
+            }
+            $retryUnitIds[] = (int) $unit->getKey();
+            $failureHistory = is_array($unitMeta['failure_history'] ?? null) ? $unitMeta['failure_history'] : [];
+            if ($unit->failure_code !== null || $unit->failure_fingerprint !== null) {
+                $failureHistory[] = [
+                    'attempt_id' => $oldAttemptId,
+                    'attempt_count' => (int) $unit->attempt_count,
+                    'failure_code' => $unit->failure_code,
+                    'failure_fingerprint' => $unit->failure_fingerprint,
+                    'failure_category' => $unitMeta['failure_category'] ?? null,
+                    'actual_execution_count' => (int) ($unitMeta['actual_execution_count'] ?? min((int) $unit->attempt_count, 1)),
+                    'failed_at' => $unit->failed_at?->toISOString(),
+                ];
+            }
+            unset($unitMeta['failure_category'], $unitMeta['actual_execution_count']);
+            $unit->forceFill([
+                'status' => DocumentProcessingUnitStatus::Pending->value,
+                'attempt_count' => 0,
+                'claim_token' => null,
+                'lease_expires_at' => null,
+                'output_version' => null,
+                'output_count' => 0,
+                'dispatch_attempt_count' => 0,
+                'last_dispatched_at' => null,
+                'next_dispatch_at' => null,
+                'failure_code' => null,
+                'failure_fingerprint' => null,
+                'metadata' => [
+                    ...$unitMeta,
+                    'failure_history' => $failureHistory,
+                    'processing_attempt_id' => $attemptId,
+                ],
+                'started_at' => null,
+                'completed_at' => null,
+                'failed_at' => null,
+            ])->save();
+        }
+
+        foreach ($document->pages as $page) {
+            if (! hash_equals($sourceVersion, (string) $page->source_version)
+                || ! in_array((int) $page->processing_unit_id, $retryUnitIds, true)) {
+                continue;
+            }
+            $page->forceFill([
+                'status' => 'queued',
+                'output_version' => null,
+                'text' => null,
+                'text_hash' => null,
+                'confidence' => null,
+                'raw_payload_path' => null,
+                'normalized_payload' => [],
+                'quality_flags' => [],
+                'excluded_at' => null,
+                'excluded_reason' => null,
+                'retry_attempt_id' => $attemptId,
+                'last_retry_requested_at' => now(),
+            ])->save();
+        }
+
+        return $preservedReady;
+    }
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/RetryEstimateGenerationDocument.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/RetryEstimateGenerationDocument.php
@@ -24,6 +24,7 @@ final class RetryEstimateGenerationDocument
         private DocumentGenerationReadinessService $readiness,
         private AuthorizationService $authorization,
         private ExplicitDocumentRetryEligibility $eligibility,
+        private ResetDocumentProcessingUnitsForAttempt $resetter,
     ) {}
 
     public function handle(
@@ -120,82 +121,12 @@ final class RetryEstimateGenerationDocument
                     'requested_at' => $requestedAt,
                 ];
 
-                $retryUnitIds = [];
-                $preservedReady = 0;
-                foreach ($lockedDocument->processingUnits as $unit) {
-                    if (! hash_equals($expectedSourceVersion, (string) $unit->source_version)) {
-                        continue;
-                    }
-                    $unitMeta = is_array($unit->metadata) ? $unit->metadata : [];
-                    $unitStatus = $unit->status instanceof DocumentProcessingUnitStatus
-                        ? $unit->status->value
-                        : (string) $unit->status;
-                    if ($unitStatus === DocumentProcessingUnitStatus::Completed->value && (int) $unit->output_count > 0) {
-                        $unit->forceFill(['metadata' => [...$unitMeta, 'processing_attempt_id' => $attemptId]])->save();
-                        $preservedReady++;
-
-                        continue;
-                    }
-                    $retryUnitIds[] = (int) $unit->getKey();
-                    $failureHistory = is_array($unitMeta['failure_history'] ?? null) ? $unitMeta['failure_history'] : [];
-                    if ($unit->failure_code !== null || $unit->failure_fingerprint !== null) {
-                        $failureHistory[] = [
-                            'attempt_id' => $oldAttemptId,
-                            'attempt_count' => (int) $unit->attempt_count,
-                            'failure_code' => $unit->failure_code,
-                            'failure_fingerprint' => $unit->failure_fingerprint,
-                            'failure_category' => $unitMeta['failure_category'] ?? null,
-                            'actual_execution_count' => (int) ($unitMeta['actual_execution_count'] ?? min((int) $unit->attempt_count, 1)),
-                            'failed_at' => $unit->failed_at?->toISOString(),
-                        ];
-                    }
-                    unset($unitMeta['failure_category']);
-                    unset($unitMeta['actual_execution_count']);
-                    $unit->forceFill([
-                        'status' => DocumentProcessingUnitStatus::Pending->value,
-                        'attempt_count' => 0,
-                        'claim_token' => null,
-                        'lease_expires_at' => null,
-                        'output_version' => null,
-                        'output_count' => 0,
-                        'dispatch_attempt_count' => 0,
-                        'last_dispatched_at' => null,
-                        'next_dispatch_at' => null,
-                        'failure_code' => null,
-                        'failure_fingerprint' => null,
-                        'metadata' => [
-                            ...$unitMeta,
-                            'failure_history' => $failureHistory,
-                            'processing_attempt_id' => $attemptId,
-                        ],
-                        'started_at' => null,
-                        'completed_at' => null,
-                        'failed_at' => null,
-                    ])->save();
-                }
-
-                foreach ($lockedDocument->pages as $page) {
-                    if (! hash_equals($expectedSourceVersion, (string) $page->source_version)) {
-                        continue;
-                    }
-                    if (! in_array((int) $page->processing_unit_id, $retryUnitIds, true)) {
-                        continue;
-                    }
-                    $page->forceFill([
-                        'status' => 'queued',
-                        'output_version' => null,
-                        'text' => null,
-                        'text_hash' => null,
-                        'confidence' => null,
-                        'raw_payload_path' => null,
-                        'normalized_payload' => [],
-                        'quality_flags' => [],
-                        'excluded_at' => null,
-                        'excluded_reason' => null,
-                        'retry_attempt_id' => $attemptId,
-                        'last_retry_requested_at' => now(),
-                    ])->save();
-                }
+                $preservedReady = $this->resetter->handle(
+                    $lockedDocument,
+                    $expectedSourceVersion,
+                    $oldAttemptId,
+                    $attemptId,
+                );
 
                 $history = is_array($meta['explicit_document_retry_history'] ?? null)
                     ? $meta['explicit_document_retry_history']

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/Understanding/SheetAnalysisOperationIdentity.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/Understanding/SheetAnalysisOperationIdentity.php
@@ -8,18 +8,33 @@ use App\BusinessModules\Addons\EstimateGeneration\Observability\AiOperationConte
 
 final class SheetAnalysisOperationIdentity
 {
-    public static function primary(int $sessionId, int $documentId, int $unitId, string $sourceVersion, string $derivativeHash): string
-    {
+    public static function primary(
+        int $sessionId,
+        int $documentId,
+        int $unitId,
+        string $sourceVersion,
+        string $derivativeHash,
+        string $processingAttemptId,
+    ): string {
         return AiOperationContext::deterministicId(implode('|', [
-            'vision-unit', $sessionId, $documentId, $unitId, $sourceVersion, $derivativeHash, 'vision-contract:v3',
+            'vision-unit', $sessionId, $documentId, $unitId, $sourceVersion, $derivativeHash,
+            'processing-attempt:v1', $processingAttemptId, 'vision-contract:v3',
         ]));
     }
 
     /** @param array{role: string, reanalysis_reason: ?string, targeted_scope?: array<string, mixed>} $routing */
-    public static function targeted(int $sessionId, int $documentId, int $unitId, string $sourceVersion, string $derivativeHash, array $routing): string
-    {
+    public static function targeted(
+        int $sessionId,
+        int $documentId,
+        int $unitId,
+        string $sourceVersion,
+        string $derivativeHash,
+        string $processingAttemptId,
+        array $routing,
+    ): string {
         return AiOperationContext::deterministicId(implode('|', [
             'sheet-targeted', $sessionId, $documentId, $unitId, $sourceVersion, $derivativeHash,
+            'processing-attempt:v1', $processingAttemptId,
             'sheet-routing:v1', $routing['role'], $routing['reanalysis_reason'] ?? '',
             hash('sha256', json_encode($routing['targeted_scope'] ?? [], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)),
             'vision-contract:v3',

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionOperationalSnapshot.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionOperationalSnapshot.php
@@ -418,6 +418,7 @@ final class BuildSessionOperationalSnapshot implements SessionOperationalSnapsho
             objectInput: $base->objectInput,
             aiEstimateQuota: $base->aiEstimateQuota,
             recommendedStep: $base->recommendedStep,
+            workflowSteps: $base->workflowSteps,
         );
     }
 

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionSnapshot.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/BuildSessionSnapshot.php
@@ -84,6 +84,7 @@ final class BuildSessionSnapshot
         $budgetScope = is_array($draft['budget_scope'] ?? null) ? $draft['budget_scope'] : [];
         $aiEstimateQuota = $session->getAttribute('ai_estimate_quota_snapshot');
         $nextAction = $this->recommendedNextAction($status, $actions);
+        $recommendedStep = $this->recommendedStep($session, $status, $documentsSummary);
 
         return new SessionSnapshotData(
             id: (int) $session->getKey(),
@@ -118,7 +119,8 @@ final class BuildSessionSnapshot
                     (string) $session->organization_id,
                     (string) $session->getKey(),
                 )->toArray(),
-            recommendedStep: $this->recommendedStep($session, $status),
+            recommendedStep: $recommendedStep,
+            workflowSteps: $this->workflowSteps($session, $status, $documentsSummary, $recommendedStep),
         );
     }
 
@@ -232,6 +234,7 @@ final class BuildSessionSnapshot
     private function recommendedStep(
         EstimateGenerationSession $session,
         EstimateGenerationStatus $status,
+        array $documentsSummary,
     ): ?string {
         if ($status === EstimateGenerationStatus::ProcessingDocuments) {
             return 'documents';
@@ -242,7 +245,71 @@ final class BuildSessionSnapshot
             return 'documents';
         }
 
+        if ($status === EstimateGenerationStatus::InputReviewRequired
+            && $this->usableDocumentResults($documentsSummary) > 0
+            && $this->hasGeometryEvidence($documentsSummary)
+            && $this->documentsTerminal($documentsSummary)) {
+            return 'geometry';
+        }
+
         return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $documentsSummary
+     * @return list<array{id: string, available: bool, recommended: bool}>
+     */
+    private function workflowSteps(
+        EstimateGenerationSession $session,
+        EstimateGenerationStatus $status,
+        array $documentsSummary,
+        ?string $recommendedStep,
+    ): array {
+        $usable = $this->usableDocumentResults($documentsSummary);
+        $total = max(0, (int) ($documentsSummary['total'] ?? $documentsSummary['total_count'] ?? 0));
+        $ignored = max(0, (int) ($documentsSummary['ignored'] ?? $documentsSummary['ignored_count'] ?? 0));
+        $requiresDocumentRecovery = $status === EstimateGenerationStatus::ProcessingDocuments
+            || ($status === EstimateGenerationStatus::Failed
+                && $session->resume_status === EstimateGenerationStatus::ProcessingDocuments);
+        $complete = $total > 0 && $this->documentsTerminal($documentsSummary) && ($usable + $ignored) >= $total;
+
+        $available = [
+            'object' => true,
+            'documents' => true,
+            'geometry' => $usable > 0 && $this->hasGeometryEvidence($documentsSummary),
+            'building' => $complete && ! $requiresDocumentRecovery,
+            'draft' => $complete && ! $requiresDocumentRecovery,
+            'review' => $complete && ! $requiresDocumentRecovery,
+            'summary' => $complete && ! $requiresDocumentRecovery,
+        ];
+
+        return array_map(
+            static fn (string $id): array => [
+                'id' => $id,
+                'available' => $available[$id],
+                'recommended' => $id === $recommendedStep,
+            ],
+            array_keys($available),
+        );
+    }
+
+    /** @param array<string, mixed> $documentsSummary */
+    private function usableDocumentResults(array $documentsSummary): int
+    {
+        return max(0, (int) ($documentsSummary['ready'] ?? $documentsSummary['ready_count'] ?? 0));
+    }
+
+    /** @param array<string, mixed> $documentsSummary */
+    private function documentsTerminal(array $documentsSummary): bool
+    {
+        return (int) ($documentsSummary['pending'] ?? $documentsSummary['pending_count'] ?? 0) === 0
+            && (int) ($documentsSummary['action_required'] ?? $documentsSummary['action_required_count'] ?? 0) === 0;
+    }
+
+    /** @param array<string, mixed> $documentsSummary */
+    private function hasGeometryEvidence(array $documentsSummary): bool
+    {
+        return (int) ($documentsSummary['drawing_elements'] ?? 0) > 0;
     }
 
     /** @return list<array<string, mixed>> */

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/LaravelEstimateGenerationRetryDispatcher.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/LaravelEstimateGenerationRetryDispatcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\BusinessModules\Addons\EstimateGeneration\Application\Sessions;
 
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentSourceVersion;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ResetDocumentProcessingUnitsForAttempt;
 use App\BusinessModules\Addons\EstimateGeneration\Jobs\GenerateEstimateDraftJob;
 use App\BusinessModules\Addons\EstimateGeneration\Jobs\ProcessEstimateGenerationDocumentJob;
 use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationDocument;
@@ -14,6 +15,8 @@ use Illuminate\Support\Str;
 
 final class LaravelEstimateGenerationRetryDispatcher implements EstimateGenerationRetryDispatcher
 {
+    public function __construct(private readonly ResetDocumentProcessingUnitsForAttempt $resetter) {}
+
     public function dispatchDocuments(array $documentIds): void
     {
         foreach (array_values(array_unique($documentIds)) as $documentId) {
@@ -22,9 +25,53 @@ final class LaravelEstimateGenerationRetryDispatcher implements EstimateGenerati
                 continue;
             }
             $attemptId = (string) Str::uuid();
+            $meta = is_array($document->meta) ? $document->meta : [];
+            $oldAttemptId = is_string($meta['processing_attempt_id'] ?? null)
+                ? $meta['processing_attempt_id']
+                : null;
+            $sourceVersion = DocumentSourceVersion::fromDocument($document);
+            $preservedReady = $this->resetter->handle($document, $sourceVersion, $oldAttemptId, $attemptId);
+            $includedPages = max(0, (int) $document->page_count);
+            $executionProgress = $includedPages === 0
+                ? 0
+                : (int) floor(($preservedReady / $includedPages) * 100);
+            $factsSummary = is_array($document->facts_summary) ? $document->facts_summary : [];
             $document->forceFill([
+                'status' => 'queued',
+                'processing_stage' => 'stored',
+                'progress_percent' => $executionProgress,
+                'ocr_started_at' => null,
+                'ocr_finished_at' => null,
+                'error_code' => null,
+                'error_message_key' => null,
+                'error_context' => null,
+                'processed_page_count' => $preservedReady,
+                'facts_summary' => [
+                    ...$factsSummary,
+                    'processing_outcome' => [
+                        'type' => 'processing',
+                        'counts' => [
+                            'included' => $includedPages,
+                            'ready' => $preservedReady,
+                            'needs_user_action' => 0,
+                            'terminal_system_failed' => 0,
+                            'breaker_stopped' => 0,
+                            'system_failed' => 0,
+                            'processing' => max(0, $includedPages - $preservedReady),
+                            'excluded' => 0,
+                        ],
+                        'retry_allowed' => false,
+                        'execution_progress_percent' => $executionProgress,
+                        'readiness' => 'processing',
+                        'is_ready' => false,
+                    ],
+                ],
+                'units_finalized_source_version' => null,
+                'units_reconciled_source_version' => null,
+                'units_reconcile_claim_token' => null,
+                'units_reconcile_lease_expires_at' => null,
                 'meta' => [
-                    ...(is_array($document->meta) ? $document->meta : []),
+                    ...$meta,
                     'processing_attempt_id' => $attemptId,
                 ],
             ])->saveQuietly();
@@ -35,7 +82,7 @@ final class LaravelEstimateGenerationRetryDispatcher implements EstimateGenerati
                     'document_manifest',
                     attemptId: $attemptId,
                     documentId: (int) $document->getKey(),
-                    sourceVersion: DocumentSourceVersion::fromDocument($document),
+                    sourceVersion: $sourceVersion,
                 ),
             )
                 ->onConnection(ProcessEstimateGenerationDocumentJob::CONNECTION)

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/SessionSnapshotData.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Sessions/SessionSnapshotData.php
@@ -45,6 +45,7 @@ final readonly class SessionSnapshotData
             'reservation_status' => null,
         ],
         public ?string $recommendedStep = null,
+        public array $workflowSteps = [],
     ) {}
 
     /** @return array<string, mixed> */
@@ -66,6 +67,7 @@ final readonly class SessionSnapshotData
             'warnings' => $this->warnings,
             'next_action' => $this->nextAction,
             'recommended_step' => $this->recommendedStep,
+            'workflow_steps' => $this->workflowSteps,
             'readiness_evaluated' => $this->readinessEvaluated,
             'documents_summary' => $this->documentsSummary,
             'estimate_summary' => $this->estimateSummary,
@@ -94,6 +96,7 @@ final readonly class SessionSnapshotData
             'warnings' => $this->warnings,
             'next_action' => $this->nextAction,
             'recommended_step' => $this->recommendedStep,
+            'workflow_steps' => $this->workflowSteps,
             'readiness_evaluated' => $this->readinessEvaluated,
             'can_generate' => $this->canGenerate,
             'can_apply' => $this->canApply,

--- a/app/BusinessModules/Addons/EstimateGeneration/Http/Resources/EstimateGenerationSessionResource.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Http/Resources/EstimateGenerationSessionResource.php
@@ -23,23 +23,29 @@ final class EstimateGenerationSessionResource extends JsonResource
 
         /** @var EstimateGenerationSession $session */
         $session = $this->resource;
+        $readiness = app(EstimatorReadinessService::class)->evaluate($session);
         $snapshot = app(BuildSessionSnapshot::class)->handle(
             session: $session,
             permissions: EstimateGenerationSessionListResource::permissions($request, $session),
-            readinessSummary: app(EstimatorReadinessService::class)->evaluate($session),
-            documentsSummary: $this->documentsSummary($session),
+            readinessSummary: $readiness,
+            documentsSummary: $this->documentsSummary(
+                $session,
+                (int) ($readiness->metrics['drawing_elements'] ?? 0),
+            ),
         );
 
         return $snapshot->toArray();
     }
 
     /** @return array<string, mixed> */
-    private function documentsSummary(EstimateGenerationSession $session): array
+    private function documentsSummary(EstimateGenerationSession $session, int $drawingElements): array
     {
-        if (!$session->relationLoaded('documents')) {
+        if (! $session->relationLoaded('documents')) {
             return [];
         }
 
-        return app(DocumentGenerationReadinessService::class)->evaluate($session)['summary'] ?? [];
+        $summary = app(DocumentGenerationReadinessService::class)->evaluate($session)['summary'] ?? [];
+
+        return [...$summary, 'drawing_elements' => $drawingElements];
     }
 }

--- a/docs/specs/2026-08-13-vision-retry-lineage-workflow-steps.md
+++ b/docs/specs/2026-08-13-vision-retry-lineage-workflow-steps.md
@@ -1,0 +1,26 @@
+# Vision retry lineage and workflow steps
+
+## Incident evidence
+
+The controlled retry for document `170` created a new document processing attempt and reset the units, but no new Vision physical-attempt rows were inserted. Two units replayed the old terminal HTTP 400 rows and the document breaker stopped the remaining twenty units. The diagnostic response inspector therefore had no new response stream to inspect.
+
+## Contracts
+
+- A processing attempt identifier is part of every primary and targeted sheet-analysis operation identity.
+- Lease retries and concurrent delivery inside one processing attempt keep the same identity.
+- A new explicit document retry keeps the pinned source/model contract but receives a different operation and physical-attempt identity.
+- The session snapshot exposes canonical `workflow_steps` entries with `id`, `available`, and `recommended`.
+- With zero usable document results and a recoverable system failure, `documents` is the only recommended recovery step; geometry and downstream steps are unavailable.
+- Partial success keeps geometry review available when at least one usable result exists, but keeps downstream steps unavailable while document recovery is required.
+- A fully recovered document set recalculates geometry and downstream availability and recommends geometry review at the input-review checkpoint.
+
+## Verification
+
+- Unit regressions for primary/targeted identities and session step policy.
+- Isolated PostgreSQL contract proving unit metadata reaches the execution context unchanged.
+- Admin Vitest/MSW regressions for zero usable system failure, partial success, and normal success.
+- PHP syntax, Pint, targeted Larastan, TypeScript, ESLint, and Prettier gates.
+
+## Release boundary
+
+This release does not change the Luna request payload and must not trigger a production Vision call. A later user-authorized retry is required to capture the provider's exact HTTP 400 parameter safely.

--- a/tests/Architecture/EstimateGenerationMutationAtomicityTest.php
+++ b/tests/Architecture/EstimateGenerationMutationAtomicityTest.php
@@ -70,6 +70,35 @@ final class EstimateGenerationMutationAtomicityTest extends TestCase
     }
 
     #[Test]
+    public function document_retry_lineage_is_propagated_before_units_are_dispatched(): void
+    {
+        $dispatcher = $this->source('Application/Sessions/LaravelEstimateGenerationRetryDispatcher.php');
+        $creator = $this->source('Application/Documents/CreateDocumentProcessingUnits.php');
+
+        self::assertStringContainsString("'processing_attempt_id' => \$attemptId", $dispatcher);
+        self::assertStringContainsString('$this->resetter->handle(', $dispatcher);
+        self::assertStringContainsString("'attempt_count' => 0", $this->source('Application/Documents/ResetDocumentProcessingUnitsForAttempt.php'));
+        self::assertStringContainsString("'processing_attempt_id' => \$processingAttemptId", $creator);
+        self::assertLessThan(
+            strpos($dispatcher, 'ProcessEstimateGenerationDocumentJob::dispatch('),
+            strpos($dispatcher, '$this->resetter->handle('),
+        );
+    }
+
+    #[Test]
+    public function ordinary_session_resource_uses_readiness_geometry_evidence_for_workflow_gating(): void
+    {
+        $resource = $this->source('Http/Resources/EstimateGenerationSessionResource.php');
+
+        self::assertStringContainsString("\$readiness->metrics['drawing_elements']", $resource);
+        self::assertStringContainsString("'drawing_elements' => \$drawingElements", $resource);
+        self::assertLessThan(
+            strpos($resource, 'documentsSummary('),
+            strpos($resource, '$readiness = app(EstimatorReadinessService::class)->evaluate($session)'),
+        );
+    }
+
+    #[Test]
     public function geometry_confirmation_starts_generation_through_the_quota_aware_workflow(): void
     {
         $source = $this->source('Application/Geometry/ConfirmBuildingGeometry.php');

--- a/tests/Feature/EstimateGeneration/Pipeline/DocumentRepresentationJsonbRoundTripPostgresTest.php
+++ b/tests/Feature/EstimateGeneration/Pipeline/DocumentRepresentationJsonbRoundTripPostgresTest.php
@@ -9,6 +9,7 @@ use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\Eloquent
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\EloquentDocumentUnitAggregateReconciler;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ProcessDocumentUnit;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ReconcileEstimateGenerationDocuments;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ResetDocumentProcessingUnitsForAttempt;
 use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationDocument;
 use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationDocumentPage;
 use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationProcessingUnit;
@@ -17,6 +18,7 @@ use App\BusinessModules\Addons\EstimateGeneration\Services\Quality\DocumentReadi
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\User;
+use Carbon\CarbonImmutable;
 use DateTimeImmutable;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\TestCase;
@@ -184,6 +186,7 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
             'filename' => 'unrelated.pdf',
             'mime_type' => 'application/pdf',
             'source_version' => $sourceVersion,
+            'meta' => ['processing_attempt_id' => 'document-fallback-attempt'],
         ]);
         $units = [];
         $attemptId = 'd173fcc2-5f5c-44b1-91f1-94034f1b0bb5';
@@ -259,6 +262,12 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
         foreach (array_slice($units, 0, 2) as $unit) {
             $claims[] = $store->claim($unit->id, $sourceVersion, $now, $now->modify('+60 seconds'), ProcessDocumentUnit::MAX_ATTEMPTS);
         }
+        CarbonImmutable::setTestNow($now);
+        try {
+            self::assertSame($attemptId, $store->executionContext($claims[0])?->processingAttemptId);
+        } finally {
+            CarbonImmutable::setTestNow();
+        }
         $fingerprint = hash('sha256', 'shared-systemic-root');
 
         $processes = [];
@@ -310,6 +319,48 @@ final class DocumentRepresentationJsonbRoundTripPostgresTest extends TestCase
         self::assertSame('pending', EstimateGenerationProcessingUnit::query()->findOrFail($unrelated->id)->status->value);
         self::assertSame('pending', EstimateGenerationProcessingUnit::query()->findOrFail($differentLineage->id)->status->value);
         self::assertSame('pending', EstimateGenerationProcessingUnit::query()->findOrFail($differentContract->id)->status->value);
+
+        $fallbackClaim = $store->claim(
+            $unrelated->id,
+            $sourceVersion,
+            $now,
+            $now->modify('+60 seconds'),
+            ProcessDocumentUnit::MAX_ATTEMPTS,
+        );
+        CarbonImmutable::setTestNow($now);
+        try {
+            self::assertSame('document-fallback-attempt', $store->executionContext($fallbackClaim)?->processingAttemptId);
+        } finally {
+            CarbonImmutable::setTestNow();
+        }
+
+        $newAttemptId = '8db877c2-b97d-453e-af34-c0af97295ed1';
+        self::assertSame(
+            0,
+            (new ResetDocumentProcessingUnitsForAttempt)->handle($document, $sourceVersion, $attemptId, $newAttemptId),
+        );
+        $reset = EstimateGenerationProcessingUnit::query()
+            ->whereIn('id', array_map(static fn ($unit): int => (int) $unit->id, $units))
+            ->orderBy('unit_index')
+            ->get();
+        self::assertSame(['pending', 'pending', 'pending', 'pending', 'pending'], $reset->pluck('status')->map->value->all());
+        self::assertSame([0, 0, 0, 0, 0], $reset->pluck('attempt_count')->all());
+        self::assertSame([$newAttemptId], $reset->pluck('metadata.processing_attempt_id')->unique()->values()->all());
+        self::assertSame($attemptId, $reset[0]->metadata['failure_history'][0]['attempt_id']);
+
+        $newClaim = $store->claim(
+            (int) $reset[0]->id,
+            $sourceVersion,
+            $now,
+            $now->modify('+60 seconds'),
+            ProcessDocumentUnit::MAX_ATTEMPTS,
+        );
+        CarbonImmutable::setTestNow($now);
+        try {
+            self::assertSame($newAttemptId, $store->executionContext($newClaim)?->processingAttemptId);
+        } finally {
+            CarbonImmutable::setTestNow();
+        }
     }
 
     #[Test]

--- a/tests/Unit/EstimateGeneration/SheetAnalysisRoutingContractTest.php
+++ b/tests/Unit/EstimateGeneration/SheetAnalysisRoutingContractTest.php
@@ -23,15 +23,24 @@ final class SheetAnalysisRoutingContractTest extends TestCase
     }
 
     #[Test]
-    public function targeted_operation_identity_is_stable_across_unit_lease_retries_and_changes_for_a_new_target(): void
+    public function operation_identities_are_stable_inside_one_processing_lineage_and_change_for_a_new_explicit_retry(): void
     {
         $routing = ['role' => 'plan', 'reanalysis_reason' => 'sheet_role_insufficient_evidence'];
+        $firstLineage = 'd173fcc2-5f5c-44b1-91f1-94034f1b0bb5';
+        $secondLineage = '51462476-b870-44eb-b31d-1b5d74d511e9';
 
-        $first = SheetAnalysisOperationIdentity::targeted(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $routing);
-        $retry = SheetAnalysisOperationIdentity::targeted(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $routing);
-        $changedTarget = SheetAnalysisOperationIdentity::targeted(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), ['role' => 'section', 'reanalysis_reason' => 'sheet_role_conflict']);
+        $primary = SheetAnalysisOperationIdentity::primary(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $firstLineage);
+        $primaryLeaseReplay = SheetAnalysisOperationIdentity::primary(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $firstLineage);
+        $primaryExplicitRetry = SheetAnalysisOperationIdentity::primary(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $secondLineage);
+        $first = SheetAnalysisOperationIdentity::targeted(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $firstLineage, $routing);
+        $leaseReplay = SheetAnalysisOperationIdentity::targeted(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $firstLineage, $routing);
+        $explicitRetry = SheetAnalysisOperationIdentity::targeted(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $secondLineage, $routing);
+        $changedTarget = SheetAnalysisOperationIdentity::targeted(4, 5, 6, 'sha256:'.str_repeat('a', 64), 'sha256:'.str_repeat('b', 64), $firstLineage, ['role' => 'section', 'reanalysis_reason' => 'sheet_role_conflict']);
 
-        self::assertSame($first, $retry);
+        self::assertSame($primary, $primaryLeaseReplay);
+        self::assertNotSame($primary, $primaryExplicitRetry);
+        self::assertSame($first, $leaseReplay);
+        self::assertNotSame($first, $explicitRetry);
         self::assertNotSame($first, $changedTarget);
     }
 

--- a/tests/Unit/EstimateGeneration/Workflow/BuildSessionSnapshotTest.php
+++ b/tests/Unit/EstimateGeneration/Workflow/BuildSessionSnapshotTest.php
@@ -199,13 +199,118 @@ final class BuildSessionSnapshotTest extends TestCase
                 'pending' => 0,
                 'action_required' => 0,
                 'ignored' => 0,
+                'drawing_elements' => 0,
             ],
         );
 
         self::assertSame('documents', $snapshot->recommendedStep);
         self::assertSame('documents', $snapshot->toArray()['recommended_step']);
+        self::assertSame([
+            ['id' => 'object', 'available' => true, 'recommended' => false],
+            ['id' => 'documents', 'available' => true, 'recommended' => true],
+            ['id' => 'geometry', 'available' => false, 'recommended' => false],
+            ['id' => 'building', 'available' => false, 'recommended' => false],
+            ['id' => 'draft', 'available' => false, 'recommended' => false],
+            ['id' => 'review', 'available' => false, 'recommended' => false],
+            ['id' => 'summary', 'available' => false, 'recommended' => false],
+        ], $snapshot->workflowSteps);
         self::assertFalse($snapshot->canGenerate);
         self::assertFalse($snapshot->canApply);
+    }
+
+    #[Test]
+    public function partial_document_success_keeps_geometry_available_but_recommends_recovery(): void
+    {
+        $session = $this->makeSession(EstimateGenerationStatus::Failed);
+        $session->forceFill([
+            'resume_status' => EstimateGenerationStatus::ProcessingDocuments,
+            'failure_code' => 'document_processing_system_failed',
+        ]);
+
+        $snapshot = app(BuildSessionSnapshot::class)->handle(
+            session: $session,
+            permissions: ['estimate_generation.generate'],
+            readinessSummary: ['blockers' => [], 'warnings' => []],
+            documentsSummary: [
+                'total' => 22,
+                'ready' => 7,
+                'pending' => 0,
+                'action_required' => 0,
+                'ignored' => 0,
+                'drawing_elements' => 12,
+            ],
+        );
+
+        self::assertSame('documents', $snapshot->recommendedStep);
+        self::assertTrue($snapshot->workflowSteps[2]['available']);
+        self::assertFalse($snapshot->workflowSteps[3]['available']);
+        self::assertFalse($snapshot->workflowSteps[6]['available']);
+    }
+
+    #[Test]
+    public function successful_recovery_recommends_geometry_and_unlocks_downstream_steps(): void
+    {
+        $snapshot = app(BuildSessionSnapshot::class)->handle(
+            session: $this->makeSession(EstimateGenerationStatus::InputReviewRequired),
+            permissions: ['estimate_generation.review'],
+            readinessSummary: ['blockers' => [], 'warnings' => []],
+            documentsSummary: [
+                'total' => 22,
+                'ready' => 22,
+                'pending' => 0,
+                'action_required' => 0,
+                'ignored' => 0,
+                'drawing_elements' => 24,
+            ],
+        );
+
+        self::assertSame('geometry', $snapshot->recommendedStep);
+        self::assertTrue($snapshot->workflowSteps[2]['recommended']);
+        self::assertTrue($snapshot->workflowSteps[6]['available']);
+    }
+
+    #[Test]
+    public function ignored_documents_count_as_terminal_without_hiding_usable_geometry(): void
+    {
+        $snapshot = app(BuildSessionSnapshot::class)->handle(
+            session: $this->makeSession(EstimateGenerationStatus::InputReviewRequired),
+            permissions: ['estimate_generation.review'],
+            readinessSummary: ['blockers' => [], 'warnings' => []],
+            documentsSummary: [
+                'total' => 2,
+                'ready' => 1,
+                'pending' => 0,
+                'action_required' => 0,
+                'ignored' => 1,
+                'drawing_elements' => 4,
+            ],
+        );
+
+        self::assertSame('geometry', $snapshot->recommendedStep);
+        self::assertTrue($snapshot->workflowSteps[2]['available']);
+        self::assertTrue($snapshot->workflowSteps[6]['available']);
+    }
+
+    #[Test]
+    public function ready_documents_without_geometry_evidence_do_not_expose_geometry_review(): void
+    {
+        $snapshot = app(BuildSessionSnapshot::class)->handle(
+            session: $this->makeSession(EstimateGenerationStatus::InputReviewRequired),
+            permissions: ['estimate_generation.review'],
+            readinessSummary: ['blockers' => [], 'warnings' => []],
+            documentsSummary: [
+                'total' => 2,
+                'ready' => 2,
+                'pending' => 0,
+                'action_required' => 0,
+                'ignored' => 0,
+                'drawing_elements' => 0,
+            ],
+        );
+
+        self::assertNull($snapshot->recommendedStep);
+        self::assertFalse($snapshot->workflowSteps[2]['available']);
+        self::assertTrue($snapshot->workflowSteps[3]['available']);
     }
 
     #[Test]
@@ -284,6 +389,7 @@ final class BuildSessionSnapshotTest extends TestCase
             'object_input',
             'available_actions', 'blocking_issues', 'warnings', 'next_action',
             'recommended_step',
+            'workflow_steps',
             'readiness_evaluated',
             'documents_summary', 'estimate_summary', 'review_summary',
             'scope_summary',

--- a/tests/Unit/EstimateGeneration/Workflow/SessionOperationalSnapshotDataTest.php
+++ b/tests/Unit/EstimateGeneration/Workflow/SessionOperationalSnapshotDataTest.php
@@ -95,6 +95,10 @@ final class SessionOperationalSnapshotDataTest extends TestCase
             appliedEstimateId: null,
             updatedAt: '2026-07-11T12:00:00+00:00',
             objectInput: ['parameters' => []],
+            workflowSteps: [
+                ['id' => 'documents', 'available' => true, 'recommended' => true],
+                ['id' => 'geometry', 'available' => false, 'recommended' => false],
+            ],
         );
 
         $payload = $snapshot->toArray();
@@ -105,6 +109,8 @@ final class SessionOperationalSnapshotDataTest extends TestCase
         self::assertSame('0.12345678', $payload['usage_summary']['cost_amount']);
         self::assertSame(4000000, $payload['estimate_summary']['items']);
         self::assertSame('{}', json_encode($payload['object_input']['parameters'], JSON_THROW_ON_ERROR));
+        self::assertSame('documents', $payload['workflow_steps'][0]['id']);
+        self::assertFalse($payload['workflow_steps'][1]['available']);
         self::assertArrayNotHasKey('lease_age_seconds', $payload['current_checkpoint']);
         self::assertSame([], array_intersect(
             ['pages', 'facts', 'text', 'prompt', 'payload', 'storage_path', 'provider_secret'],


### PR DESCRIPTION
## Что изменено
- новый processing attempt включён в identity primary/targeted Vision operations
- session и explicit retry используют единый атомарный reset units с failure history
- workflow_steps учитывают system failure, geometry evidence и ignored documents
- обычный и operational snapshot отдают единый навигационный контракт

## Проверки
- targeted PHPUnit: 18 tests / 122 assertions
- PostgreSQL concurrency/lineage contract: 1 test / 18 assertions
- php-l, Pint, targeted Larastan
- независимое correctness/security/architecture review: blockers закрыты

Luna payload не менялся: контролируемый retry переиспользовал старые physical attempts, поэтому точный rejected parameter ещё не доказан.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a processing attempt identifier to document processing units to track retry lineage.</li>
<li>Updated document processing unit creation and synchronization logic to include and maintain the processing attempt ID in metadata.</li>
<li>Enhanced session snapshot and resource logic to support workflow gating based on readiness and geometry evidence.</li>
<li>Added architectural and feature tests to verify the propagation of retry lineage and workflow gating policies.</li>
<li>Documented the new retry lineage and workflow steps in a technical specification.</li>
</ul></div>