### PR TITLE
fix[backend]: сохранена диагностика ошибок обработки документов

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/EloquentDocumentProcessingUnitStore.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/EloquentDocumentProcessingUnitStore.php
@@ -176,6 +176,12 @@ final readonly class EloquentDocumentProcessingUnitStore implements DocumentProc
                     'document_representation_source_mismatch',
                     'vision_provider_request_rejected',
                     'vision_http_failed',
+                    'document_unit_pre_wire_failed',
+                    'vision_operation_settings_failed',
+                    'vision_request_preparation_failed',
+                    'vision_physical_claim_failed',
+                    'vision_physical_attempt_persistence_failed',
+                    'vision_provider_response_invalid',
                 ])
                 ->selectRaw('count(*) as aggregate')
                 ->groupBy('failure_fingerprint')

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ExplicitDocumentRetryEligibility.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ExplicitDocumentRetryEligibility.php
@@ -21,6 +21,12 @@ final readonly class ExplicitDocumentRetryEligibility
         'document_unit_processing_failed',
         'vision_provider_request_rejected',
         'vision_http_failed',
+        'document_unit_pre_wire_failed',
+        'vision_operation_settings_failed',
+        'vision_request_preparation_failed',
+        'vision_physical_claim_failed',
+        'vision_physical_attempt_persistence_failed',
+        'vision_provider_response_invalid',
     ];
 
     private const BREAKER_FAILURE_CODES = [

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/InMemoryDocumentProcessingUnitStore.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/InMemoryDocumentProcessingUnitStore.php
@@ -14,6 +14,12 @@ final class InMemoryDocumentProcessingUnitStore implements DocumentProcessingUni
 
     private const SYSTEMIC_FAILURE_CODES = [
         'document_unit_processing_failed',
+        'document_unit_pre_wire_failed',
+        'vision_operation_settings_failed',
+        'vision_request_preparation_failed',
+        'vision_physical_claim_failed',
+        'vision_physical_attempt_persistence_failed',
+        'vision_provider_response_invalid',
         'unexpected_internal_failure',
         'document_representation_contract_invalid',
         'document_representation_source_mismatch',

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProcessDocumentUnit.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProcessDocumentUnit.php
@@ -81,8 +81,22 @@ final readonly class ProcessDocumentUnit
                 throw new DocumentUnitProcessingException('unit_output_identity_mismatch');
             }
 
-            if (! $this->store->publish($claim, $output, now()->toDateTimeImmutable())) {
-                throw new TypedFailureException(FailureCategory::Recoverable, 'unit_claim_lost');
+            try {
+                $published = $this->store->publish($claim, $output, now()->toDateTimeImmutable());
+            } catch (Throwable $error) {
+                throw new TypedFailureException(
+                    FailureCategory::Recoverable,
+                    'document_unit_output_persistence_failed',
+                    ['execution_boundary' => 'document_unit_output_persistence'],
+                    $error,
+                );
+            }
+            if (! $published) {
+                throw new TypedFailureException(
+                    FailureCategory::Recoverable,
+                    'unit_claim_lost',
+                    ['execution_boundary' => 'document_unit_output_persistence'],
+                );
             }
 
             try {
@@ -95,23 +109,44 @@ final readonly class ProcessDocumentUnit
             $fingerprint = is_string($diagnosticFingerprint)
                 ? substr($diagnosticFingerprint, strlen('sha256:'))
                 : $this->failureFingerprint($error, $failure->code);
-            $persisted = $this->store->fail(
-                $claim,
-                $failure->code,
-                $fingerprint,
-                now()->toDateTimeImmutable(),
-                $failure->category,
-                $failure->category === FailureCategory::Terminal
-                    && in_array($failure->code, [
-                        'document_unit_processing_failed',
-                        'unexpected_internal_failure',
-                        'document_representation_contract_invalid',
-                        'document_representation_source_mismatch',
-                        'vision_provider_request_rejected',
-                        'vision_http_failed',
-                    ], true),
-                $this->resourceUsage($error),
-            );
+            try {
+                $persisted = $this->store->fail(
+                    $claim,
+                    $failure->code,
+                    $fingerprint,
+                    now()->toDateTimeImmutable(),
+                    $failure->category,
+                    $failure->category === FailureCategory::Terminal
+                        && in_array($failure->code, [
+                            'document_unit_processing_failed',
+                            'document_unit_pre_wire_failed',
+                            'vision_operation_settings_failed',
+                            'vision_request_preparation_failed',
+                            'vision_physical_claim_failed',
+                            'vision_physical_attempt_persistence_failed',
+                            'vision_provider_response_invalid',
+                            'unexpected_internal_failure',
+                            'document_representation_contract_invalid',
+                            'document_representation_source_mismatch',
+                            'vision_provider_request_rejected',
+                            'vision_http_failed',
+                        ], true),
+                    $this->resourceUsage($error),
+                );
+            } catch (Throwable $persistenceError) {
+                $persistenceFailure = new TypedFailureException(
+                    FailureCategory::Recoverable,
+                    'document_unit_failure_persistence_failed',
+                    [
+                        'execution_boundary' => 'document_unit_failure_persistence',
+                        'failure_fingerprint' => $failure->fingerprint,
+                    ],
+                    $persistenceError,
+                );
+                $this->failureRecorder->capture($persistenceFailure, $this->failureContext($context));
+
+                throw $persistenceFailure;
+            }
 
             if (! $persisted) {
                 throw new TypedFailureException(FailureCategory::Recoverable, 'unit_claim_lost', previous: $error);
@@ -176,6 +211,14 @@ final readonly class ProcessDocumentUnit
             documentId: $context->documentId,
             pageId: $context->pageId,
             unitId: $context->unitId,
+            processingAttemptId: $this->processingAttemptId($context),
         );
+    }
+
+    private function processingAttemptId(DocumentUnitExecutionContext $context): ?string
+    {
+        return preg_match('/\A[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i', $context->processingAttemptId) === 1
+            ? strtolower($context->processingAttemptId)
+            : null;
     }
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProductionDocumentUnitProcessor.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ProductionDocumentUnitProcessor.php
@@ -59,6 +59,7 @@ final readonly class ProductionDocumentUnitProcessor implements DocumentUnitProc
         } catch (DocumentRepresentationMeasurementException $exception) {
             throw $this->processingFailure(
                 $exception->getPrevious() ?? $exception,
+                $context,
                 [
                     'duration_ms' => $exception->measurement->durationMs,
                     'peak_memory_bytes' => $exception->measurement->incrementalPeakMemoryBytes,
@@ -67,23 +68,32 @@ final readonly class ProductionDocumentUnitProcessor implements DocumentUnitProc
                 ],
             );
         } catch (Throwable $exception) {
-            throw $this->processingFailure($exception);
+            throw $this->processingFailure($exception, $context);
         }
     }
 
     /** @param array<string, mixed> $resourceUsage */
-    private function processingFailure(Throwable $exception, array $resourceUsage = []): Throwable
-    {
+    private function processingFailure(
+        Throwable $exception,
+        DocumentUnitExecutionContext $context,
+        array $resourceUsage = [],
+    ): Throwable {
         return match (true) {
             $exception instanceof DocumentUnitProcessingException => $resourceUsage === []
                 ? $exception
                 : new DocumentUnitProcessingException($exception->safeCode, $exception, $resourceUsage),
             $exception instanceof TypedFailureException => $resourceUsage === []
-                ? $exception
+                ? new TypedFailureException(
+                    $exception->category,
+                    $exception->safeCode,
+                    [...$this->boundaryContext($context), ...$exception->safeContext],
+                    $exception->getPrevious() ?? $exception,
+                    $exception->resourceUsage,
+                )
                 : new TypedFailureException(
                     $exception->category,
                     $exception->safeCode,
-                    $exception->safeContext,
+                    [...$this->boundaryContext($context), ...$exception->safeContext],
                     $exception,
                     $resourceUsage,
                 ),
@@ -106,6 +116,16 @@ final readonly class ProductionDocumentUnitProcessor implements DocumentUnitProc
                 $exception,
                 $resourceUsage,
             ),
+            $exception instanceof VisionContractException => new TypedFailureException(
+                FailureCategory::Terminal,
+                'vision_provider_response_invalid',
+                [
+                    ...$this->boundaryContext($context),
+                    'execution_boundary' => 'vision_provider_response_parsing',
+                ],
+                $exception,
+                $resourceUsage,
+            ),
             $exception instanceof VisionProviderException => new TypedFailureException(
                 $exception->retryable ? FailureCategory::Recoverable : FailureCategory::Terminal,
                 $exception->reason,
@@ -122,8 +142,25 @@ final readonly class ProductionDocumentUnitProcessor implements DocumentUnitProc
                 previous: $exception,
                 resourceUsage: $resourceUsage,
             ),
-            default => new DocumentUnitProcessingException('document_unit_processing_failed', $exception, $resourceUsage),
+            default => new TypedFailureException(
+                FailureCategory::Terminal,
+                'document_unit_pre_wire_failed',
+                $this->boundaryContext($context),
+                $exception,
+                $resourceUsage,
+            ),
         };
+    }
+
+    /** @return array<string, string> */
+    private function boundaryContext(DocumentUnitExecutionContext $context): array
+    {
+        return [
+            'execution_boundary' => 'document_unit_representation',
+            ...(preg_match('/\A[0-9a-f-]{36}\z/i', $context->processingAttemptId) === 1
+                ? ['processing_attempt_id' => strtolower($context->processingAttemptId)]
+                : []),
+        ];
     }
 
     private function processMeasured(DocumentUnitExecutionContext $context): DocumentUnitOutput

--- a/app/BusinessModules/Addons/EstimateGeneration/EstimateGenerationServiceProvider.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/EstimateGenerationServiceProvider.php
@@ -156,8 +156,10 @@ use App\BusinessModules\Addons\EstimateGeneration\Observability\AiUsageStore;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\AttemptAwareNormativeLlmClient;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\EloquentAiUsageStore;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\EloquentFailureStore;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureRecorderObserver;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureStore;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\RerankWireClient;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\SafeLogFailureRecorderObserver;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\TimewebRerankWireClient;
 use App\BusinessModules\Addons\EstimateGeneration\Pipeline\EloquentGenerationPipelineDataGateway;
 use App\BusinessModules\Addons\EstimateGeneration\Pipeline\EloquentPipelineCheckpointStore;
@@ -630,6 +632,7 @@ class EstimateGenerationServiceProvider extends ServiceProvider
             \App\BusinessModules\Addons\EstimateGeneration\Vision\PhysicalAttempt\EloquentVisionPhysicalAttemptStore::class,
         );
         $this->app->singleton(FailureStore::class, EloquentFailureStore::class);
+        $this->app->singleton(FailureRecorderObserver::class, SafeLogFailureRecorderObserver::class);
         $this->app->singleton(PipelineCompletionHook::class, PublishValidatedDraft::class);
         $this->app->singleton(PublishDraftOnce::class, EloquentPublishDraftOnce::class);
         $this->app->singleton(PipelineDefinitionGraph::class, static fn (): PipelineDefinitionGraph => PipelineDefinitionGraph::standard());

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureContext.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureContext.php
@@ -27,6 +27,7 @@ final readonly class FailureContext
         public ?string $usageAttemptId = null,
         public ?string $provider = null,
         public ?string $model = null,
+        public ?string $processingAttemptId = null,
     ) {
         foreach ([$organizationId, $projectId, $sessionId, $attempt] as $value) {
             if ($value < 1) {
@@ -47,8 +48,11 @@ final readonly class FailureContext
         if ($provider !== null && (preg_match('/\A[a-z][a-z0-9_]{0,39}\z/', $provider) !== 1 || self::looksSensitive($provider))) {
             throw new InvalidArgumentException('Invalid failure provider.');
         }
-        if ($model !== null && (preg_match('/\A[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}\z/', $model) !== 1 || self::looksSensitive($model))) {
+        if ($model !== null && (! self::isSafeModel($model) || self::looksSensitiveModel($model))) {
             throw new InvalidArgumentException('Invalid failure model.');
+        }
+        if ($processingAttemptId !== null && ! self::isUuid($processingAttemptId)) {
+            throw new InvalidArgumentException('Invalid failure processing attempt identifier.');
         }
         if (($pageId !== null || $unitId !== null) && $documentId === null) {
             throw new InvalidArgumentException('Failure page and unit scopes require a document.');
@@ -69,5 +73,15 @@ final readonly class FailureContext
     private static function looksSensitive(string $value): bool
     {
         return preg_match('/(?:token|secret|password|bearer|api[_-]?key|[\\\\\/]|\.\.|eyJ|sk-|gh[pousr]_)/i', $value) === 1;
+    }
+
+    private static function isSafeModel(string $value): bool
+    {
+        return preg_match('/\A[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}(?:\/[a-zA-Z0-9][a-zA-Z0-9._-]{0,79})?\z/', $value) === 1;
+    }
+
+    private static function looksSensitiveModel(string $value): bool
+    {
+        return preg_match('/(?:token|secret|password|bearer|api[_-]?key|\.\.|eyJ|sk-|gh[pousr]_)/i', $value) === 1;
     }
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureDiagnosticIdentity.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureDiagnosticIdentity.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\BusinessModules\Addons\EstimateGeneration\Observability;
 
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentUnitProcessingException;
+use App\BusinessModules\Addons\EstimateGeneration\Vision\Exceptions\VisionContractException;
+use App\BusinessModules\Addons\EstimateGeneration\Vision\Exceptions\VisionProviderException;
 use Illuminate\Database\QueryException;
 use InvalidArgumentException;
 use LogicException;
@@ -16,6 +18,9 @@ final readonly class FailureDiagnosticIdentity
 {
     private const CLASS_SLUGS = [
         DocumentUnitProcessingException::class => 'document_unit_processing_exception',
+        TypedFailureException::class => 'typed_failure_exception',
+        VisionProviderException::class => 'vision_provider_exception',
+        VisionContractException::class => 'vision_contract_exception',
         QueryException::class => 'query_exception',
         PDOException::class => 'pdo_exception',
         InvalidArgumentException::class => 'invalid_argument_exception',

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureNormalizer.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureNormalizer.php
@@ -43,10 +43,19 @@ final readonly class FailureNormalizer
 
         $diagnostics = [
             ...$this->diagnostics->forThrowable($error, $this->executionBoundary($context)),
+            ...($context->model === null ? [] : ['requested_model' => $context->model]),
             ...$diagnostics,
+            ...($context->processingAttemptId === null ? [] : ['processing_attempt_id' => $context->processingAttemptId]),
         ];
 
-        return new FailureData($context, $category, $code, $this->sanitizer->sanitize($diagnostics));
+        $safeDiagnostics = $this->sanitizer->sanitize($diagnostics);
+
+        return new FailureData(
+            $this->effectiveProviderContext($context, $safeDiagnostics),
+            $category,
+            $code,
+            $safeDiagnostics,
+        );
     }
 
     /** @return array{FailureCategory, string, array<string, mixed>} */
@@ -94,5 +103,36 @@ final readonly class FailureNormalizer
         return $context->operation === 'process_unit'
             ? 'document_unit_processor'
             : $this->safeKnownCode($context->operation, 'application_operation');
+    }
+
+    /** @param array<string, int|string> $diagnostics */
+    private function effectiveProviderContext(FailureContext $context, array $diagnostics): FailureContext
+    {
+        $provider = is_string($diagnostics['provider'] ?? null) ? $diagnostics['provider'] : $context->provider;
+        $model = is_string($diagnostics['requested_model'] ?? null) ? $diagnostics['requested_model'] : $context->model;
+        if ($provider === $context->provider && $model === $context->model) {
+            return $context;
+        }
+
+        return new FailureContext(
+            organizationId: $context->organizationId,
+            projectId: $context->projectId,
+            sessionId: $context->sessionId,
+            stage: $context->stage,
+            operation: $context->operation,
+            attempt: $context->attempt,
+            correlationId: $context->correlationId,
+            eventId: $context->eventId,
+            expectedSessionStateVersion: $context->expectedSessionStateVersion,
+            expectedSessionStatus: $context->expectedSessionStatus,
+            documentId: $context->documentId,
+            pageId: $context->pageId,
+            unitId: $context->unitId,
+            checkpointId: $context->checkpointId,
+            usageAttemptId: $context->usageAttemptId,
+            provider: $provider,
+            model: $model,
+            processingAttemptId: $context->processingAttemptId,
+        );
     }
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorder.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorder.php
@@ -27,7 +27,7 @@ final readonly class FailureRecorder
             $this->store->record($failure, now()->toDateTimeImmutable());
         } catch (Throwable) {
             try {
-                $this->observer->recordingFailed($failure->code, $failure->fingerprint);
+                $this->observer->recordingFailed($failure);
             } catch (Throwable) {
             }
         }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorderObserver.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorderObserver.php
@@ -6,5 +6,5 @@ namespace App\BusinessModules\Addons\EstimateGeneration\Observability;
 
 interface FailureRecorderObserver
 {
-    public function recordingFailed(string $failureCode, string $fingerprint): void;
+    public function recordingFailed(FailureData $failure): void;
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/NullFailureRecorderObserver.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/NullFailureRecorderObserver.php
@@ -6,5 +6,5 @@ namespace App\BusinessModules\Addons\EstimateGeneration\Observability;
 
 final class NullFailureRecorderObserver implements FailureRecorderObserver
 {
-    public function recordingFailed(string $failureCode, string $fingerprint): void {}
+    public function recordingFailed(FailureData $failure): void {}
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/SafeLogFailureRecorderObserver.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/SafeLogFailureRecorderObserver.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Observability;
+
+use Illuminate\Support\Facades\Log;
+
+final class SafeLogFailureRecorderObserver implements FailureRecorderObserver
+{
+    public function recordingFailed(FailureData $failure): void
+    {
+        Log::error('[EstimateGeneration] failure observability persistence failed', [
+            'failure_code' => $failure->code,
+            'failure_category' => $failure->category->value,
+            'failure_fingerprint' => $failure->fingerprint,
+            'organization_id' => $failure->context->organizationId,
+            'project_id' => $failure->context->projectId,
+            'session_id' => $failure->context->sessionId,
+            'document_id' => $failure->context->documentId,
+            'page_id' => $failure->context->pageId,
+            'unit_id' => $failure->context->unitId,
+            'stage' => $failure->context->stage->value,
+            'operation' => $failure->context->operation,
+            'provider' => $failure->context->provider,
+            'model' => $failure->context->model,
+            'safe_context' => $failure->safeContext,
+        ]);
+    }
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/SensitiveDiagnosticSanitizer.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/SensitiveDiagnosticSanitizer.php
@@ -11,6 +11,7 @@ final readonly class SensitiveDiagnosticSanitizer
     /** @var array<string, array{string, int}> */
     private const STRING_DOMAINS = [
         'provider_code' => ['/\A[a-z][a-z0-9._-]*\z/', 80],
+        'provider' => ['/\A[a-z][a-z0-9_]{0,39}\z/', 40],
         'provider_error_type' => ['/\A[a-zA-Z][a-zA-Z0-9._-]*\z/', 80],
         'provider_error_code' => ['/\A[a-zA-Z][a-zA-Z0-9._-]*\z/', 80],
         'provider_error_param' => ['/\A[a-zA-Z][a-zA-Z0-9_.\[\]-]*\z/', 80],
@@ -32,6 +33,8 @@ final readonly class SensitiveDiagnosticSanitizer
         'exception_class' => ['/\A[a-z][a-z0-9_]{0,79}\z/', 80],
         'root_exception_class' => ['/\A[a-z][a-z0-9_]{0,79}\z/', 80],
         'execution_boundary' => ['/\A[a-z][a-z0-9_]{0,79}\z/', 80],
+        'processing_attempt_id' => ['/\A[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i', 36],
+        'requested_model' => ['/\A[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}(?:\/[a-zA-Z0-9][a-zA-Z0-9._-]{0,79})?\z/', 80],
     ];
 
     /** @var array<string, array{int, int}> */
@@ -75,7 +78,7 @@ final readonly class SensitiveDiagnosticSanitizer
             [$pattern, $maximumLength] = self::STRING_DOMAINS[$key];
             if (strlen($value) <= min($maximumLength, $this->maxStringLength)
                 && preg_match($pattern, $value) === 1
-                && ! $this->looksSecret($value)) {
+                && ! $this->looksSecret($key, $value)) {
                 $result[$key] = $value;
             }
         }
@@ -83,9 +86,9 @@ final readonly class SensitiveDiagnosticSanitizer
         return $result;
     }
 
-    private function looksSecret(string $value): bool
+    private function looksSecret(string $key, string $value): bool
     {
-        return str_contains($value, '/')
+        return ($key !== 'requested_model' && str_contains($value, '/'))
             || str_contains($value, '\\')
             || preg_match('/(?:bearer|api[_-]?key|secret|password|token|eyj[a-z0-9_-]{8,}\.|akia[0-9a-z]{12,}|gh[pousr]_[0-9a-z]{12,}|sk-[0-9a-z]{8,})/i', $value) === 1
             || (strlen($value) >= 24 && preg_match('/\A[A-Za-z0-9_-]+\z/', $value) === 1 && preg_match('/[A-Z]/', $value) === 1 && preg_match('/[a-z]/', $value) === 1 && preg_match('/[0-9]/', $value) === 1);

--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebVisionProvider.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebVisionProvider.php
@@ -59,44 +59,53 @@ final readonly class TimewebVisionProvider implements VisionProvider
     {
         $apiKey = trim((string) config('estimate-generation.vision.api_key', ''));
         $baseUri = rtrim(trim((string) config('estimate-generation.vision.base_uri', '')), '/');
-        $model = $this->settingsResolver?->visionModelForOperation(
-            $input->operationContext->correlationId,
-            $input->organizationId,
-            $input->sessionId,
-            $input->isTargetedSheetReanalysis() ? $input->primaryAnalysis?->requestedModel : null,
-        ) ?? VisionModelPolicy::assertSupported(trim((string) config('estimate-generation.vision.model', '')));
-        $effective = $this->settingsResolver?->forOperation(
-            $input->operationContext->correlationId,
-            $input->organizationId,
-            $input->sessionId,
-        );
-        if ($effective !== null && $input->pageNumber > $effective->maxPagesPerFile()) {
-            throw new VisionProviderException('vision_page_limit_exceeded');
+        $configuredModel = trim((string) config('estimate-generation.vision.model', ''));
+        try {
+            $model = $this->settingsResolver?->visionModelForOperation(
+                $input->operationContext->correlationId,
+                $input->organizationId,
+                $input->sessionId,
+                $input->isTargetedSheetReanalysis() ? $input->primaryAnalysis?->requestedModel : null,
+            ) ?? VisionModelPolicy::assertSupported($configuredModel);
+            $effective = $this->settingsResolver?->forOperation(
+                $input->operationContext->correlationId,
+                $input->organizationId,
+                $input->sessionId,
+            );
+            if ($effective !== null && $input->pageNumber > $effective->maxPagesPerFile()) {
+                throw new VisionProviderException('vision_page_limit_exceeded');
+            }
+            if ($effective !== null) {
+                $this->documentLimits?->assertWithinTotalPages($input->operationContext, $effective);
+            }
+            $modelVersion = VisionModelPolicy::isLuna($model)
+                ? trim((string) config('estimate-generation.vision.model_version', 'timeweb-gpt-5.6-luna-2026-08-13'))
+                : 'timeweb-legacy-vision-2026-07-14';
+            $maxElements = $input->isTargetedSheetReanalysis()
+                ? min(self::effectiveMaxElements(), self::sheetRoutingLimit('max_elements', 96, 1, 500))
+                : self::effectiveMaxElements();
+            $maxFacts = $input->isTargetedSheetReanalysis()
+                ? min($maxElements, self::sheetRoutingLimit('max_facts', 64, 1, 500))
+                : $maxElements;
+            $contractHash = self::promptHash(
+                $maxElements,
+                $maxFacts,
+                $input->sheetRole,
+                $input->isTargetedSheetReanalysis() && $input->primaryAnalysis !== null,
+            );
+            if ((string) config('estimate-generation.vision.provider', '') !== self::PROVIDER
+                || $apiKey === '' || $baseUri === '' || $model === '' || $modelVersion === ''
+                || preg_match('#^[A-Za-z0-9._/-]{1,160}$#', $model) !== 1) {
+                throw new VisionProviderException('vision_not_configured');
+            }
+        } catch (Throwable $exception) {
+            throw $this->preWireFailure(
+                'vision_operation_settings_failed',
+                'vision_operation_settings',
+                $configuredModel,
+                $exception,
+            );
         }
-        if ($effective !== null) {
-            $this->documentLimits?->assertWithinTotalPages($input->operationContext, $effective);
-        }
-        $modelVersion = VisionModelPolicy::isLuna($model)
-            ? trim((string) config('estimate-generation.vision.model_version', 'timeweb-gpt-5.6-luna-2026-08-13'))
-            : 'timeweb-legacy-vision-2026-07-14';
-        $maxElements = $input->isTargetedSheetReanalysis()
-            ? min(self::effectiveMaxElements(), self::sheetRoutingLimit('max_elements', 96, 1, 500))
-            : self::effectiveMaxElements();
-        $maxFacts = $input->isTargetedSheetReanalysis()
-            ? min($maxElements, self::sheetRoutingLimit('max_facts', 64, 1, 500))
-            : $maxElements;
-        $contractHash = self::promptHash(
-            $maxElements,
-            $maxFacts,
-            $input->sheetRole,
-            $input->isTargetedSheetReanalysis() && $input->primaryAnalysis !== null,
-        );
-        if ((string) config('estimate-generation.vision.provider', '') !== self::PROVIDER
-            || $apiKey === '' || $baseUri === '' || $model === '' || $modelVersion === ''
-            || preg_match('#^[A-Za-z0-9._/-]{1,160}$#', $model) !== 1) {
-            throw new VisionProviderException('vision_not_configured');
-        }
-
         if (count($input->nativeReferences) > self::MAX_NATIVE_REFERENCES) {
             throw new DocumentManifestNeedsReview('document_native_registry_provider_limit_exceeded', [
                 'actual' => count($input->nativeReferences),
@@ -105,20 +114,38 @@ final readonly class TimewebVisionProvider implements VisionProvider
                 'processing_unit_id' => $input->processingUnitId,
             ]);
         }
-        $payload = $this->requestPayload($input, $model, $maxElements, $maxFacts, $contractHash);
-        $endpointKind = 'chat_completions';
-        $payloadShapeFingerprint = $this->payloadShapeFingerprint($payload, $contractHash, $endpointKind);
-        $attempts = $effective !== null
-            ? max(1, $effective->retryAttempts('vision') + 1)
-            : max(1, min(5, (int) config('estimate-generation.vision.retry_attempts', 3)));
+        try {
+            $payload = $this->requestPayload($input, $model, $maxElements, $maxFacts, $contractHash);
+            $endpointKind = 'chat_completions';
+            $payloadShapeFingerprint = $this->payloadShapeFingerprint($payload, $contractHash, $endpointKind);
+            $attempts = $effective !== null
+                ? max(1, $effective->retryAttempts('vision') + 1)
+                : max(1, min(5, (int) config('estimate-generation.vision.retry_attempts', 3)));
+        } catch (Throwable $exception) {
+            throw $this->preWireFailure(
+                'vision_request_preparation_failed',
+                'vision_request_preparation',
+                $model,
+                $exception,
+            );
+        }
         $lastException = null;
         for ($wireAttempt = 1; $wireAttempt <= $attempts; $wireAttempt++) {
-            $physicalContext = $this->physicalContext($input, $model, $wireAttempt, $contractHash);
-            $priceSnapshot = $this->priceResolver?->resolve(
-                $physicalContext,
-                self::PROVIDER,
-                $model,
-            ) ?? AiPriceSnapshot::fromArray([]);
+            try {
+                $physicalContext = $this->physicalContext($input, $model, $wireAttempt, $contractHash);
+                $priceSnapshot = $this->priceResolver?->resolve(
+                    $physicalContext,
+                    self::PROVIDER,
+                    $model,
+                ) ?? AiPriceSnapshot::fromArray([]);
+            } catch (Throwable $exception) {
+                throw $this->preWireFailure(
+                    'vision_physical_claim_failed',
+                    'vision_physical_claim',
+                    $model,
+                    $exception,
+                );
+            }
             $startedAt = hrtime(true);
             $responsePayload = [];
             $status = 'connection_failed';
@@ -137,13 +164,22 @@ final readonly class TimewebVisionProvider implements VisionProvider
             $ownerToken = $this->ownerToken();
             $leaseTtl = max(30, min(900, (int) config('estimate-generation.vision.physical_attempt_lease_seconds', 180)));
             $claimNow = new DateTimeImmutable;
-            $snapshot = $this->physicalAttempts->claim(
-                $physicalContext,
-                $requestFingerprint,
-                $ownerToken,
-                $claimNow,
-                $claimNow->modify('+'.$leaseTtl.' seconds'),
-            );
+            try {
+                $snapshot = $this->physicalAttempts->claim(
+                    $physicalContext,
+                    $requestFingerprint,
+                    $ownerToken,
+                    $claimNow,
+                    $claimNow->modify('+'.$leaseTtl.' seconds'),
+                );
+            } catch (Throwable $exception) {
+                throw $this->preWireFailure(
+                    'vision_physical_claim_failed',
+                    'vision_physical_claim',
+                    $model,
+                    $exception,
+                );
+            }
             if ($snapshot->state === 'ambiguous') {
                 if (! $snapshot->usageRecorded) {
                     $usageRecorded = $this->recordAttempt(
@@ -158,17 +194,26 @@ final readonly class TimewebVisionProvider implements VisionProvider
                         AiPriceSnapshot::fromArray($snapshot->priceSnapshot ?? []),
                     );
                     if ($usageRecorded) {
-                        $this->physicalAttempts->markUsageRecorded($physicalContext->attemptId, $requestFingerprint);
+                        $this->safeMarkUsageRecorded($physicalContext, $requestFingerprint, $input, $model);
                     }
                 }
-                throw new VisionProviderException('vision_wire_outcome_ambiguous');
+                throw new VisionProviderException(
+                    'vision_wire_outcome_ambiguous',
+                    safeContext: $this->boundarySafeContext('vision_physical_claim', $model),
+                );
             }
             if ($snapshot->state === 'reserved') {
-                throw new VisionProviderException('vision_wire_outcome_ambiguous');
+                throw new VisionProviderException(
+                    'vision_wire_outcome_ambiguous',
+                    safeContext: $this->boundarySafeContext('vision_physical_claim', $model),
+                );
             }
             if (in_array($snapshot->state, ['pre_wire', 'wire_started'], true)
                 && $snapshot->ownerToken !== $ownerToken) {
-                throw new VisionProviderException('vision_wire_attempt_busy');
+                throw new VisionProviderException(
+                    'vision_wire_attempt_busy',
+                    safeContext: $this->boundarySafeContext('vision_physical_claim', $model),
+                );
             }
             $replayed = in_array($snapshot->state, ['response_received', 'completed'], true);
             if ($replayed) {
@@ -188,13 +233,17 @@ final readonly class TimewebVisionProvider implements VisionProvider
                         ?? max(1, min(120, (int) config('estimate-generation.vision.timeout_seconds', 60)));
                     $timeoutSeconds = $this->boundedDocumentAttemptTimeout($input, $attempts, $timeoutSeconds);
                     $wireNow = new DateTimeImmutable;
-                    $this->physicalAttempts->markWireStarted(
-                        $physicalContext->attemptId,
-                        $requestFingerprint,
-                        $ownerToken,
-                        $wireNow,
-                        $wireNow->modify('+'.$leaseTtl.' seconds'),
-                    );
+                    try {
+                        $this->physicalAttempts->markWireStarted(
+                            $physicalContext->attemptId,
+                            $requestFingerprint,
+                            $ownerToken,
+                            $wireNow,
+                            $wireNow->modify('+'.$leaseTtl.' seconds'),
+                        );
+                    } catch (Throwable $exception) {
+                        throw $this->physicalPersistenceFailure($model, $exception);
+                    }
                     $wireStarted = true;
                     $response = Http::timeout($timeoutSeconds)
                         ->withOptions(['stream' => true])
@@ -213,10 +262,16 @@ final readonly class TimewebVisionProvider implements VisionProvider
                         );
                         $responsePayload = ['provider_error' => $diagnostics->payload];
                         $status = 'http_failed';
-                        $this->physicalAttempts->storeResponse(
-                            $physicalContext->attemptId, $requestFingerprint, $ownerToken, $responsePayload, $status, $httpCode,
-                            (int) max(0, round((hrtime(true) - $startedAt) / 1_000_000)), null, $priceSnapshot->toArray(),
-                        );
+                        try {
+                            $this->physicalAttempts->storeResponse(
+                                $physicalContext->attemptId, $requestFingerprint, $ownerToken, $responsePayload, $status, $httpCode,
+                                (int) max(0, round((hrtime(true) - $startedAt) / 1_000_000)), null, $priceSnapshot->toArray(),
+                            );
+                        } catch (UsageInvariantViolation $exception) {
+                            throw $exception;
+                        } catch (Throwable $exception) {
+                            throw $this->physicalPersistenceFailure($model, $exception);
+                        }
                         $wireStarted = false;
                         $hasPersistedResponse = true;
                         Log::warning('[EstimateGeneration Vision] provider HTTP failure', [
@@ -231,20 +286,26 @@ final readonly class TimewebVisionProvider implements VisionProvider
                             'unit_id' => $input->processingUnitId,
                             'attempt_id' => $physicalContext->attemptId,
                         ]);
-                        $lastException = $this->httpFailureException($httpCode, $responsePayload);
+                        $lastException = $this->httpFailureException($httpCode, $responsePayload, $model);
                     } else {
                         $body = $this->bodyReader->read($response, max(1_024, (int) config('estimate-generation.vision.max_response_bytes', 1_000_000)));
-                        $this->physicalAttempts->storeResponse(
-                            $physicalContext->attemptId, $requestFingerprint, $ownerToken,
-                            ['raw_body_base64' => base64_encode($body)], 'response_received', $httpCode,
-                            (int) max(0, round((hrtime(true) - $startedAt) / 1_000_000)), null, $priceSnapshot->toArray(),
-                        );
+                        try {
+                            $this->physicalAttempts->storeResponse(
+                                $physicalContext->attemptId, $requestFingerprint, $ownerToken,
+                                ['raw_body_base64' => base64_encode($body)], 'response_received', $httpCode,
+                                (int) max(0, round((hrtime(true) - $startedAt) / 1_000_000)), null, $priceSnapshot->toArray(),
+                            );
+                        } catch (UsageInvariantViolation $exception) {
+                            throw $exception;
+                        } catch (Throwable $exception) {
+                            throw $this->physicalPersistenceFailure($model, $exception);
+                        }
                         $wireStarted = false;
                         $hasPersistedResponse = true;
                     }
                 }
                 if (($replayed && $status === 'http_failed') || (! $replayed && $status === 'http_failed')) {
-                    $lastException = $this->httpFailureException($httpCode, $responsePayload);
+                    $lastException = $this->httpFailureException($httpCode, $responsePayload, $model);
                 } else {
                     if ($replayed) {
                         $encodedBody = $responsePayload['raw_body_base64'] ?? null;
@@ -340,39 +401,55 @@ final readonly class TimewebVisionProvider implements VisionProvider
                 $lastException = $exception;
             } catch (ConnectionException $exception) {
                 $status = 'connection_failed';
-                $lastException = new VisionProviderException('vision_connection_failed', retryable: true, previous: $exception);
+                $lastException = new VisionProviderException(
+                    'vision_connection_failed',
+                    retryable: true,
+                    previous: $exception,
+                    safeContext: $this->boundarySafeContext('vision_http_transport', $model),
+                );
             } catch (UsageInvariantViolation $exception) {
                 $invariantFailure = true;
                 throw $exception;
             } catch (Throwable $exception) {
                 $status = 'connection_failed';
-                $lastException = new VisionProviderException('vision_request_failed', retryable: false, previous: $exception);
+                $lastException = new VisionProviderException(
+                    'vision_request_failed',
+                    retryable: false,
+                    previous: $exception,
+                    safeContext: $this->boundarySafeContext('vision_http_transport', $model),
+                );
             } finally {
                 $durationMs = $replayed
                     ? (int) $snapshot->durationMs
                     : (int) max(0, round((hrtime(true) - $startedAt) / 1_000_000));
                 if ($wireStarted && ! $hasPersistedResponse && ! $invariantFailure) {
-                    $this->physicalAttempts->markAmbiguous(
-                        $physicalContext->attemptId,
+                    $this->safeMarkAmbiguous(
+                        $physicalContext,
                         $requestFingerprint,
                         $ownerToken,
-                        'provider_request_outcome_unknown',
-                        new DateTimeImmutable,
                         $durationMs,
                         $httpCode,
                         $reportedModel,
-                        $priceSnapshot->toArray(),
+                        $priceSnapshot,
+                        $input,
+                        $model,
                     );
                     $status = 'ambiguous';
-                    $lastException = new VisionProviderException('vision_wire_outcome_ambiguous');
+                    if ($lastException?->reason !== 'vision_physical_attempt_persistence_failed') {
+                        $lastException = new VisionProviderException(
+                            'vision_wire_outcome_ambiguous',
+                            safeContext: $this->boundarySafeContext('vision_physical_attempt_persistence', $model),
+                        );
+                    }
                 }
-                if (! $replayed || ! $snapshot->usageRecorded) {
+                if (($replayed || $wireStarted || $hasPersistedResponse || $httpCode !== null)
+                    && (! $replayed || ! $snapshot->usageRecorded)) {
                     $usageRecorded = $this->recordAttempt(
                         $input, $model, $reportedModel, $status, $httpCode, $responsePayload,
                         $durationMs, $physicalContext, $priceSnapshot,
                     );
                     if ($usageRecorded && ($hasPersistedResponse || $status === 'ambiguous')) {
-                        $this->physicalAttempts->markUsageRecorded($physicalContext->attemptId, $requestFingerprint);
+                        $this->safeMarkUsageRecorded($physicalContext, $requestFingerprint, $input, $model);
                     }
                 }
             }
@@ -393,13 +470,128 @@ final readonly class TimewebVisionProvider implements VisionProvider
         throw new VisionProviderException('vision_provider_failed');
     }
 
+    private function preWireFailure(
+        string $safeCode,
+        string $boundary,
+        string $model,
+        Throwable $exception,
+    ): Throwable {
+        if ($exception instanceof DocumentManifestNeedsReview) {
+            return $exception;
+        }
+        if ($exception instanceof VisionProviderException) {
+            return new VisionProviderException(
+                $exception->reason,
+                $exception->httpCode,
+                $exception->retryable,
+                $exception,
+                [...$exception->safeContext, ...$this->boundarySafeContext($boundary, $model)],
+            );
+        }
+
+        return new VisionProviderException(
+            $safeCode,
+            retryable: false,
+            previous: $exception,
+            safeContext: $this->boundarySafeContext($boundary, $model),
+        );
+    }
+
+    /** @return array<string, string> */
+    private function boundarySafeContext(string $boundary, string $model): array
+    {
+        return [
+            'execution_boundary' => $boundary,
+            'provider' => self::PROVIDER,
+            ...(preg_match('/\A[a-zA-Z0-9][a-zA-Z0-9._-]{0,79}(?:\/[a-zA-Z0-9][a-zA-Z0-9._-]{0,79})?\z/', $model) === 1
+                ? ['requested_model' => $model]
+                : []),
+        ];
+    }
+
+    private function physicalPersistenceFailure(string $model, Throwable $exception): VisionProviderException
+    {
+        return new VisionProviderException(
+            'vision_physical_attempt_persistence_failed',
+            retryable: false,
+            previous: $exception,
+            safeContext: $this->boundarySafeContext('vision_physical_attempt_persistence', $model),
+        );
+    }
+
+    private function safeMarkAmbiguous(
+        AiOperationContext $context,
+        string $requestFingerprint,
+        string $ownerToken,
+        int $durationMs,
+        ?int $httpCode,
+        ?string $reportedModel,
+        AiPriceSnapshot $priceSnapshot,
+        VisionDocumentInput $input,
+        string $model,
+    ): void {
+        try {
+            $this->physicalAttempts->markAmbiguous(
+                $context->attemptId,
+                $requestFingerprint,
+                $ownerToken,
+                'provider_request_outcome_unknown',
+                new DateTimeImmutable,
+                $durationMs,
+                $httpCode,
+                $reportedModel,
+                $priceSnapshot->toArray(),
+            );
+        } catch (Throwable) {
+            $this->logPhysicalPersistenceFailure($input, $context, $model, 'mark_ambiguous');
+        }
+    }
+
+    private function safeMarkUsageRecorded(
+        AiOperationContext $context,
+        string $requestFingerprint,
+        VisionDocumentInput $input,
+        string $model,
+    ): void {
+        try {
+            $this->physicalAttempts->markUsageRecorded($context->attemptId, $requestFingerprint);
+        } catch (Throwable) {
+            $this->logPhysicalPersistenceFailure($input, $context, $model, 'mark_usage_recorded');
+        }
+    }
+
+    private function logPhysicalPersistenceFailure(
+        VisionDocumentInput $input,
+        AiOperationContext $context,
+        string $model,
+        string $operation,
+    ): void {
+        try {
+            Log::error('[EstimateGeneration Vision] physical attempt persistence failed', [
+                'failure_code' => 'vision_physical_attempt_persistence_failed',
+                'execution_boundary' => 'vision_physical_attempt_persistence',
+                'operation' => $operation,
+                'organization_id' => $input->organizationId,
+                'project_id' => $input->projectId,
+                'session_id' => $input->sessionId,
+                'document_id' => $input->documentId,
+                'page_id' => $input->pageId,
+                'unit_id' => $input->processingUnitId,
+                'attempt_id' => $context->attemptId,
+                'provider' => self::PROVIDER,
+                'model' => $model,
+            ]);
+        } catch (Throwable) {
+        }
+    }
+
     private function retryableStatus(int $status): bool
     {
         return in_array($status, [408, 409, 429], true) || $status >= 500;
     }
 
     /** @param array<string, mixed> $responsePayload */
-    private function httpFailureException(?int $httpCode, array $responsePayload): VisionProviderException
+    private function httpFailureException(?int $httpCode, array $responsePayload, string $model): VisionProviderException
     {
         $retryable = $httpCode !== null && $this->retryableStatus($httpCode);
         $reason = match (true) {
@@ -410,7 +602,7 @@ final readonly class TimewebVisionProvider implements VisionProvider
         $diagnostic = is_array($responsePayload['provider_error'] ?? null)
             ? $responsePayload['provider_error']
             : [];
-        $context = [];
+        $context = $this->boundarySafeContext('vision_provider_response', $model);
         foreach ([
             'provider_http_status', 'provider_error_type', 'provider_error_code', 'provider_error_param',
             'body_fingerprint', 'body_shape_fingerprint', 'endpoint_kind', 'prompt_contract_fingerprint',

--- a/tests/Feature/EstimateGeneration/Pipeline/ExplicitDocumentRetryPostgresContractTest.php
+++ b/tests/Feature/EstimateGeneration/Pipeline/ExplicitDocumentRetryPostgresContractTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\EstimateGeneration\Pipeline;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentMutationSessionReconciler;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ExplicitDocumentRetryConflict;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ExplicitDocumentRetryEligibility;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ResetDocumentProcessingUnitsForAttempt;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\RetryEstimateGenerationDocument;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Sessions\EstimateGenerationMutationPolicy;
 use App\BusinessModules\Addons\EstimateGeneration\Jobs\ProcessEstimateGenerationDocumentJob;
@@ -134,6 +135,7 @@ final class ExplicitDocumentRetryPostgresContractTest extends TestCase
             $readiness,
             $authorization,
             new ExplicitDocumentRetryEligibility,
+            new ResetDocumentProcessingUnitsForAttempt,
         );
         $actor = new User;
         $actor->forceFill(['id' => 7, 'current_organization_id' => 38]);
@@ -336,6 +338,7 @@ final class ExplicitDocumentRetryPostgresContractTest extends TestCase
             $readiness,
             $authorization,
             new ExplicitDocumentRetryEligibility,
+            new ResetDocumentProcessingUnitsForAttempt,
         );
         $actor = new User;
         $actor->forceFill(['id' => 7, 'current_organization_id' => 38]);

--- a/tests/Support/ExplicitDocumentRetryConcurrentWorker.php
+++ b/tests/Support/ExplicitDocumentRetryConcurrentWorker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentMutationSessionReconciler;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ExplicitDocumentRetryEligibility;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ResetDocumentProcessingUnitsForAttempt;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\RetryEstimateGenerationDocument;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Sessions\EstimateGenerationMutationPolicy;
 use App\BusinessModules\Addons\EstimateGeneration\Jobs\ProcessEstimateGenerationDocumentJob;
@@ -32,6 +33,7 @@ $service = new RetryEstimateGenerationDocument(
     $readiness,
     $authorization,
     new ExplicitDocumentRetryEligibility,
+    new ResetDocumentProcessingUnitsForAttempt,
 );
 $actor = new User;
 $actor->forceFill(['id' => 7, 'current_organization_id' => 38]);

--- a/tests/Unit/EstimateGeneration/DocumentProcessingUnitContractTest.php
+++ b/tests/Unit/EstimateGeneration/DocumentProcessingUnitContractTest.php
@@ -475,6 +475,69 @@ final class DocumentProcessingUnitContractTest extends TestCase
     }
 
     #[Test]
+    public function persisted_retry_history_records_failure_against_the_new_processing_attempt(): void
+    {
+        $store = new InMemoryDocumentProcessingUnitStore;
+        $record = $store->create(1, 2, 3, 4, $this->unit(DocumentUnitType::PdfPage, 1, 'source'));
+        $record->metadata = [
+            'failure_history' => [[
+                'failure_code' => 'vision_provider_request_rejected',
+                'processing_attempt_id' => '018f4a20-3f4c-7a11-8a22-123456789abc',
+            ]],
+            'processing_attempt_id' => '7d1385db-106e-47ab-993b-322fb5d124af',
+        ];
+        $failures = new class implements FailureStore
+        {
+            public ?FailureData $recorded = null;
+
+            public function record(FailureData $failure, DateTimeImmutable $seenAt): void
+            {
+                $this->recorded = $failure;
+            }
+
+            public function resolve(FailureContext $context, string $fingerprint, string $resolutionCode, DateTimeImmutable $resolvedAt): bool
+            {
+                return false;
+            }
+
+            public function resolveActive(FailureContext $context, string $resolutionCode, DateTimeImmutable $resolvedAt): int
+            {
+                return 0;
+            }
+        };
+        $processor = new class implements DocumentUnitProcessor
+        {
+            public function process(DocumentUnitExecutionContext $context): DocumentUnitOutput
+            {
+                throw new TypedFailureException(
+                    FailureCategory::Terminal,
+                    'vision_operation_settings_failed',
+                    ['execution_boundary' => 'vision_operation_settings'],
+                    new \RuntimeException('Bearer private prompt'),
+                );
+            }
+        };
+        $usecase = new ProcessDocumentUnit(
+            $store,
+            $processor,
+            new class implements DocumentUnitAggregateReconciler
+            {
+                public function reconcile(int $documentId, string $sourceVersion): void {}
+            },
+            new FailureRecorder($failures),
+        );
+
+        self::assertSame(DocumentProcessingUnitClaimStatus::Terminal, $usecase->handle($record->id, 'source')->status);
+        self::assertSame(
+            '7d1385db-106e-47ab-993b-322fb5d124af',
+            $failures->recorded?->safeContext['processing_attempt_id'] ?? null,
+        );
+        self::assertSame('vision_operation_settings', $failures->recorded?->safeContext['execution_boundary'] ?? null);
+        self::assertSame('018f4a20-3f4c-7a11-8a22-123456789abc', $record->metadata['failure_history'][0]['processing_attempt_id']);
+        self::assertStringNotContainsString('private', json_encode($failures->recorded?->safeContext, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
     public function repeated_terminal_vision_rejection_never_executes_all_twenty_two_units(): void
     {
         $store = new InMemoryDocumentProcessingUnitStore;
@@ -514,6 +577,45 @@ final class DocumentProcessingUnitContractTest extends TestCase
         }
         self::assertSame(DocumentProcessingUnitStatus::Pending, $store->find($differentContract->id)?->status);
         self::assertSame(0, $store->find($differentContract->id)?->attemptCount);
+    }
+
+    #[Test]
+    public function repeated_physical_persistence_failure_stops_after_two_executions(): void
+    {
+        $store = new InMemoryDocumentProcessingUnitStore;
+        $units = [];
+        foreach (range(1, 22) as $index) {
+            $units[] = $store->create(1, 2, 3, 4, $this->unit(DocumentUnitType::PdfPage, $index, 'source'));
+        }
+        $processor = new class implements DocumentUnitProcessor
+        {
+            public int $calls = 0;
+
+            public function process(DocumentUnitExecutionContext $context): DocumentUnitOutput
+            {
+                $this->calls++;
+
+                throw new TypedFailureException(
+                    FailureCategory::Terminal,
+                    'vision_physical_attempt_persistence_failed',
+                    ['diagnostic_fingerprint' => 'sha256:'.str_repeat('d', 64)],
+                );
+            }
+        };
+        $usecase = $this->processUnit($store, $processor, new class implements DocumentUnitAggregateReconciler
+        {
+            public function reconcile(int $documentId, string $sourceVersion): void {}
+        });
+
+        foreach ($units as $unit) {
+            $usecase->handle($unit->id, 'source');
+        }
+
+        self::assertSame(2, $processor->calls);
+        self::assertSame(20, count(array_filter(
+            array_map(static fn ($unit): ?string => $store->find($unit->id)?->failureCode, $units),
+            static fn (?string $code): bool => $code === 'breaker_stopped',
+        )));
     }
 
     #[Test]
@@ -1068,13 +1170,15 @@ final class DocumentProcessingUnitContractTest extends TestCase
     public function explicit_document_retry_preserves_rows_and_owns_idempotent_lineage(): void
     {
         $retry = file_get_contents(__DIR__.'/../../../app/BusinessModules/Addons/EstimateGeneration/Application/Documents/RetryEstimateGenerationDocument.php');
+        $resetter = file_get_contents(__DIR__.'/../../../app/BusinessModules/Addons/EstimateGeneration/Application/Documents/ResetDocumentProcessingUnitsForAttempt.php');
         $actions = file_get_contents(__DIR__.'/../../../app/BusinessModules/Addons/EstimateGeneration/Http/Presentation/EstimateGenerationDocumentActionBuilder.php');
 
         self::assertIsString($retry);
+        self::assertIsString($resetter);
         self::assertIsString($actions);
         self::assertStringContainsString("'idempotency_hash' => \$keyHash", $retry);
         self::assertStringContainsString("'explicit_document_retry_history' => \$history", $retry);
-        self::assertStringContainsString("'failure_history' => \$failureHistory", $retry);
+        self::assertStringContainsString("'failure_history' => \$failureHistory", $resetter);
         self::assertStringContainsString("'retry_disposition' => 'explicit_system_failure_retry'", $actions);
         self::assertStringNotContainsString('$lockedDocument->pages()->delete()', $retry);
         self::assertStringNotContainsString('$lockedDocument->processingUnits()->delete()', $retry);

--- a/tests/Unit/EstimateGeneration/Observability/FailureNormalizerTest.php
+++ b/tests/Unit/EstimateGeneration/Observability/FailureNormalizerTest.php
@@ -110,6 +110,32 @@ final class FailureNormalizerTest extends TestCase
     }
 
     #[Test]
+    public function pre_wire_diagnostics_keep_new_retry_lineage_and_requested_model_without_private_text(): void
+    {
+        $failure = (new FailureNormalizer)->normalize(
+            new TypedFailureException(
+                FailureCategory::Terminal,
+                'vision_operation_settings_failed',
+                ['execution_boundary' => 'vision_operation_settings'],
+                new RuntimeException('Bearer secret prompt https://signed.example/private.png'),
+            ),
+            $this->context(
+                processingAttemptId: '7d1385db-106e-47ab-993b-322fb5d124af',
+                model: 'openai/gpt-5.6-luna',
+            ),
+        );
+
+        self::assertSame('vision_operation_settings_failed', $failure->code);
+        self::assertSame('vision_operation_settings', $failure->safeContext['execution_boundary']);
+        self::assertSame('7d1385db-106e-47ab-993b-322fb5d124af', $failure->safeContext['processing_attempt_id']);
+        self::assertSame('openai/gpt-5.6-luna', $failure->safeContext['requested_model']);
+        self::assertSame('runtime_exception', $failure->safeContext['root_exception_class']);
+        self::assertMatchesRegularExpression('/\Asha256:[0-9a-f]{64}\z/', $failure->safeContext['exception_chain_fingerprint']);
+        self::assertStringNotContainsString('secret', json_encode($failure->safeContext, JSON_THROW_ON_ERROR));
+        self::assertStringNotContainsString('signed.example', json_encode($failure->safeContext, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
     public function fingerprint_ignores_message_but_separates_tenant_stage_and_code(): void
     {
         $normalizer = new FailureNormalizer;
@@ -177,11 +203,31 @@ final class FailureNormalizerTest extends TestCase
         self::assertSame(400, $failure->safeContext['provider_http_status']);
     }
 
+    #[Test]
+    public function immutable_provider_model_overrides_stale_environment_identity(): void
+    {
+        $failure = (new FailureNormalizer)->normalize(new TypedFailureException(
+            FailureCategory::Terminal,
+            'vision_physical_attempt_persistence_failed',
+            [
+                'provider' => 'timeweb',
+                'requested_model' => 'openai/gpt-5.6-luna',
+                'execution_boundary' => 'vision_physical_attempt_persistence',
+            ],
+        ), $this->context(model: 'legacy/model-v1'));
+
+        self::assertSame('timeweb', $failure->context->provider);
+        self::assertSame('openai/gpt-5.6-luna', $failure->context->model);
+        self::assertSame('openai/gpt-5.6-luna', $failure->safeContext['requested_model']);
+    }
+
     private function context(
         int $organizationId = 1,
         ProcessingStage $stage = ProcessingStage::UnderstandDocuments,
         ?int $pageId = null,
         int $unitId = 1001,
+        ?string $processingAttemptId = null,
+        ?string $model = null,
     ): FailureContext {
         return new FailureContext(
             organizationId: $organizationId,
@@ -195,6 +241,8 @@ final class FailureNormalizerTest extends TestCase
             documentId: 1000,
             pageId: $pageId,
             unitId: $unitId,
+            processingAttemptId: $processingAttemptId,
+            model: $model,
         );
     }
 }

--- a/tests/Unit/EstimateGeneration/Observability/FailureProductionIntegrationContractTest.php
+++ b/tests/Unit/EstimateGeneration/Observability/FailureProductionIntegrationContractTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\EstimateGeneration\Observability;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ProcessDocumentUnit;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Generation\RunEstimateGenerationDraft;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureRecorder;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureRecorderObserver;
 use App\BusinessModules\Addons\EstimateGeneration\Pipeline\DraftPipelineEntrypoint;
 use App\BusinessModules\Addons\EstimateGeneration\Pipeline\PipelineRunner;
 use App\BusinessModules\Addons\EstimateGeneration\Pipeline\Stages\ValidateDraftStage;
@@ -32,6 +33,16 @@ final class FailureProductionIntegrationContractTest extends TestCase
                 self::assertFalse($byType[$dependency]->isDefaultValueAvailable(), $class.' '.$dependency);
             }
         }
+    }
+
+    #[Test]
+    public function production_container_binds_a_non_null_failure_recorder_observer(): void
+    {
+        $provider = file_get_contents(dirname(__DIR__, 4).'/app/BusinessModules/Addons/EstimateGeneration/EstimateGenerationServiceProvider.php');
+
+        self::assertIsString($provider);
+        self::assertStringContainsString(FailureRecorderObserver::class, $provider);
+        self::assertStringContainsString('SafeLogFailureRecorderObserver::class', $provider);
     }
 
     #[Test]

--- a/tests/Unit/EstimateGeneration/Observability/FailureRecorderTest.php
+++ b/tests/Unit/EstimateGeneration/Observability/FailureRecorderTest.php
@@ -40,12 +40,12 @@ final class FailureRecorderTest extends TestCase
         };
         $observer = new class implements FailureRecorderObserver
         {
-            /** @var list<array{string, string}> */
+            /** @var list<FailureData> */
             public array $events = [];
 
-            public function recordingFailed(string $failureCode, string $fingerprint): void
+            public function recordingFailed(FailureData $failure): void
             {
-                $this->events[] = [$failureCode, $fingerprint];
+                $this->events[] = $failure;
             }
         };
         $recorder = new FailureRecorder($store, observer: $observer);
@@ -58,10 +58,48 @@ final class FailureRecorderTest extends TestCase
             self::assertSame($original, $actual);
         }
 
-        self::assertSame('unexpected_internal_failure', $observer->events[0][0]);
-        self::assertMatchesRegularExpression('/^sha256:[0-9a-f]{64}$/', $observer->events[0][1]);
+        self::assertSame('unexpected_internal_failure', $observer->events[0]->code);
+        self::assertSame(1000, $observer->events[0]->context->documentId);
+        self::assertMatchesRegularExpression('/^sha256:[0-9a-f]{64}$/', $observer->events[0]->fingerprint);
         self::assertStringNotContainsString('secret', json_encode($observer->events, JSON_THROW_ON_ERROR));
         self::assertStringNotContainsString('private', json_encode($observer->events, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
+    public function observer_failure_never_masks_the_original_throwable(): void
+    {
+        $store = new class implements FailureStore
+        {
+            public function record(FailureData $failure, DateTimeImmutable $seenAt): void
+            {
+                throw new RuntimeException('private database path');
+            }
+
+            public function resolve(FailureContext $context, string $fingerprint, string $resolutionCode, DateTimeImmutable $resolvedAt): bool
+            {
+                return false;
+            }
+
+            public function resolveActive(FailureContext $context, string $resolutionCode, DateTimeImmutable $resolvedAt): int
+            {
+                return 0;
+            }
+        };
+        $observer = new class implements FailureRecorderObserver
+        {
+            public function recordingFailed(FailureData $failure): void
+            {
+                throw new RuntimeException('logging transport secret');
+            }
+        };
+        $original = new RuntimeException('private prompt');
+
+        try {
+            (new FailureRecorder($store, observer: $observer))->captureAndRethrow($original, $this->context());
+            self::fail('Original throwable was not rethrown.');
+        } catch (Throwable $actual) {
+            self::assertSame($original, $actual);
+        }
     }
 
     #[Test]

--- a/tests/Unit/EstimateGeneration/ProductionDocumentUnitProcessorTest.php
+++ b/tests/Unit/EstimateGeneration/ProductionDocumentUnitProcessorTest.php
@@ -10,7 +10,6 @@ use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\CadRepre
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentSourceManifestStorage;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentUnitContentReader;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentUnitExecutionContext;
-use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentUnitProcessingException;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentUnitProvenance;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\DocumentUnitType;
 use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ImageDocumentAdapter;
@@ -554,8 +553,9 @@ final class ProductionDocumentUnitProcessorTest extends DatabaseLessTestCase
         try {
             $processor->process($context);
             self::fail('Geometry failure must be wrapped.');
-        } catch (DocumentUnitProcessingException $exception) {
-            self::assertSame('document_unit_processing_failed', $exception->safeCode);
+        } catch (TypedFailureException $exception) {
+            self::assertSame('document_unit_pre_wire_failed', $exception->safeCode);
+            self::assertSame('document_unit_representation', $exception->safeContext['execution_boundary']);
             self::assertSame($original, $exception->getPrevious());
         }
     }

--- a/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
+++ b/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
@@ -608,13 +608,125 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
         try {
             $this->provider()->analyze($this->input());
             self::fail('Lost pre-wire claim was accepted.');
-        } catch (\App\BusinessModules\Addons\EstimateGeneration\Observability\UsageInvariantViolation) {
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_physical_attempt_persistence_failed', $exception->reason);
+            self::assertSame('vision_physical_attempt_persistence', $exception->safeContext['execution_boundary']);
         }
 
         Http::assertNothingSent();
-        self::assertCount(1, $this->attempts);
-        self::assertSame('connection_failed', $this->attempts[0]->status);
-        self::assertNotSame('ambiguous', $this->attempts[0]->status);
+        self::assertSame([], $this->attempts);
+    }
+
+    #[Test]
+    public function unknown_physical_claim_failure_is_typed_without_http_or_secret_leak(): void
+    {
+        $store = $this->createMock(VisionPhysicalAttemptStore::class);
+        $store->method('claim')->willThrowException(
+            new \RuntimeException('Bearer secret signed URL https://storage.example/private.png'),
+        );
+        $this->app->instance(VisionPhysicalAttemptStore::class, $store);
+        $this->app->forgetInstance(TimewebVisionProvider::class);
+        Http::fake();
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Unknown physical claim failure was accepted.');
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_physical_claim_failed', $exception->reason);
+            self::assertSame('vision_physical_claim', $exception->safeContext['execution_boundary']);
+            self::assertSame('openai/gpt-5.6-luna', $exception->safeContext['requested_model']);
+            self::assertInstanceOf(\RuntimeException::class, $exception->getPrevious());
+            self::assertStringNotContainsString('secret', json_encode($exception->safeContext, JSON_THROW_ON_ERROR));
+            self::assertStringNotContainsString('storage.example', json_encode($exception->safeContext, JSON_THROW_ON_ERROR));
+        }
+
+        Http::assertNothingSent();
+        self::assertSame([], $this->attempts);
+    }
+
+    #[Test]
+    public function response_persistence_failure_keeps_typed_boundary_and_does_not_wire_retry(): void
+    {
+        $store = $this->getMockBuilder(VisionPhysicalAttemptStore::class)->getMock();
+        $store->method('claim')->willReturnCallback(
+            static fn (AiOperationContext $context, string $fingerprint, string $owner, DateTimeImmutable $now, DateTimeImmutable $lease): VisionPhysicalAttemptSnapshot => new VisionPhysicalAttemptSnapshot(
+                true,
+                'pre_wire',
+                ownerToken: $owner,
+                leaseExpiresAt: $lease,
+            ),
+        );
+        $store->method('storeResponse')->willThrowException(new \RuntimeException('database password private path'));
+        $store->method('markAmbiguous')->willThrowException(new \RuntimeException('secondary logging secret'));
+        $this->app->instance(VisionPhysicalAttemptStore::class, $store);
+        $this->app->forgetInstance(TimewebVisionProvider::class);
+        Http::fake(['*' => Http::response($this->response())]);
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Response persistence failure was accepted.');
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_physical_attempt_persistence_failed', $exception->reason);
+            self::assertSame('vision_physical_attempt_persistence', $exception->safeContext['execution_boundary']);
+            self::assertSame('timeweb', $exception->safeContext['provider']);
+            self::assertSame('openai/gpt-5.6-luna', $exception->safeContext['requested_model']);
+            self::assertStringNotContainsString('password', json_encode($exception->safeContext, JSON_THROW_ON_ERROR));
+        }
+
+        Http::assertSentCount(1);
+    }
+
+    #[Test]
+    public function usage_marker_persistence_failure_does_not_replace_successful_analysis(): void
+    {
+        $store = $this->getMockBuilder(VisionPhysicalAttemptStore::class)->getMock();
+        $store->method('claim')->willReturnCallback(
+            static fn (AiOperationContext $context, string $fingerprint, string $owner, DateTimeImmutable $now, DateTimeImmutable $lease): VisionPhysicalAttemptSnapshot => new VisionPhysicalAttemptSnapshot(
+                true,
+                'pre_wire',
+                ownerToken: $owner,
+                leaseExpiresAt: $lease,
+            ),
+        );
+        $store->method('markUsageRecorded')->willThrowException(new \RuntimeException('marker storage password'));
+        $this->app->instance(VisionPhysicalAttemptStore::class, $store);
+        $this->app->forgetInstance(TimewebVisionProvider::class);
+        Http::fake(['*' => Http::response($this->response())]);
+
+        $analysis = $this->provider()->analyze($this->input());
+
+        self::assertSame('openai/gpt-5.6-luna', $analysis->requestedModel);
+        Http::assertSentCount(1);
+    }
+
+    #[Test]
+    public function unknown_operation_settings_failure_is_typed_without_http_or_secret_leak(): void
+    {
+        $store = new class implements EffectiveSettingsOperationStore
+        {
+            public function pin(string $correlationId, int $organizationId, int $sessionId): EffectiveSettingsPair
+            {
+                throw new \RuntimeException('postgres password signed path https://storage.example/private.png');
+            }
+        };
+        $this->app->instance(EffectiveSettingsResolver::class, new EffectiveSettingsResolver($store));
+        $this->app->forgetInstance(TimewebVisionProvider::class);
+        Http::fake();
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Unknown operation settings failure was accepted.');
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_operation_settings_failed', $exception->reason);
+            self::assertSame('vision_operation_settings', $exception->safeContext['execution_boundary']);
+            self::assertSame('openai/gpt-5.6-luna', $exception->safeContext['requested_model']);
+            self::assertInstanceOf(\RuntimeException::class, $exception->getPrevious());
+            self::assertStringNotContainsString('password', json_encode($exception->safeContext, JSON_THROW_ON_ERROR));
+            self::assertStringNotContainsString('storage.example', json_encode($exception->safeContext, JSON_THROW_ON_ERROR));
+        }
+
+        Http::assertNothingSent();
+        self::assertSame([], $this->attempts);
     }
 
     #[Test]


### PR DESCRIPTION
## Что изменено
- добавлены стабильные typed-коды и boundary-контекст для ошибок до HTTP: настройки операции, подготовка запроса, physical claim и representation
- failure ledger связывает ошибку с processing_attempt_id, unit/document/session и фактическими pinned provider/model
- неизвестные исключения сохраняют allowlisted class/category и безопасный fingerprint цепочки без message, stack, prompt, URL и секретов
- persistence/logging observability работает fail-safe; secondary-сбои physical attempt не маскируют первичную причину
- deterministic systemic persistence/pre-wire failures участвуют в document breaker 2/20
- существующий bounded HTTP 4xx inspector сохранён без изменения Luna payload

## Проверки
- PHPUnit: 119 tests, 594 assertions (1 существующий platform skip)
- PostgreSQL contract: 4 tests, 83 assertions, без skip
- targeted Larastan: 11 runtime files, 0 errors
- Pint, php-l, git diff --check
- независимое correctness/security/architecture review: P1/P2 закрыты

## Ограничение выпуска
Этот PR улучшает диагностическую наблюдаемость. Он не меняет Luna payload и не заявляет исправление исходного HTTP 400. После deploy нужен ровно один контролируемый retry пользователя; автоматический AI-вызов не выполняется.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enhanced failure observability by adding new failure codes and tracking processing attempt IDs.</li>
<li>Improved error handling in document processing by wrapping persistence operations in try-catch blocks and introducing specific failure categories.</li>
<li>Registered a new `SafeLogFailureRecorderObserver` in the `EstimateGenerationServiceProvider` to improve failure logging.</li>
<li>Updated `ProductionDocumentUnitProcessor` to include boundary context and better map exceptions to typed failures.</li>
<li>Added validation for processing attempt IDs and model names in `FailureContext`.</li>
</ul></div>