### PR TITLE
fix[backend]: устранён сбой повторной обработки Vision

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailurePersistenceDiagnostic.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailurePersistenceDiagnostic.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BusinessModules\Addons\EstimateGeneration\Observability;
+
+use Throwable;
+
+final readonly class FailurePersistenceDiagnostic
+{
+    private function __construct(
+        public string $code,
+        public string $exceptionClass,
+        public string $rootExceptionClass,
+        public string $chainFingerprint,
+        public string $fingerprint,
+    ) {}
+
+    public static function fromThrowable(Throwable $error): self
+    {
+        $diagnostic = (new FailureDiagnosticIdentity)->forThrowable(
+            $error,
+            'failure_observability_persistence',
+        );
+
+        return new self(
+            'failure_observability_persistence_failed',
+            $diagnostic['exception_class'],
+            $diagnostic['root_exception_class'],
+            $diagnostic['exception_chain_fingerprint'],
+            $diagnostic['diagnostic_fingerprint'],
+        );
+    }
+}

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorder.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorder.php
@@ -25,9 +25,12 @@ final readonly class FailureRecorder
 
         try {
             $this->store->record($failure, now()->toDateTimeImmutable());
-        } catch (Throwable) {
+        } catch (Throwable $persistenceError) {
             try {
-                $this->observer->recordingFailed($failure);
+                $this->observer->recordingFailed(
+                    $failure,
+                    FailurePersistenceDiagnostic::fromThrowable($persistenceError),
+                );
             } catch (Throwable) {
             }
         }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorderObserver.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/FailureRecorderObserver.php
@@ -6,5 +6,8 @@ namespace App\BusinessModules\Addons\EstimateGeneration\Observability;
 
 interface FailureRecorderObserver
 {
-    public function recordingFailed(FailureData $failure): void;
+    public function recordingFailed(
+        FailureData $failure,
+        FailurePersistenceDiagnostic $persistenceFailure,
+    ): void;
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/NullFailureRecorderObserver.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/NullFailureRecorderObserver.php
@@ -6,5 +6,8 @@ namespace App\BusinessModules\Addons\EstimateGeneration\Observability;
 
 final class NullFailureRecorderObserver implements FailureRecorderObserver
 {
-    public function recordingFailed(FailureData $failure): void {}
+    public function recordingFailed(
+        FailureData $failure,
+        FailurePersistenceDiagnostic $persistenceFailure,
+    ): void {}
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/Observability/SafeLogFailureRecorderObserver.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Observability/SafeLogFailureRecorderObserver.php
@@ -8,8 +8,10 @@ use Illuminate\Support\Facades\Log;
 
 final class SafeLogFailureRecorderObserver implements FailureRecorderObserver
 {
-    public function recordingFailed(FailureData $failure): void
-    {
+    public function recordingFailed(
+        FailureData $failure,
+        FailurePersistenceDiagnostic $persistenceFailure,
+    ): void {
         Log::error('[EstimateGeneration] failure observability persistence failed', [
             'failure_code' => $failure->code,
             'failure_category' => $failure->category->value,
@@ -25,6 +27,13 @@ final class SafeLogFailureRecorderObserver implements FailureRecorderObserver
             'provider' => $failure->context->provider,
             'model' => $failure->context->model,
             'safe_context' => $failure->safeContext,
+            'persistence_failure' => [
+                'code' => $persistenceFailure->code,
+                'exception_class' => $persistenceFailure->exceptionClass,
+                'root_exception_class' => $persistenceFailure->rootExceptionClass,
+                'exception_chain_fingerprint' => $persistenceFailure->chainFingerprint,
+                'diagnostic_fingerprint' => $persistenceFailure->fingerprint,
+            ],
         ]);
     }
 }

--- a/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000210_allow_sheet_analysis_retry_lineages.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000210_allow_sheet_analysis_retry_lineages.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE estimate_generation_sheet_analysis_operations DROP CONSTRAINT IF EXISTS eg_sheet_analysis_scope_kind_uq');
+        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS eg_sheet_analysis_scope_kind_idx');
+        DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS eg_sheet_analysis_scope_kind_idx ON estimate_generation_sheet_analysis_operations (session_id, document_id, unit_id, source_version, kind)');
+    }
+
+    public function down(): void
+    {
+        throw new LogicException('estimate_generation_sheet_analysis_retry_lineages_are_irreversible');
+    }
+};

--- a/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000220_expand_failure_diagnostics_contract.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000220_expand_failure_diagnostics_contract.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        $previousLockTimeout = (string) DB::scalar('SHOW lock_timeout');
+        $previousStatementTimeout = (string) DB::scalar('SHOW statement_timeout');
+        DB::statement("SET lock_timeout TO '5s'");
+        DB::statement("SET statement_timeout TO '120s'");
+
+        try {
+            foreach ([
+                'eg_failure_events_safe_context_closed_ck_v2',
+                'eg_failure_events_safe_context_values_ck_v2',
+                'eg_failure_events_safe_context_privacy_ck_v2',
+            ] as $constraint) {
+                DB::statement(sprintf(
+                    'ALTER TABLE public.estimate_generation_failure_events DROP CONSTRAINT IF EXISTS %s',
+                    $constraint,
+                ));
+            }
+            DB::statement('ALTER TABLE public.estimate_generation_failure_identities DROP CONSTRAINT IF EXISTS eg_failure_identities_provider_model_ck_v2');
+
+            DB::statement(<<<'SQL'
+            ALTER TABLE public.estimate_generation_failure_events
+            ADD CONSTRAINT eg_failure_events_safe_context_closed_ck_v2 CHECK (
+                jsonb_typeof(safe_context) = 'object'
+                AND (safe_context - ARRAY[
+                    'provider_code','provider','provider_error_type','provider_error_code','provider_error_param',
+                    'endpoint_kind','body_fingerprint','body_shape_fingerprint','prompt_contract_fingerprint',
+                    'payload_shape_fingerprint','http_class','http_code','provider_http_status','status','safe_code',
+                    'retry_after_seconds','attempt','validation_code','storage_code','claim_status','lineage_code',
+                    'failure_fingerprint','diagnostic_fingerprint','exception_chain_fingerprint','exception_class',
+                    'root_exception_class','execution_boundary','processing_attempt_id','requested_model'
+                ]) = '{}'::jsonb
+            ) NOT VALID
+        SQL);
+            DB::unprepared(<<<'SQL'
+            ALTER TABLE public.estimate_generation_failure_events
+            ADD CONSTRAINT eg_failure_events_safe_context_values_ck_v2 CHECK (
+                (NOT safe_context ? 'http_code' OR (jsonb_typeof(safe_context->'http_code') = 'number' AND (safe_context->>'http_code')::integer BETWEEN 100 AND 599))
+                AND (NOT safe_context ? 'provider_http_status' OR (jsonb_typeof(safe_context->'provider_http_status') = 'number' AND (safe_context->>'provider_http_status')::integer BETWEEN 100 AND 599))
+                AND (NOT safe_context ? 'retry_after_seconds' OR (jsonb_typeof(safe_context->'retry_after_seconds') = 'number' AND (safe_context->>'retry_after_seconds')::integer BETWEEN 0 AND 86400))
+                AND (NOT safe_context ? 'attempt' OR (jsonb_typeof(safe_context->'attempt') = 'number' AND (safe_context->>'attempt')::integer BETWEEN 1 AND 1000))
+                AND (NOT safe_context ? 'http_class' OR safe_context->>'http_class' ~ '^[1-5]xx$')
+                AND (NOT safe_context ? 'claim_status' OR safe_context->>'claim_status' IN ('lost','expired','stale','busy'))
+                AND (NOT safe_context ? 'processing_attempt_id' OR safe_context->>'processing_attempt_id' ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+                AND (NOT safe_context ? 'requested_model' OR safe_context->>'requested_model' ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,79}(/[A-Za-z0-9][A-Za-z0-9._-]{0,79})?$')
+                AND (NOT safe_context ? 'provider' OR safe_context->>'provider' ~ '^[a-z][a-z0-9_]{0,39}$')
+                AND (NOT safe_context ? 'provider_code' OR safe_context->>'provider_code' ~ '^[a-z][a-z0-9._-]{0,79}$')
+                AND (NOT safe_context ? 'provider_error_type' OR safe_context->>'provider_error_type' ~ '^[A-Za-z][A-Za-z0-9._-]{0,79}$')
+                AND (NOT safe_context ? 'provider_error_code' OR safe_context->>'provider_error_code' ~ '^[A-Za-z][A-Za-z0-9._-]{0,79}$')
+                AND (NOT safe_context ? 'provider_error_param' OR safe_context->>'provider_error_param' ~ '^[A-Za-z][A-Za-z0-9._\[\]-]{0,79}$')
+                AND (NOT safe_context ? 'endpoint_kind' OR safe_context->>'endpoint_kind' ~ '^[a-z][a-z0-9_]{0,39}$')
+                AND (NOT safe_context ? 'status' OR safe_context->>'status' ~ '^[a-z][a-z0-9_]{0,39}$')
+                AND (NOT safe_context ? 'safe_code' OR safe_context->>'safe_code' ~ '^[a-z][a-z0-9_]{0,79}$')
+                AND (NOT safe_context ? 'validation_code' OR safe_context->>'validation_code' ~ '^[a-z][a-z0-9_]{0,79}$')
+                AND (NOT safe_context ? 'storage_code' OR safe_context->>'storage_code' ~ '^[a-z][a-z0-9_]{0,79}$')
+                AND (NOT safe_context ? 'lineage_code' OR safe_context->>'lineage_code' ~ '^[a-z][a-z0-9_]{0,79}$')
+                AND (NOT safe_context ? 'exception_class' OR safe_context->>'exception_class' ~ '^[a-z][a-z0-9_]{0,79}$')
+                AND (NOT safe_context ? 'root_exception_class' OR safe_context->>'root_exception_class' ~ '^[a-z][a-z0-9_]{0,79}$')
+                AND (NOT safe_context ? 'execution_boundary' OR safe_context->>'execution_boundary' ~ '^[a-z][a-z0-9_]{0,79}$')
+                AND (NOT safe_context ? 'body_fingerprint' OR safe_context->>'body_fingerprint' ~ '^sha256:[0-9a-f]{64}$')
+                AND (NOT safe_context ? 'body_shape_fingerprint' OR safe_context->>'body_shape_fingerprint' ~ '^sha256:[0-9a-f]{64}$')
+                AND (NOT safe_context ? 'prompt_contract_fingerprint' OR safe_context->>'prompt_contract_fingerprint' ~ '^sha256:[0-9a-f]{64}$')
+                AND (NOT safe_context ? 'payload_shape_fingerprint' OR safe_context->>'payload_shape_fingerprint' ~ '^sha256:[0-9a-f]{64}$')
+                AND (NOT safe_context ? 'failure_fingerprint' OR safe_context->>'failure_fingerprint' ~ '^sha256:[0-9a-f]{64}$')
+                AND (NOT safe_context ? 'diagnostic_fingerprint' OR safe_context->>'diagnostic_fingerprint' ~ '^sha256:[0-9a-f]{64}$')
+                AND (NOT safe_context ? 'exception_chain_fingerprint' OR safe_context->>'exception_chain_fingerprint' ~ '^sha256:[0-9a-f]{64}$')
+            ) NOT VALID
+        SQL);
+            DB::statement(<<<'SQL'
+            ALTER TABLE public.estimate_generation_failure_events
+            ADD CONSTRAINT eg_failure_events_safe_context_privacy_ck_v2 CHECK (
+                NOT jsonb_path_exists(
+                    safe_context,
+                    '$.* ? (@.type() == "string" && @ like_regex "(authorization|api_key|apikey|token|secret|password|cookie|bearer|eyj[a-z0-9_-]{8,}\\.|akia[0-9a-z]{12,}|gh[pousr]_[0-9a-z]{12,}|sk-[0-9a-z]{8,})" flag "i")'
+                )
+            ) NOT VALID
+        SQL);
+            DB::statement(<<<'SQL'
+            ALTER TABLE public.estimate_generation_failure_identities
+            ADD CONSTRAINT eg_failure_identities_provider_model_ck_v2 CHECK (
+                (provider IS NULL OR provider ~ '^[a-z][a-z0-9_]{0,39}$')
+                AND (model IS NULL OR model ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,79}(/[A-Za-z0-9][A-Za-z0-9._-]{0,79})?$')
+                AND lower(COALESCE(provider, '') || COALESCE(model, '')) !~ '(token|secret|password|bearer|api[_-]?key|eyj|sk-|gh[pousr]_)'
+            ) NOT VALID
+        SQL);
+
+            DB::statement('ALTER TABLE public.estimate_generation_failure_events VALIDATE CONSTRAINT eg_failure_events_safe_context_closed_ck_v2');
+            DB::statement('ALTER TABLE public.estimate_generation_failure_events VALIDATE CONSTRAINT eg_failure_events_safe_context_values_ck_v2');
+            DB::statement('ALTER TABLE public.estimate_generation_failure_events VALIDATE CONSTRAINT eg_failure_events_safe_context_privacy_ck_v2');
+            DB::statement('ALTER TABLE public.estimate_generation_failure_identities VALIDATE CONSTRAINT eg_failure_identities_provider_model_ck_v2');
+
+            DB::transaction(function (): void {
+                DB::statement("SET LOCAL lock_timeout TO '5s'");
+                DB::statement('LOCK TABLE public.estimate_generation_failure_events, public.estimate_generation_failure_identities IN ACCESS EXCLUSIVE MODE');
+                DB::unprepared(<<<'SQL'
+                ALTER TABLE public.estimate_generation_failure_events
+                    DROP CONSTRAINT IF EXISTS eg_failure_events_safe_context_closed_ck,
+                    DROP CONSTRAINT IF EXISTS eg_failure_events_safe_context_values_ck,
+                    DROP CONSTRAINT IF EXISTS eg_failure_events_safe_context_privacy_ck;
+                ALTER TABLE public.estimate_generation_failure_events
+                    RENAME CONSTRAINT eg_failure_events_safe_context_closed_ck_v2 TO eg_failure_events_safe_context_closed_ck;
+                ALTER TABLE public.estimate_generation_failure_events
+                    RENAME CONSTRAINT eg_failure_events_safe_context_values_ck_v2 TO eg_failure_events_safe_context_values_ck;
+                ALTER TABLE public.estimate_generation_failure_events
+                    RENAME CONSTRAINT eg_failure_events_safe_context_privacy_ck_v2 TO eg_failure_events_safe_context_privacy_ck;
+                ALTER TABLE public.estimate_generation_failure_identities
+                    DROP CONSTRAINT IF EXISTS eg_failure_identities_provider_model_ck;
+                ALTER TABLE public.estimate_generation_failure_identities
+                    RENAME CONSTRAINT eg_failure_identities_provider_model_ck_v2 TO eg_failure_identities_provider_model_ck;
+                SQL);
+            });
+        } finally {
+            DB::statement("SELECT set_config('lock_timeout', ?, false)", [$previousLockTimeout]);
+            DB::statement("SELECT set_config('statement_timeout', ?, false)", [$previousStatementTimeout]);
+        }
+    }
+
+    public function down(): void
+    {
+        throw new LogicException('estimate_generation_failure_diagnostics_contract_is_irreversible');
+    }
+};

--- a/tests/Feature/EstimateGeneration/Documents/DocumentUnitRetryLeasePostgresTest.php
+++ b/tests/Feature/EstimateGeneration/Documents/DocumentUnitRetryLeasePostgresTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\EstimateGeneration\Documents;
+
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\EloquentDocumentProcessingUnitStore;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ProcessDocumentUnit;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\ResetDocumentProcessingUnitsForAttempt;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\Understanding\DocumentSheetOperationScope;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\Understanding\SheetAnalysisOperationIdentity;
+use App\BusinessModules\Addons\EstimateGeneration\Application\Documents\Understanding\SheetAnalysisOperationJournal;
+use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationDocument;
+use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationDocumentPage;
+use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationProcessingUnit;
+use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationSession;
+use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationSheetAnalysisOperation;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\User;
+use DateTimeImmutable;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+#[Group('postgres-contract')]
+final class DocumentUnitRetryLeasePostgresTest extends TestCase
+{
+    public function createApplication()
+    {
+        $app = require dirname(__DIR__, 4).'/bootstrap/app.php';
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+
+    #[Test]
+    public function persisted_terminal_history_can_renew_a_claim_in_a_new_processing_lineage(): void
+    {
+        if (getenv('RUN_ESTIMATE_GENERATION_POSTGRES_CONTRACT') !== '1' || DB::getDriverName() !== 'pgsql') {
+            self::markTestSkipped('Requires explicit isolated PostgreSQL contract environment.');
+        }
+        $organization = Organization::factory()->create();
+        $project = Project::factory()->for($organization)->create();
+        $user = User::factory()->create();
+        $sourceVersion = 'sha256:'.str_repeat('a', 64);
+        $oldAttemptId = '7d1385db-106e-47ab-993b-322fb5d124af';
+        $newAttemptId = '2899deb2-a38f-4eeb-9ebe-4d833c789bbb';
+        $session = EstimateGenerationSession::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'user_id' => $user->id,
+            'status' => 'processing_documents',
+            'processing_stage' => 'processing_documents',
+            'processing_progress' => 0,
+            'input_payload' => [],
+            'state_version' => 1,
+        ]);
+        $document = EstimateGenerationDocument::query()->create([
+            'session_id' => $session->id,
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'user_id' => $user->id,
+            'filename' => 'retry.pdf',
+            'mime_type' => 'application/pdf',
+            'source_version' => $sourceVersion,
+            'status' => 'failed',
+        ]);
+        $unit = EstimateGenerationProcessingUnit::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'session_id' => $session->id,
+            'document_id' => $document->id,
+            'unit_type' => 'pdf_page',
+            'unit_index' => 1,
+            'source_version' => $sourceVersion,
+            'status' => 'failed',
+            'attempt_count' => ProcessDocumentUnit::MAX_ATTEMPTS,
+            'failure_code' => 'document_unit_processing_failed',
+            'failure_fingerprint' => hash('sha256', 'old-failure'),
+            'failed_at' => now(),
+            'locator' => [
+                'source_kind' => 'pdf',
+                'source_version' => $sourceVersion,
+                'coordinate_space' => 'pdf_page_pixels',
+                'artifact_path' => 'org-'.$organization->id.'/estimate-generation/tests/page.png',
+                'artifact_source_version' => $sourceVersion,
+                'artifact_bytes' => 1,
+                'artifact_sha256' => $sourceVersion,
+                'artifact_version_id' => 'retry-lineage-fixture-v1',
+                'content_type' => 'image/png',
+            ],
+            'metadata' => [
+                'processing_attempt_id' => $oldAttemptId,
+                'failure_category' => 'terminal',
+                'actual_execution_count' => 1,
+                'failure_history' => [[
+                    'attempt_id' => '6b04208e-0f8a-43a6-b8bb-d4f5d86664bd',
+                    'attempt_count' => 3,
+                    'failure_code' => 'vision_http_failed',
+                    'failure_fingerprint' => hash('sha256', 'provider-failure'),
+                ]],
+            ],
+        ]);
+        EstimateGenerationDocumentPage::query()->create([
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'session_id' => $session->id,
+            'document_id' => $document->id,
+            'processing_unit_id' => $unit->id,
+            'source_version' => $sourceVersion,
+            'page_number' => 1,
+            'status' => 'failed',
+            'language_codes' => [],
+            'normalized_payload' => [],
+            'quality_flags' => [],
+        ]);
+
+        (new ResetDocumentProcessingUnitsForAttempt)->handle(
+            $document,
+            $sourceVersion,
+            $oldAttemptId,
+            $newAttemptId,
+        );
+        $store = new EloquentDocumentProcessingUnitStore(DB::connection());
+        $now = new DateTimeImmutable;
+        $claim = $store->claim(
+            (int) $unit->id,
+            $sourceVersion,
+            $now,
+            $now->modify('+2100 seconds'),
+            ProcessDocumentUnit::MAX_ATTEMPTS,
+        );
+        $context = $store->executionContext($claim);
+
+        self::assertNotNull($context);
+        self::assertSame($newAttemptId, $context->processingAttemptId);
+        $context->renewLeaseOrFail();
+        self::assertGreaterThan($now, $unit->fresh()->lease_expires_at?->toDateTimeImmutable());
+
+        $derivativeHash = 'sha256:'.str_repeat('b', 64);
+        $oldOperationId = SheetAnalysisOperationIdentity::primary(
+            (int) $session->id,
+            (int) $document->id,
+            (int) $unit->id,
+            $sourceVersion,
+            $derivativeHash,
+            $oldAttemptId,
+        );
+        EstimateGenerationSheetAnalysisOperation::query()->create([
+            'operation_id' => $oldOperationId,
+            'kind' => 'primary',
+            'organization_id' => $organization->id,
+            'project_id' => $project->id,
+            'session_id' => $session->id,
+            'document_id' => $document->id,
+            'unit_id' => $unit->id,
+            'source_version' => $sourceVersion,
+            'status' => 'failed',
+            'lease_token' => null,
+            'lease_expires_at' => null,
+            'attempt_count' => 2,
+            'initial_routing' => ['role' => 'unknown'],
+            'final_routing' => ['status' => 'pending'],
+            'analysis_payload' => ['status' => 'pending'],
+            'failure_reason' => 'old_provider_failure',
+        ]);
+        $operationId = SheetAnalysisOperationIdentity::primary(
+            (int) $session->id,
+            (int) $document->id,
+            (int) $unit->id,
+            $sourceVersion,
+            $derivativeHash,
+            $newAttemptId,
+        );
+        $scope = new DocumentSheetOperationScope(
+            (int) $organization->id,
+            (int) $project->id,
+            (int) $session->id,
+            (int) $document->id,
+            (int) $unit->id,
+            $sourceVersion,
+            (string) $claim->token,
+        );
+        $wireReached = false;
+        try {
+            (new SheetAnalysisOperationJournal)->run(
+                $operationId,
+                'primary',
+                $scope,
+                ['role' => 'unknown'],
+                static function () use (&$wireReached): never {
+                    $wireReached = true;
+
+                    throw new RuntimeException('provider_boundary_reached');
+                },
+            );
+            self::fail('The provider boundary sentinel was not raised.');
+        } catch (RuntimeException $error) {
+            self::assertSame('provider_boundary_reached', $error->getMessage());
+        }
+
+        self::assertTrue($wireReached);
+        self::assertNotSame($oldOperationId, $operationId);
+        self::assertDatabaseHas('estimate_generation_sheet_analysis_operations', [
+            'operation_id' => $operationId,
+            'unit_id' => $unit->id,
+            'status' => 'failed',
+            'attempt_count' => 1,
+        ]);
+    }
+}

--- a/tests/Feature/EstimateGeneration/EstimateGenerationFailureLedgerPostgresTest.php
+++ b/tests/Feature/EstimateGeneration/EstimateGenerationFailureLedgerPostgresTest.php
@@ -8,8 +8,10 @@ use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationDocum
 use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationProcessingUnit;
 use App\BusinessModules\Addons\EstimateGeneration\Models\EstimateGenerationSession;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\EloquentFailureStore;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureCategory;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureContext;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureNormalizer;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\TypedFailureException;
 use App\BusinessModules\Addons\EstimateGeneration\Pipeline\ProcessingStage;
 use App\Models\Organization;
 use App\Models\Project;
@@ -278,6 +280,62 @@ final class EstimateGenerationFailureLedgerPostgresTest extends TestCase
         }
     }
 
+    #[Test]
+    public function postgres_persists_bounded_pre_wire_diagnostics_for_the_pinned_provider_model(): void
+    {
+        $this->requireEnvironment(false);
+        $fixture = $this->fixture();
+        $eventId = (string) Str::uuid();
+        $processingAttemptId = (string) Str::uuid();
+
+        try {
+            $failure = (new FailureNormalizer)->normalize(
+                new TypedFailureException(
+                    FailureCategory::Terminal,
+                    'document_unit_pre_wire_failed',
+                    [
+                        'execution_boundary' => 'document_unit_representation',
+                        'processing_attempt_id' => $processingAttemptId,
+                    ],
+                    new \LogicException('private object path and signed URL'),
+                ),
+                new FailureContext(
+                    organizationId: $fixture['organization_id'],
+                    projectId: $fixture['project_id'],
+                    sessionId: $fixture['session_id'],
+                    stage: ProcessingStage::UnderstandDocuments,
+                    operation: 'process_unit',
+                    attempt: 1,
+                    correlationId: $eventId,
+                    eventId: $eventId,
+                    documentId: $fixture['document_id'],
+                    unitId: $fixture['unit_id'],
+                    provider: 'timeweb',
+                    model: 'openai/gpt-5.6-luna',
+                    processingAttemptId: $processingAttemptId,
+                ),
+            );
+
+            (new EloquentFailureStore(DB::connection()))->record(
+                $failure,
+                new \DateTimeImmutable('2026-08-13T18:27:12+00:00'),
+            );
+
+            $event = DB::table('estimate_generation_failure_events')->where('event_id', $eventId)->first();
+            self::assertNotNull($event);
+            $safeContext = json_decode((string) $event->safe_context, true, 16, JSON_THROW_ON_ERROR);
+            self::assertSame('logic_exception', $safeContext['root_exception_class']);
+            self::assertSame('document_unit_representation', $safeContext['execution_boundary']);
+            self::assertSame($processingAttemptId, $safeContext['processing_attempt_id']);
+            self::assertSame('openai/gpt-5.6-luna', DB::table('estimate_generation_failure_identities')
+                ->where('fingerprint', $failure->fingerprint)->value('model'));
+            self::assertStringNotContainsString('private', json_encode($safeContext, JSON_THROW_ON_ERROR));
+            self::assertStringNotContainsString('path', json_encode($safeContext, JSON_THROW_ON_ERROR));
+        } finally {
+            $this->cleanup($fixture);
+        }
+    }
+
     private function failure(array $fixture, string $eventId): \App\BusinessModules\Addons\EstimateGeneration\Observability\FailureData
     {
         return (new FailureNormalizer)->normalize(new RuntimeException('private document'), new FailureContext(
@@ -375,9 +433,20 @@ final class EstimateGenerationFailureLedgerPostgresTest extends TestCase
             $document = EstimateGenerationDocument::query()->create(['session_id' => $session->id, 'organization_id' => $organization->id,
                 'project_id' => $project->id, 'user_id' => $user->id, 'filename' => 'contract.pdf', 'mime_type' => 'application/pdf']);
             $fixture['document_id'] = (int) $document->id;
+            $sourceVersion = 'sha256:'.str_repeat('a', 64);
             $unit = EstimateGenerationProcessingUnit::query()->create(['organization_id' => $organization->id, 'project_id' => $project->id,
                 'session_id' => $session->id, 'document_id' => $document->id, 'unit_type' => 'pdf_page', 'unit_index' => 1,
-                'source_version' => 'contract-v1', 'status' => 'pending', 'locator' => [], 'metadata' => []]);
+                'source_version' => $sourceVersion, 'status' => 'pending', 'locator' => [
+                    'source_kind' => 'pdf',
+                    'source_version' => $sourceVersion,
+                    'coordinate_space' => 'pdf_page_pixels',
+                    'artifact_path' => 'org-'.$organization->id.'/estimate-generation/contracts/page-1.png',
+                    'artifact_source_version' => $sourceVersion,
+                    'artifact_version_id' => 'failure-contract-page-1',
+                    'artifact_bytes' => 1,
+                    'artifact_sha256' => $sourceVersion,
+                    'content_type' => 'image/png',
+                ], 'metadata' => (object) []]);
             $fixture['unit_id'] = (int) $unit->id;
 
             return $fixture;

--- a/tests/Support/EstimateGeneration/EstimateGenerationContractDatabaseProvisioner.php
+++ b/tests/Support/EstimateGeneration/EstimateGenerationContractDatabaseProvisioner.php
@@ -12,12 +12,12 @@ final class EstimateGenerationContractDatabaseProvisioner
     private const LOCK_FUNCTION_DEFINITION_SHA256 = '5485864f6b968742ea73b23de39fed9e33380d5f5649f924923352ef8e4510f8';
 
     private const INVENTORY_DIGEST = [
-        'geometry' => '0b91edf054220f275588aed03de0b6a4e9a95165bd728da1de4a6679239d0474',
-        'training' => '47a496e258535b303396eb80088940334f02743e14630652e16f599e012729a7',
-        'pricing' => '47a496e258535b303396eb80088940334f02743e14630652e16f599e012729a7',
+        'geometry' => '15188f630c48197a18659725d9f8d493acf44147894659812a3e21065bfabf3e',
+        'training' => '4a167aa891c13d44b15e73e96deeb2b4b68cf6f773dab692870b6218fd419374',
+        'pricing' => '4a167aa891c13d44b15e73e96deeb2b4b68cf6f773dab692870b6218fd419374',
     ];
 
-    private const FRESH_INVENTORY_DIGEST = '6cdcf45b1e6bbf19c834fd9497499c877b666a28a7cea79ef2c0f816a2e7bd1f';
+    private const FRESH_INVENTORY_DIGEST = '28b1b798e18a64c87125bbb64fb910ec3ef975d5b7bd5aad2b10f931c0308fd3';
 
     private const SUBJECT = [
         'geometry' => [
@@ -171,6 +171,8 @@ final class EstimateGenerationContractDatabaseProvisioner
         'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000100_pin_effective_vision_model.php',
         'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000200_expand_sheet_analysis_source_version.php',
         'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000210_finalize_terminal_explicit_document_retries.php',
+        'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000210_allow_sheet_analysis_retry_lineages.php',
+        'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000220_expand_failure_diagnostics_contract.php',
         'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_03_000100_backfill_document_unit_provenance.php',
         'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_04_000100_fix_document_unit_provenance_regex_bound.php',
         'app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_10_000100_add_request_context_to_estimate_generation_ai_usage.php',

--- a/tests/Unit/EstimateGeneration/Observability/FailurePersistenceContractTest.php
+++ b/tests/Unit/EstimateGeneration/Observability/FailurePersistenceContractTest.php
@@ -51,6 +51,36 @@ final class FailurePersistenceContractTest extends TestCase
     }
 
     #[Test]
+    public function diagnostic_expansion_keeps_a_closed_bounded_postgres_contract(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 4)
+            .'/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000220_expand_failure_diagnostics_contract.php');
+
+        self::assertIsString($source);
+        foreach ([
+            'diagnostic_fingerprint',
+            'exception_chain_fingerprint',
+            'root_exception_class',
+            'execution_boundary',
+            'processing_attempt_id',
+            'requested_model',
+            'jsonb_path_exists',
+            'NOT VALID',
+            'VALIDATE CONSTRAINT',
+            'RENAME CONSTRAINT',
+            'public $withinTransaction = false',
+            'failure_diagnostics_contract_is_irreversible',
+            "SET lock_timeout TO '5s'",
+            "SET statement_timeout TO '120s'",
+            'LOCK TABLE public.estimate_generation_failure_events, public.estimate_generation_failure_identities',
+            "set_config('lock_timeout'",
+        ] as $required) {
+            self::assertStringContainsString($required, $source);
+        }
+        self::assertStringContainsString('eg_failure_events_safe_context_size_ck', $this->migrationSource());
+    }
+
+    #[Test]
     public function model_and_store_are_module_owned_and_store_implements_contract(): void
     {
         self::assertSame('estimate_generation_failures', (new EstimateGenerationFailure)->getTable());

--- a/tests/Unit/EstimateGeneration/Observability/FailureRecorderTest.php
+++ b/tests/Unit/EstimateGeneration/Observability/FailureRecorderTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\EstimateGeneration\Observability;
 
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureContext;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureData;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\FailurePersistenceDiagnostic;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureRecorder;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureRecorderObserver;
 use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureStore;
@@ -43,9 +44,13 @@ final class FailureRecorderTest extends TestCase
             /** @var list<FailureData> */
             public array $events = [];
 
-            public function recordingFailed(FailureData $failure): void
+            /** @var list<FailurePersistenceDiagnostic> */
+            public array $persistenceFailures = [];
+
+            public function recordingFailed(FailureData $failure, FailurePersistenceDiagnostic $persistenceFailure): void
             {
                 $this->events[] = $failure;
+                $this->persistenceFailures[] = $persistenceFailure;
             }
         };
         $recorder = new FailureRecorder($store, observer: $observer);
@@ -61,8 +66,12 @@ final class FailureRecorderTest extends TestCase
         self::assertSame('unexpected_internal_failure', $observer->events[0]->code);
         self::assertSame(1000, $observer->events[0]->context->documentId);
         self::assertMatchesRegularExpression('/^sha256:[0-9a-f]{64}$/', $observer->events[0]->fingerprint);
+        self::assertSame('failure_observability_persistence_failed', $observer->persistenceFailures[0]->code);
+        self::assertSame('runtime_exception', $observer->persistenceFailures[0]->exceptionClass);
+        self::assertMatchesRegularExpression('/^sha256:[0-9a-f]{64}$/', $observer->persistenceFailures[0]->fingerprint);
         self::assertStringNotContainsString('secret', json_encode($observer->events, JSON_THROW_ON_ERROR));
         self::assertStringNotContainsString('private', json_encode($observer->events, JSON_THROW_ON_ERROR));
+        self::assertStringNotContainsString('secret', json_encode($observer->persistenceFailures, JSON_THROW_ON_ERROR));
     }
 
     #[Test]
@@ -87,7 +96,7 @@ final class FailureRecorderTest extends TestCase
         };
         $observer = new class implements FailureRecorderObserver
         {
-            public function recordingFailed(FailureData $failure): void
+            public function recordingFailed(FailureData $failure, FailurePersistenceDiagnostic $persistenceFailure): void
             {
                 throw new RuntimeException('logging transport secret');
             }

--- a/tests/Unit/EstimateGeneration/Observability/SafeLogFailureRecorderObserverTest.php
+++ b/tests/Unit/EstimateGeneration/Observability/SafeLogFailureRecorderObserverTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\EstimateGeneration\Observability;
+
+use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureContext;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\FailureNormalizer;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\FailurePersistenceDiagnostic;
+use App\BusinessModules\Addons\EstimateGeneration\Observability\SafeLogFailureRecorderObserver;
+use App\BusinessModules\Addons\EstimateGeneration\Pipeline\ProcessingStage;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Tests\Support\DatabaseLessTestCase;
+
+final class SafeLogFailureRecorderObserverTest extends DatabaseLessTestCase
+{
+    #[Test]
+    public function fallback_logs_only_typed_persistence_identity_without_raw_messages(): void
+    {
+        $failure = (new FailureNormalizer)->normalize(
+            new RuntimeException('private prompt and signed storage path'),
+            new FailureContext(
+                organizationId: 1,
+                projectId: 2,
+                sessionId: 3,
+                stage: ProcessingStage::UnderstandDocuments,
+                operation: 'process_unit',
+                attempt: 1,
+                correlationId: '018f4a20-3f4c-7a11-8a22-123456789abc',
+                eventId: '018f4a20-3f4c-7a11-8a22-123456789abd',
+                documentId: 4,
+                unitId: 5,
+            ),
+        );
+        $persistenceFailure = FailurePersistenceDiagnostic::fromThrowable(
+            new RuntimeException('database password and private socket path'),
+        );
+
+        Log::shouldReceive('error')->once()->with(
+            '[EstimateGeneration] failure observability persistence failed',
+            \Mockery::on(static function (array $context): bool {
+                $encoded = json_encode($context, JSON_THROW_ON_ERROR);
+
+                return ($context['persistence_failure']['code'] ?? null) === 'failure_observability_persistence_failed'
+                    && ($context['persistence_failure']['exception_class'] ?? null) === 'runtime_exception'
+                    && preg_match('/^sha256:[0-9a-f]{64}$/', (string) ($context['persistence_failure']['diagnostic_fingerprint'] ?? '')) === 1
+                    && ! str_contains($encoded, 'password')
+                    && ! str_contains($encoded, 'socket')
+                    && ! str_contains($encoded, 'private prompt');
+            }),
+        );
+
+        (new SafeLogFailureRecorderObserver)->recordingFailed($failure, $persistenceFailure);
+    }
+}

--- a/tests/Unit/EstimateGeneration/SheetAnalysisRoutingContractTest.php
+++ b/tests/Unit/EstimateGeneration/SheetAnalysisRoutingContractTest.php
@@ -115,6 +115,19 @@ final class SheetAnalysisRoutingContractTest extends TestCase
     }
 
     #[Test]
+    public function explicit_retry_lineages_are_not_rejected_by_the_legacy_scope_unique_constraint(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $migration = (string) file_get_contents($root
+            .'/app/BusinessModules/Addons/EstimateGeneration/migrations/2026_08_13_000210_allow_sheet_analysis_retry_lineages.php');
+
+        self::assertStringContainsString('DROP CONSTRAINT IF EXISTS eg_sheet_analysis_scope_kind_uq', $migration);
+        self::assertStringContainsString('CREATE INDEX CONCURRENTLY IF NOT EXISTS eg_sheet_analysis_scope_kind_idx', $migration);
+        self::assertStringNotContainsString('CREATE UNIQUE INDEX', $migration);
+        self::assertStringContainsString('sheet_analysis_retry_lineages_are_irreversible', $migration);
+    }
+
+    #[Test]
     public function document_vision_runtime_cannot_outlive_its_journal_or_unit_lease(): void
     {
         $root = dirname(__DIR__, 3);


### PR DESCRIPTION
## Что исправлено
- устранён конфликт journal между старой и новой retry-lineage
- расширен безопасный PostgreSQL-контракт диагностических событий
- fallback observability теперь сообщает typed persistence failure без сырых сообщений
- DDL выполняется online с bounded lock/statement timeout

## Проверки
- 78 targeted DB-free tests, 505 assertions
- 2 isolated PostgreSQL contract tests, 14 assertions
- php-l, Pint, git diff --check
- independent correctness/security/architecture review: no P1/P2

Larastan bootstrap blocked by unrelated storage_configuration_invalid eager validation.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced FailurePersistenceDiagnostic to capture and report details when failure recording fails.</li>
<li>Updated FailureRecorder to pass persistence diagnostic information to the observer when a recording error occurs.</li>
<li>Updated FailureRecorderObserver interface and implementations (Null, SafeLog) to accept the new diagnostic parameter.</li>
<li>Added database migrations to support expanded failure diagnostics and retry lineages.</li>
<li>Updated multiple test suites to accommodate the changes in the failure recording contract.</li>
</ul></div>