### PR TITLE
fix[backend]: сохранена безопасная причина ошибки Vision

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebProviderErrorInspector.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebProviderErrorInspector.php
@@ -35,6 +35,8 @@ final readonly class TimewebProviderErrorInspector
         $type = $this->typedValue($error['type'] ?? null);
         $code = $this->typedValue($error['code'] ?? null);
         $param = $this->parameter($error['param'] ?? null);
+        $message = $this->messageDiagnostic($error['message'] ?? null);
+        $messageFingerprint = $message === null ? null : 'sha256:'.hash('sha256', (string) $error['message']);
         $envelopeKind = $error === null ? 'unknown' : 'openai_error';
         $bodyShapeFingerprint = $this->bodyShapeFingerprint($body, $truncated, $contentType);
         $diagnosticFingerprint = 'sha256:'.hash('sha256', json_encode([
@@ -45,7 +47,9 @@ final readonly class TimewebProviderErrorInspector
             'error_param' => $param,
             'error_identity' => $error === null
                 ? $bodyShapeFingerprint
-                : ['type' => $type, 'code' => $code, 'param' => $param],
+                : ['type' => $type, 'code' => $code, 'param' => $param, 'message' => $type === null && $code === null && $param === null
+                    ? [$message['code'] ?? 'provider_message_missing', $message['parameter'] ?? null]
+                    : null],
             'model' => $model,
             'endpoint_kind' => $endpointKind,
             'prompt_contract_fingerprint' => $promptContractFingerprint,
@@ -73,9 +77,25 @@ final readonly class TimewebProviderErrorInspector
         if ($param !== null) {
             $payload['error_param'] = $param;
         }
-        $payload['diagnostic_summary'] = $this->diagnosticSummary($httpStatus, $envelopeKind, $type, $code, $param);
+        if ($message !== null && $messageFingerprint !== null) {
+            $payload['error_message_code'] = $message['code'];
+            if (isset($message['preview'])) {
+                $payload['error_message_preview'] = $message['preview'];
+            }
+            $payload['error_message_fingerprint'] = $messageFingerprint;
+        }
+        $payload['diagnostic_summary'] = $this->diagnosticSummary(
+            $httpStatus,
+            $envelopeKind,
+            $type,
+            $code,
+            $param,
+            $message['code'] ?? null,
+            $message['parameter'] ?? null,
+            $messageFingerprint,
+        );
         if ($error === null) {
-            $payload['redacted_preview'] = $this->safeText($body, $limit);
+            $payload['redacted_preview'] = '[redacted-unclassified-body]';
         }
 
         return new ProviderErrorDiagnostics($payload, array_filter([
@@ -130,7 +150,8 @@ final readonly class TimewebProviderErrorInspector
 
     private function typedValue(mixed $value): ?string
     {
-        if (! is_string($value) || strlen($value) > self::MAX_TYPED_VALUE_BYTES
+        $value = is_string($value) ? trim($value) : null;
+        if ($value === null || $this->isNullMarker($value) || strlen($value) > self::MAX_TYPED_VALUE_BYTES
             || preg_match('/\A[a-zA-Z][a-zA-Z0-9._-]*\z/', $value) !== 1) {
             return null;
         }
@@ -140,7 +161,8 @@ final readonly class TimewebProviderErrorInspector
 
     private function parameter(mixed $value): ?string
     {
-        if (! is_string($value) || strlen($value) > self::MAX_TYPED_VALUE_BYTES
+        $value = is_string($value) ? trim($value) : null;
+        if ($value === null || $this->isNullMarker($value) || strlen($value) > self::MAX_TYPED_VALUE_BYTES
             || preg_match('/\A[a-zA-Z][a-zA-Z0-9_.\[\]-]*\z/', $value) !== 1) {
             return null;
         }
@@ -161,6 +183,9 @@ final readonly class TimewebProviderErrorInspector
         ?string $type,
         ?string $code,
         ?string $param,
+        ?string $messageCode,
+        ?string $messageParameter,
+        ?string $messageFingerprint,
     ): string {
         return implode('; ', array_filter([
             'provider_http_status='.$httpStatus,
@@ -168,7 +193,48 @@ final readonly class TimewebProviderErrorInspector
             $type === null ? null : 'type='.$type,
             $code === null ? null : 'code='.$code,
             $param === null ? null : 'param='.$param,
+            $messageCode === null ? null : 'message_code='.$messageCode,
+            $messageParameter === null ? null : 'message_param='.$messageParameter,
+            $messageFingerprint === null ? null : 'message_fingerprint='.$messageFingerprint,
         ], static fn (?string $value): bool => $value !== null));
+    }
+
+    /** @return array{code: string, preview?: string, parameter?: string}|null */
+    private function messageDiagnostic(mixed $value): ?array
+    {
+        if (! is_string($value) || $this->isNullMarker(trim($value))) {
+            return null;
+        }
+
+        $message = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+        if (preg_match('/\b(unsupported|unknown|unrecognized|invalid)\s+(?:parameter|argument|field)\s*(?::|=)?\s*[\'\"]?([A-Za-z][A-Za-z0-9_.\[\]-]{0,119})/i', $message, $matches) === 1) {
+            $parameter = $this->parameter($matches[2]);
+            if ($parameter !== null) {
+                $code = strtolower($matches[1]) === 'invalid' ? 'invalid_parameter' : 'unsupported_parameter';
+
+                return [
+                    'code' => $code,
+                    'preview' => ($code === 'invalid_parameter' ? 'Invalid parameter: ' : 'Unsupported parameter: ').$parameter,
+                    'parameter' => $parameter,
+                ];
+            }
+        }
+        if (preg_match('/\binvalid\s+(?:json\s+)?schema(?:\s+for)?\s*[\'\"]?([A-Za-z][A-Za-z0-9_.\[\]-]{0,119})/i', $message, $matches) === 1) {
+            $parameter = $this->parameter($matches[1]);
+            if ($parameter !== null) {
+                return ['code' => 'invalid_schema', 'preview' => 'Invalid schema: '.$parameter, 'parameter' => $parameter];
+            }
+        }
+        if (preg_match('/\bmodel\s+[\'\"]?([A-Za-z0-9][A-Za-z0-9._\/-]{0,159})[\'\"]?\s+(?:is\s+)?(?:not\s+found|unavailable|not\s+supported)/i', $message, $matches) === 1) {
+            return ['code' => 'model_unavailable', 'preview' => 'Model unavailable'];
+        }
+
+        return ['code' => 'provider_message_unclassified'];
+    }
+
+    private function isNullMarker(string $value): bool
+    {
+        return in_array(strtolower($value), ['', 'none', 'null'], true);
     }
 
     private function bodyShapeFingerprint(string $body, bool $truncated, string $contentType): string
@@ -228,6 +294,13 @@ final readonly class TimewebProviderErrorInspector
             '~[?&](?:x-amz-[a-z-]+|signature|token|key|secret)=[^&\s"\']+~i' => '[redacted-query]',
             '~\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b~i' => '[redacted-email]',
             '~(?<!\d)(?:\+?\d[\s().-]*){10,15}(?!\d)~' => '[redacted-phone]',
+            '~\b[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b~i' => '[redacted-id]',
+            '~\b[0-9a-f]{24,}\b~i' => '[redacted-id]',
+            '~\b[A-Za-z]:[\\\\/][^\s;]+~' => '[redacted-path]',
+            '~/(?:org-\d+|app|home|tmp|var|storage)(?:/[^\s;,]+)+~i' => '[redacted-path]',
+            '~\b[A-Za-z0-9+/=_-]{128,}\b~' => '[redacted-binary]',
+            '~\b(prompt|user(?:_text| text)?|input)\s*[:=].*$~i' => '$1=[redacted]',
+            '~\bcustomer text\s+(?:"(?:\\\\.|[^"])*"|\'(?:\\\\.|[^\'])*\'|[^;,.]{1,320})~i' => 'customer text [redacted]',
             '~[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]+~u' => ' ',
         ];
         $redacted = preg_replace(array_keys($patterns), array_values($patterns), $value) ?? '';

--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebVisionProvider.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/Providers/TimewebVisionProvider.php
@@ -277,6 +277,7 @@ final readonly class TimewebVisionProvider implements VisionProvider
                         Log::warning('[EstimateGeneration Vision] provider HTTP failure', [
                             ...array_diff_key($diagnostics->payload, [
                                 'redacted_preview' => true,
+                                'error_message_preview' => true,
                             ]),
                             'organization_id' => $input->organizationId,
                             'project_id' => $input->projectId,

--- a/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
+++ b/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
@@ -373,10 +373,10 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
         self::assertSame('invalid_request_error', $diagnostic['error_type']);
         self::assertSame('unsupported_parameter', $diagnostic['error_code']);
         self::assertSame('response_format', $diagnostic['error_param']);
-        self::assertSame(
-            'provider_http_status=400; envelope=openai_error; type=invalid_request_error; code=unsupported_parameter; param=response_format',
-            $diagnostic['diagnostic_summary'],
-        );
+        self::assertStringContainsString('message_code=unsupported_parameter', $diagnostic['diagnostic_summary']);
+        self::assertStringContainsString('message_param=response_format', $diagnostic['diagnostic_summary']);
+        self::assertStringContainsString('message_fingerprint=sha256:', $diagnostic['diagnostic_summary']);
+        self::assertSame('Unsupported parameter: response_format', $diagnostic['error_message_preview']);
         self::assertArrayNotHasKey('error_message', $diagnostic);
         self::assertSame('application/json', $diagnostic['response_content_type']);
         self::assertSame('openai/gpt-5.6-luna', $diagnostic['model']);
@@ -402,8 +402,105 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
                 && ($context['error_param'] ?? null) === 'response_format'
                 && ! str_contains(json_encode($context, JSON_THROW_ON_ERROR), $secret)
                 && ! array_key_exists('redacted_preview', $context)
+                && ! array_key_exists('error_message_preview', $context)
                 && ! array_key_exists('request', $context),
         );
+    }
+
+    #[Test]
+    public function production_openai_error_with_null_identity_keeps_a_bounded_sanitized_message(): void
+    {
+        $message = "Unsupported parameter: 'response_format.json_schema.strict' is not available for this model.";
+        Http::fake(['*' => Http::response([
+            'error' => [
+                'message' => $message,
+                'type' => null,
+                'param' => null,
+                'code' => null,
+            ],
+        ], 400, ['Content-Type' => 'application/json'])]);
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Terminal provider rejection was accepted.');
+        } catch (VisionProviderException $exception) {
+            self::assertSame('vision_provider_request_rejected', $exception->reason);
+            self::assertArrayNotHasKey('provider_error_type', $exception->safeContext);
+            self::assertArrayNotHasKey('provider_error_code', $exception->safeContext);
+            self::assertArrayNotHasKey('provider_error_param', $exception->safeContext);
+            self::assertArrayNotHasKey('error_message_preview', $exception->safeContext);
+        }
+
+        $diagnostic = $this->physicalAttempts->onlySnapshot()->responsePayload['provider_error'];
+        self::assertSame('unsupported_parameter', $diagnostic['error_message_code']);
+        self::assertSame('Unsupported parameter: response_format.json_schema.strict', $diagnostic['error_message_preview']);
+        self::assertArrayNotHasKey('error_type', $diagnostic);
+        self::assertArrayNotHasKey('error_code', $diagnostic);
+        self::assertArrayNotHasKey('error_param', $diagnostic);
+        self::assertMatchesRegularExpression('/\Asha256:[0-9a-f]{64}\z/', $diagnostic['error_message_fingerprint']);
+        self::assertStringContainsString('message_fingerprint='.$diagnostic['error_message_fingerprint'], $diagnostic['diagnostic_summary']);
+        self::assertLessThanOrEqual(320, strlen($diagnostic['error_message_preview']));
+    }
+
+    #[Test]
+    public function string_null_identity_and_sensitive_or_oversized_message_are_safely_normalized(): void
+    {
+        $secret = 'sk-live-DoNotPersist123456789';
+        $uuid = '976e6171-d8a0-4ba8-8ad3-6148933d931c';
+        $message = "Invalid request for api_key=prodLiveAbc123; s3://confidential-bucket/project/private.pdf; Authorization: Bearer {$secret}; "
+            .'https://storage.example/private.png?X-Amz-Signature=hidden; C:\\private\\drawing.png; /org-38/private/drawing.png; '
+            ."owner@example.test; {$uuid}; data:image/png;base64,".str_repeat('A', 2_000)."; prompt:\n".str_repeat('PRIVATE CUSTOMER TEXT ', 100);
+        Http::fake(['*' => Http::response([
+            'error' => [
+                'message' => $message,
+                'type' => 'None',
+                'param' => ' null ',
+                'code' => 'NONE',
+            ],
+        ], 400, ['Content-Type' => 'application/json'])]);
+
+        try {
+            $this->provider()->analyze($this->input());
+            self::fail('Terminal provider rejection was accepted.');
+        } catch (VisionProviderException) {
+        }
+
+        $diagnostic = $this->physicalAttempts->onlySnapshot()->responsePayload['provider_error'];
+        $encoded = json_encode($diagnostic, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        self::assertArrayNotHasKey('error_type', $diagnostic);
+        self::assertArrayNotHasKey('error_code', $diagnostic);
+        self::assertArrayNotHasKey('error_param', $diagnostic);
+        self::assertSame('provider_message_unclassified', $diagnostic['error_message_code']);
+        self::assertArrayNotHasKey('error_message_preview', $diagnostic);
+        foreach ([$secret, 'prodLiveAbc123', 'confidential-bucket', 'storage.example', 'X-Amz-Signature', 'C:\\private', '/org-38/', 'owner@example.test', $uuid, 'data:image', 'PRIVATE CUSTOMER TEXT'] as $forbidden) {
+            self::assertStringNotContainsString($forbidden, $encoded);
+        }
+    }
+
+    #[Test]
+    public function null_identity_breaker_ignores_request_ids_and_reflected_customer_text(): void
+    {
+        Http::fakeSequence()
+            ->push(['error' => ['message' => "Unsupported parameter 'response_format' for req-A111 and customer text 'private one'.", 'type' => null, 'param' => null, 'code' => null]], 400)
+            ->push(['error' => ['message' => "Unsupported parameter 'response_format' for req-B222 and customer text 'private two'.", 'type' => null, 'param' => null, 'code' => null]], 400);
+
+        foreach ([1, 2] as $claim) {
+            try {
+                $this->provider()->analyze($this->input(claim: $claim));
+                self::fail('Terminal provider rejection was accepted.');
+            } catch (VisionProviderException) {
+            }
+        }
+
+        $snapshots = $this->physicalAttempts->snapshots();
+        self::assertCount(2, $snapshots);
+        self::assertSame(
+            $snapshots[0]->responsePayload['provider_error']['diagnostic_fingerprint'],
+            $snapshots[1]->responsePayload['provider_error']['diagnostic_fingerprint'],
+        );
+        self::assertSame('Unsupported parameter: response_format', $snapshots[0]->responsePayload['provider_error']['error_message_preview']);
+        self::assertStringNotContainsString('private', json_encode($snapshots, JSON_THROW_ON_ERROR));
+        self::assertStringNotContainsString('req-', json_encode($snapshots, JSON_THROW_ON_ERROR));
     }
 
     #[Test]
@@ -498,7 +595,7 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
         self::assertStringNotContainsString('PRIVATE CUSTOMER TEXT', $diagnostic['redacted_preview']);
         self::assertStringNotContainsString('999', $diagnostic['redacted_preview']);
         self::assertStringNotContainsString('storage.example', $diagnostic['redacted_preview']);
-        self::assertStringContainsString('[redacted]', $diagnostic['redacted_preview']);
+        self::assertSame('[redacted-unclassified-body]', $diagnostic['redacted_preview']);
         Log::shouldHaveReceived('warning')->once()->withArgs(
             static fn (string $message, array $context): bool => $message === '[EstimateGeneration Vision] provider HTTP failure'
                 && ! array_key_exists('redacted_preview', $context)


### PR DESCRIPTION
## Что исправлено
- JSON null и строковые None/null больше не становятся typed provider fields
- OpenAI error.message преобразуется только в allowlisted canonical technical summary
- произвольный provider/customer text не сохраняется; остаётся hash
- breaker identity не зависит от request-id и reflected text
- preview исключён из API-safe exception context и warning logs

## Проверки
- 75 targeted tests, 293 assertions
- php-l, Pint, git diff --check
- independent security/correctness review: no blocker/P1/P2

Larastan bootstrap blocked by unrelated storage_configuration_invalid.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enhanced error inspection by adding message-level diagnostics (code, parameter, and fingerprint) to provider error reports.</li>
<li>Implemented sanitization and normalization for error messages, including trimming, null-marker handling, and length limiting.</li>
<li>Updated diagnostic summaries to include message-specific metadata, improving observability of provider rejections.</li>
<li>Added unit tests to verify safe handling of sensitive or oversized error messages and null-identity error scenarios.</li>
</ul></div>