### PR TITLE
fix[backend]: восстановлено чтение сохранённых элементов Vision

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/DTO/VisionAnalysisData.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/DTO/VisionAnalysisData.php
@@ -224,7 +224,7 @@ final readonly class VisionAnalysisData
         );
         $elements = array_map(
             static fn (mixed $item): VisionElementData => is_array($item)
-                ? VisionElementData::fromArray($item)
+                ? VisionElementData::fromArray(self::normalizeStoredElement($item))
                 : throw new VisionContractException('invalid_element'),
             $data['elements'],
         );
@@ -262,6 +262,23 @@ final readonly class VisionAnalysisData
             is_array($data['visual_attributes'] ?? null) ? $data['visual_attributes'] : [],
             $projectSheetAnalysis,
         );
+    }
+
+    /** @param array<string, mixed> $element @return array<string, mixed> */
+    private static function normalizeStoredElement(array $element): array
+    {
+        $keys = array_keys($element);
+        sort($keys);
+        $expected = ['confidence', 'evidence_ref', 'key', 'polygon', 'type'];
+        sort($expected);
+        if ($keys === $expected) {
+            return [...$element, 'label' => null];
+        }
+
+        $opening = [...$expected, 'geometry'];
+        sort($opening);
+
+        return $keys === $opening ? [...$element, 'label' => null] : $element;
     }
 
     /**

--- a/app/BusinessModules/Addons/EstimateGeneration/Vision/DTO/VisionElementData.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/Vision/DTO/VisionElementData.php
@@ -80,7 +80,15 @@ final readonly class VisionElementData
     /** @return array<string, mixed> */
     public function toArray(): array
     {
-        return array_filter(['key' => $this->key, 'type' => $this->type, 'label' => $this->label, 'polygon' => $this->polygon, 'confidence' => $this->confidence, 'evidence_ref' => $this->evidenceRef, 'geometry' => $this->geometry], static fn (mixed $value): bool => $value !== null);
+        return [
+            'key' => $this->key,
+            'type' => $this->type,
+            'label' => $this->label,
+            'polygon' => $this->polygon,
+            'confidence' => $this->confidence,
+            'evidence_ref' => $this->evidenceRef,
+            ...($this->geometry === null ? [] : ['geometry' => $this->geometry]),
+        ];
     }
 
     private static function validOpeningGeometry(array $geometry): bool

--- a/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
+++ b/tests/Unit/EstimateGeneration/Vision/TimewebVisionProviderTest.php
@@ -1019,6 +1019,46 @@ final class TimewebVisionProviderTest extends DatabaseLessTestCase
     }
 
     #[Test]
+    public function stored_elements_with_nullable_label_round_trip_without_losing_required_shape(): void
+    {
+        $response = $this->response(['elements' => [[
+            'key' => 'wall-1',
+            'type' => 'wall',
+            'label' => null,
+            'polygon' => [[0.1, 0.1], [0.2, 0.1]],
+            'confidence' => 0.9,
+            'evidence_ref' => 'page-1',
+        ]]]);
+        Http::fake(['*' => Http::response($response)]);
+
+        $result = $this->provider()->analyze($this->input());
+        $stored = $result->toArray();
+        unset($stored['elements'][0]['label']);
+        $stored['elements'][] = [
+            'key' => 'window-1',
+            'type' => 'opening',
+            'polygon' => [[0.1, 0.1], [0.2, 0.1]],
+            'confidence' => 0.8,
+            'evidence_ref' => 'page-1',
+            'geometry' => [
+                'wall_key' => 'wall-1',
+                'opening_type' => 'window',
+                'offset' => 0,
+                'width' => 1.2,
+                'height' => 1.5,
+            ],
+        ];
+
+        $replayed = VisionAnalysisData::fromStoredArray($stored);
+        $reserialized = $replayed->toArray();
+
+        self::assertArrayHasKey('label', $reserialized['elements'][0]);
+        self::assertNull($reserialized['elements'][0]['label']);
+        self::assertNull($reserialized['elements'][1]['label']);
+        self::assertSame('wall-1', VisionAnalysisData::fromStoredArray($reserialized)->elements[0]->key);
+    }
+
+    #[Test]
     public function persisted_invalid_json_is_not_retried_with_a_second_charge(): void
     {
         $invalid = $this->response();


### PR DESCRIPTION
## Причина
VisionElementData::toArray удалял обязательный nullable label. Strict replay сохранённого результата падал invalid_element и recovery job повторял rebuild.

## Исправление
- label всегда сохраняется, включая null
- geometry остаётся опциональным
- provider→stored→replay round-trip покрыт регрессией

## Проверки
- exact RED/GREEN: 1 тест, 3 assertions
- связанные Vision regressions: 2 теста, 10 assertions
- php-l, Pint, git diff --check
- read-only production SQL подтвердил shape без чтения label content

Новых AI-вызовов нет.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored VisionElementData::toArray to explicitly include null values for keys like 'label' instead of filtering them out.</li>
<li>Updated the geometry field handling in toArray to only include it if it is not null.</li>
<li>Added a unit test in TimewebVisionProviderTest to verify that elements with null labels maintain their structure during round-trip serialization.</li>
</ul></div>