### PR TITLE
fix[backend]: согласованы ключи Vision и модели здания

### DIFF
--- a/app/BusinessModules/Addons/EstimateGeneration/BuildingModel/BuildingModelAssembler.php
+++ b/app/BusinessModules/Addons/EstimateGeneration/BuildingModel/BuildingModelAssembler.php
@@ -55,6 +55,7 @@ final class BuildingModelAssembler
         $engineering = [];
         $roomKeys = [];
         $wallKeys = [];
+        $modelKeys = [];
         $clarifications = [];
         $floorEvidence = [];
         $modelElements = [];
@@ -67,6 +68,10 @@ final class BuildingModelAssembler
             }
             $modelElements[] = $element;
         }
+        $modelKeys = $this->buildingModelKeys(
+            array_map(static fn (FusedGeometryElementData $element): string => $element->key, $modelElements),
+            $input->floorKey,
+        );
         foreach ($modelElements as $element) {
             if ($element->type === 'room') {
                 $roomKeys[$element->key] = true;
@@ -84,10 +89,10 @@ final class BuildingModelAssembler
             }
             $floorEvidence = [...$floorEvidence, ...$evidenceIds];
             if ($element->type === 'room') {
-                $rooms[] = new RoomData($element->key, $element->label, $confirmed ? $this->metricPolygon($element, $input->scale->metersPerUnit) : null, $evidenceIds, $element->confidence, $confirmed ? 'confirmed' : 'unknown');
+                $rooms[] = new RoomData($modelKeys[$element->key], $element->label, $confirmed ? $this->metricPolygon($element, $input->scale->metersPerUnit) : null, $evidenceIds, $element->confidence, $confirmed ? 'confirmed' : 'unknown');
             } elseif ($element->type === 'wall') {
                 $walls[] = new WallData(
-                    $element->key,
+                    $modelKeys[$element->key],
                     $confirmed ? $this->metricPoint($element->geometry['start'], $input->scale->metersPerUnit) : null,
                     $confirmed ? $this->metricPoint($element->geometry['end'], $input->scale->metersPerUnit) : null,
                     $confirmed ? $this->metricValue($element->geometry['thickness'], $input->scale->metersPerUnit) : null,
@@ -101,7 +106,7 @@ final class BuildingModelAssembler
                     continue;
                 }
                 $openings[] = new OpeningData(
-                    $element->key, $element->geometry['wall_key'], $element->geometry['opening_type'],
+                    $modelKeys[$element->key], $modelKeys[$element->geometry['wall_key']], $element->geometry['opening_type'],
                     $confirmed ? $this->metricValue($element->geometry['offset'], $input->scale->metersPerUnit) : null,
                     $confirmed ? $this->metricValue($element->geometry['width'], $input->scale->metersPerUnit) : null,
                     $confirmed ? $this->metricValue($element->geometry['height'], $input->scale->metersPerUnit) : null,
@@ -114,9 +119,10 @@ final class BuildingModelAssembler
                     continue;
                 }
                 $engineering[] = new EngineeringElementData(
-                    $element->key, $element->geometry['engineering_type'],
+                    $modelKeys[$element->key], $element->geometry['engineering_type'],
                     $confirmed ? $this->metricPoint($element->geometry['location'], $input->scale->metersPerUnit) : null,
-                    $element->geometry['room_key'], $evidenceIds, $element->confidence, $confirmed ? 'confirmed' : 'unknown',
+                    $element->geometry['room_key'] === null ? null : $modelKeys[$element->geometry['room_key']],
+                    $evidenceIds, $element->confidence, $confirmed ? 'confirmed' : 'unknown',
                     $confirmed && is_array($element->geometry['path'] ?? null)
                         ? $this->metricValue(hypot(
                             (float) $element->geometry['path'][1][0] - (float) $element->geometry['path'][0][0],
@@ -360,6 +366,51 @@ final class BuildingModelAssembler
         }
 
         return min(array_map(static fn (FusedGeometryElementData $element): float => $element->confidence, $elements));
+    }
+
+    private function buildingModelKey(string $sourceKey): string
+    {
+        if (preg_match('/^[a-z][a-z0-9_-]{0,127}$/', $sourceKey) === 1) {
+            return $sourceKey;
+        }
+
+        $normalized = preg_replace('/[^a-z0-9_-]+/', '_', strtolower($sourceKey)) ?? '';
+        $normalized = trim($normalized, '_-');
+        $normalized = $normalized === '' ? 'element' : $normalized;
+
+        return 'vision_'.substr($normalized, 0, 100).'_'.substr(hash('sha256', $sourceKey), 0, 12);
+    }
+
+    /** @param list<string> $sourceKeys @return array<string, string> */
+    private function buildingModelKeys(array $sourceKeys, string $floorKey): array
+    {
+        sort($sourceKeys, SORT_STRING);
+        $sourceKeys = array_values(array_unique($sourceKeys));
+        $used = [$floorKey => true];
+        $mapping = [];
+
+        foreach ($sourceKeys as $sourceKey) {
+            if ($sourceKey !== $floorKey && preg_match('/^[a-z][a-z0-9_-]{0,127}$/', $sourceKey) === 1) {
+                $mapping[$sourceKey] = $sourceKey;
+                $used[$sourceKey] = true;
+            }
+        }
+
+        foreach ($sourceKeys as $sourceKey) {
+            if (isset($mapping[$sourceKey])) {
+                continue;
+            }
+            $targetKey = $this->buildingModelKey($sourceKey);
+            $attempt = 0;
+            while (isset($used[$targetKey])) {
+                $attempt++;
+                $targetKey = 'vision_element_'.substr(hash('sha256', $sourceKey."\0".$attempt), 0, 24);
+            }
+            $mapping[$sourceKey] = $targetKey;
+            $used[$targetKey] = true;
+        }
+
+        return $mapping;
     }
 
     private function matchesScaleContext(FusedGeometryElementData $element, ?ScaleContextData $context): bool

--- a/tests/Unit/EstimateGeneration/BuildingModel/BuildingModelAssemblerTest.php
+++ b/tests/Unit/EstimateGeneration/BuildingModel/BuildingModelAssemblerTest.php
@@ -241,6 +241,73 @@ final class BuildingModelAssemblerTest extends TestCase
     }
 
     #[Test]
+    public function vision_keys_are_mapped_deterministically_with_internal_references_preserved(): void
+    {
+        $elements = [
+            self::sourceRoom('room.living_area', 'e1', [[0.0, 0.0], [100.0, 0.0], [100.0, 100.0], [0.0, 100.0]]),
+            self::sourceElement('wall.outer:main', 'wall', 'e2', ['start' => [0.0, 0.0], 'end' => [100.0, 0.0], 'thickness' => 10.0, 'height' => 280.0]),
+            self::sourceElement('opening.window:1', 'opening', 'e3', ['wall_key' => 'wall.outer:main', 'opening_type' => 'window', 'offset' => 10.0, 'width' => 20.0, 'height' => 140.0]),
+            self::sourceElement('engineering.socket:1', 'engineering_element', 'e4', ['engineering_type' => 'outlet', 'location' => [10.0, 10.0], 'room_key' => 'room.living_area']),
+        ];
+        $input = new VisionBuildingModelInputData(
+            new ScaleResolutionData('confirmed', 0.01, ['e1'], null, self::scaleContext()),
+            (new GeometryFusionService)->fuse($elements),
+            [],
+            [],
+            ['e1' => 11, 'e2' => 12, 'e3' => 13, 'e4' => 14],
+            'vision-fusion:v1',
+            'floor-1',
+        );
+        $assembler = new BuildingModelAssembler;
+
+        $first = $assembler->assembleVision($input)->model->floors[0];
+        $second = $assembler->assembleVision($input)->model->floors[0];
+
+        self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]{0,127}$/', $first->rooms[0]->key);
+        self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]{0,127}$/', $first->walls[0]->key);
+        self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]{0,127}$/', $first->openings[0]->key);
+        self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]{0,127}$/', $first->engineeringElements[0]->key);
+        self::assertSame($first->walls[0]->key, $first->openings[0]->wallKey);
+        self::assertSame($first->rooms[0]->key, $first->engineeringElements[0]->roomKey);
+        self::assertSame($first->toArray(), $second->toArray());
+    }
+
+    #[Test]
+    public function vision_key_mapping_resolves_generated_and_floor_key_collisions(): void
+    {
+        $generatedCollision = 'vision_room_a_'.substr(hash('sha256', 'room.a'), 0, 12);
+        $elements = [
+            self::sourceRoom('room.a', 'e1', [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0]]),
+            self::sourceRoom($generatedCollision, 'e2', [[20.0, 0.0], [30.0, 0.0], [30.0, 10.0]]),
+            self::sourceRoom('floor-1', 'e3', [[40.0, 0.0], [50.0, 0.0], [50.0, 10.0]]),
+        ];
+        $result = (new BuildingModelAssembler)->assembleVision(new VisionBuildingModelInputData(
+            new ScaleResolutionData('confirmed', 0.01, ['e1'], null, self::scaleContext()),
+            (new GeometryFusionService)->fuse($elements),
+            [],
+            [],
+            ['e1' => 11, 'e2' => 12, 'e3' => 13],
+            'vision-fusion:v1',
+            'floor-1',
+        ));
+        $roomKeys = array_map(static fn (RoomData $room): string => $room->key, $result->model->floors[0]->rooms);
+
+        self::assertCount(3, array_unique($roomKeys));
+        self::assertNotContains('floor-1', $roomKeys);
+        self::assertContains($generatedCollision, $roomKeys);
+        self::assertSame([11, 12, 13], $result->model->floors[0]->evidenceIds);
+        self::assertSame($result->toArray(), (new BuildingModelAssembler)->assembleVision(new VisionBuildingModelInputData(
+            new ScaleResolutionData('confirmed', 0.01, ['e1'], null, self::scaleContext()),
+            (new GeometryFusionService)->fuse(array_reverse($elements)),
+            [],
+            [],
+            ['e1' => 11, 'e2' => 12, 'e3' => 13],
+            'vision-fusion:v1',
+            'floor-1',
+        ))->toArray());
+    }
+
+    #[Test]
     public function all_eight_questions_keep_business_order_separate_from_geometry_clarifications(): void
     {
         $questions = array_map(static fn (string $key): SketchQuestionData => new SketchQuestionData($key), SketchQuestionData::KEYS);

--- a/tests/Unit/EstimateGeneration/BuildingModel/SessionBuildingModelBridgeTest.php
+++ b/tests/Unit/EstimateGeneration/BuildingModel/SessionBuildingModelBridgeTest.php
@@ -24,6 +24,30 @@ use Tests\Support\EstimateGeneration\InMemoryProjectModelRepository;
 final class SessionBuildingModelBridgeTest extends TestCase
 {
     #[Test]
+    public function persisted_vision_key_with_dot_is_mapped_before_building_model_validation(): void
+    {
+        $context = new BuildingModelOperationContext(10, 20, 30, 'sha256:'.str_repeat('f', 64));
+        [$bridge] = $this->bridge();
+        $unit = $this->visionUnit();
+        $payload = $unit->payload;
+        $payload['vision_analysis']['elements'][0]['key'] = 'room.living_area';
+
+        $model = $bridge->store($context, [new SessionBuildingModelUnitData(
+            $unit->unitId,
+            $unit->documentId,
+            $unit->pageId,
+            $unit->type,
+            $unit->index,
+            $unit->sourceVersion,
+            $unit->confidence,
+            $payload,
+        )]);
+
+        self::assertNotNull($model);
+        self::assertMatchesRegularExpression('/^[a-z][a-z0-9_-]{0,127}$/', $model->floors[0]->rooms[0]->key);
+    }
+
+    #[Test]
     public function stored_canonical_schema_three_analysis_is_hydrated_without_provider_schema_reparse(): void
     {
         $context = new BuildingModelOperationContext(10, 20, 30, 'sha256:'.str_repeat('f', 64));


### PR DESCRIPTION
## Что исправлено
- детерминированно отображены допустимые Vision-ключи с точками и двоеточиями в строгие ключи модели здания
- сохранены внутренние связи проёмов со стенами и инженерных элементов с помещениями
- исключены коллизии с допустимыми ключами и ключом этажа без изменения уже валидных identity

## Проверки
- 36 PHPUnit тестов, 149 assertions
- Pint для изменённых файлов
- php-l и git diff --check
- независимое targeted review: green, Blocker/P1/P2 нет
- Larastan: известный несвязанный bootstrap blocker storage_configuration_invalid